### PR TITLE
SQL connector modular discover

### DIFF
--- a/samples/sample_tap_bigquery/__init__.py
+++ b/samples/sample_tap_bigquery/__init__.py
@@ -1,0 +1,57 @@
+"""A sample implementation for BigQuery"""
+
+from typing import List, Type
+
+from singer_sdk import SQLTap, SQLStream
+from singer_sdk import typing as th  # JSON schema typing helpers
+
+from typing import List, Tuple
+
+from singer_sdk import SQLConnector, SQLStream
+from singer_sdk import typing as th  # JSON schema typing helpers
+
+
+class BigQueryConnector(SQLConnector):
+    """Connects to the BigQuery SQL source."""
+
+    def get_sqlalchemy_url(cls, config: dict) -> str:
+        """Concatenate a SQLAlchemy URL for use in connecting to the source."""
+        return f"bigquery://{config['project_id']}"
+
+    def _get_object_names(self, engine, inspected, schema_name: str) -> List[Tuple[str, bool]]:
+        # Bigquery inspections returns table names in the form
+        # `schema_name.table_name` which later results in the project name
+        # override due to specifics in behavior of sqlalchemy-bigquery
+        # 
+        # Let's strip `schema_name` prefix on the inspection
+        
+        return [
+            (table_name.split(".")[-1], is_view)
+            for (table_name, is_view)
+            in super()._get_object_names(engine, inspected, schema_name)
+        ]
+
+
+class BigQueryStream(SQLStream):
+    """Stream class for BigQuery streams."""
+
+    connector_class = BigQueryConnector
+
+
+class TapBigQuery(SQLTap):
+    """BigQuery tap class."""
+    name = "tap-bigquery"
+
+    config_jsonschema = th.PropertiesList(
+        th.Property(
+            "project_id",
+            th.StringType,
+            required=True,
+            description="GCP Project"
+        ),
+    ).to_dict()
+
+    default_stream_class: Type[SQLStream] = BigQueryStream
+
+
+__all__ = ["TapBigQuery", "BigQueryConnector", "BigQueryStream"]

--- a/samples/sample_tap_bigquery/__init__.py
+++ b/samples/sample_tap_bigquery/__init__.py
@@ -16,6 +16,7 @@ class BigQueryConnector(SQLConnector):
     def get_object_names(
         self, engine, inspected, schema_name: str
     ) -> List[Tuple[str, bool]]:
+        """Return discoverable object names."""
         # Bigquery inspections returns table names in the form
         # `schema_name.table_name` which later results in the project name
         # override due to specifics in behavior of sqlalchemy-bigquery

--- a/samples/sample_tap_bigquery/__init__.py
+++ b/samples/sample_tap_bigquery/__init__.py
@@ -1,4 +1,4 @@
-"""A sample implementation for BigQuery"""
+"""A sample implementation for BigQuery."""
 
 from typing import List, Tuple, Type
 

--- a/samples/sample_tap_bigquery/__init__.py
+++ b/samples/sample_tap_bigquery/__init__.py
@@ -1,13 +1,8 @@
 """A sample implementation for BigQuery"""
 
-from typing import List, Type
+from typing import List, Tuple, Type
 
-from singer_sdk import SQLTap, SQLStream
-from singer_sdk import typing as th  # JSON schema typing helpers
-
-from typing import List, Tuple
-
-from singer_sdk import SQLConnector, SQLStream
+from singer_sdk import SQLConnector, SQLStream, SQLTap
 from singer_sdk import typing as th  # JSON schema typing helpers
 
 

--- a/samples/sample_tap_bigquery/__init__.py
+++ b/samples/sample_tap_bigquery/__init__.py
@@ -13,7 +13,7 @@ class BigQueryConnector(SQLConnector):
         """Concatenate a SQLAlchemy URL for use in connecting to the source."""
         return f"bigquery://{config['project_id']}"
 
-    def _get_object_names(
+    def get_object_names(
         self, engine, inspected, schema_name: str
     ) -> List[Tuple[str, bool]]:
         # Bigquery inspections returns table names in the form
@@ -24,7 +24,7 @@ class BigQueryConnector(SQLConnector):
 
         return [
             (table_name.split(".")[-1], is_view)
-            for (table_name, is_view) in super()._get_object_names(
+            for (table_name, is_view) in super().get_object_names(
                 engine, inspected, schema_name
             )
         ]

--- a/samples/sample_tap_bigquery/__init__.py
+++ b/samples/sample_tap_bigquery/__init__.py
@@ -18,17 +18,20 @@ class BigQueryConnector(SQLConnector):
         """Concatenate a SQLAlchemy URL for use in connecting to the source."""
         return f"bigquery://{config['project_id']}"
 
-    def _get_object_names(self, engine, inspected, schema_name: str) -> List[Tuple[str, bool]]:
+    def _get_object_names(
+        self, engine, inspected, schema_name: str
+    ) -> List[Tuple[str, bool]]:
         # Bigquery inspections returns table names in the form
         # `schema_name.table_name` which later results in the project name
         # override due to specifics in behavior of sqlalchemy-bigquery
-        # 
+        #
         # Let's strip `schema_name` prefix on the inspection
-        
+
         return [
             (table_name.split(".")[-1], is_view)
-            for (table_name, is_view)
-            in super()._get_object_names(engine, inspected, schema_name)
+            for (table_name, is_view) in super()._get_object_names(
+                engine, inspected, schema_name
+            )
         ]
 
 
@@ -40,14 +43,12 @@ class BigQueryStream(SQLStream):
 
 class TapBigQuery(SQLTap):
     """BigQuery tap class."""
+
     name = "tap-bigquery"
 
     config_jsonschema = th.PropertiesList(
         th.Property(
-            "project_id",
-            th.StringType,
-            required=True,
-            description="GCP Project"
+            "project_id", th.StringType, required=True, description="GCP Project"
         ),
     ).to_dict()
 

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -291,10 +291,10 @@ class SQLConnector:
             "Streams list may be incomplete or `is_view` may be unpopulated."
         )
 
-    def _get_schema_names(self, engine: Engine, inspected: Inspector) -> List[str]:
+    def get_schema_names(self, engine: Engine, inspected: Inspector) -> List[str]:
         return inspected.get_schema_names()
 
-    def _get_object_names(
+    def get_object_names(
         self, engine: Engine, inspected: Inspector, schema_name: str
     ) -> List[Tuple[str, bool]]:
         """Return a list of syncable objects.
@@ -322,7 +322,7 @@ class SQLConnector:
         return object_names
 
     # TODO maybe should be splitted into smaller parts?
-    def _discover_catalog_entry(
+    def discover_catalog_entry(
         self,
         engine: Engine,
         inspected: Inspector,
@@ -407,12 +407,12 @@ class SQLConnector:
         result: List[dict] = []
         engine = self.create_sqlalchemy_engine()
         inspected = sqlalchemy.inspect(engine)
-        for schema_name in self._get_schema_names(engine, inspected):
+        for schema_name in self.get_schema_names(engine, inspected):
             # Iterate through each table and view
-            for table_name, is_view in self._get_object_names(
+            for table_name, is_view in self.get_object_names(
                 engine, inspected, schema_name
             ):
-                catalog_entry = self._discover_catalog_entry(
+                catalog_entry = self.discover_catalog_entry(
                     engine, inspected, schema_name, table_name, is_view
                 )
                 result.append(catalog_entry.to_dict())

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -293,7 +293,9 @@ class SQLConnector:
     def _get_schema_names(self, engine, inspected: Inspector) -> List[str]:
         return inspected.get_schema_names()
 
-    def _get_object_names(self, engine, inspected: Inspector, schema_name: str) -> List[Tuple[str, bool]]:
+    def _get_object_names(
+        self, engine, inspected: Inspector, schema_name: str
+    ) -> List[Tuple[str, bool]]:
         """Return a list of syncable objects.
 
         Returns:
@@ -314,7 +316,14 @@ class SQLConnector:
         return object_names
 
     # TODO maybe should be splitted into smaller parts?
-    def _discover_catalog_entry(self, engine, inspected: Inspector, schema_name: str, table_name: str, is_view: bool) -> CatalogEntry:
+    def _discover_catalog_entry(
+        self,
+        engine,
+        inspected: Inspector,
+        schema_name: str,
+        table_name: str,
+        is_view: bool,
+    ) -> CatalogEntry:
         # Initialize unique stream name
         unique_stream_id = self.get_fully_qualified_name(
             db_name=None,
@@ -357,9 +366,7 @@ class SQLConnector:
         #   a replication_key value.
         # - 'LOG_BASED' replication must be enabled by the developer, according
         #   to source-specific implementation capabilities.
-        replication_method = next(
-            reversed(["FULL_TABLE"] + addl_replication_methods)
-        )
+        replication_method = next(reversed(["FULL_TABLE"] + addl_replication_methods))
 
         # Create the catalog entry object
         catalog_entry = CatalogEntry(
@@ -396,8 +403,12 @@ class SQLConnector:
         inspected = sqlalchemy.inspect(engine)
         for schema_name in self._get_schema_names(engine, inspected):
             # Iterate through each table and view
-            for table_name, is_view in self._get_object_names(engine, inspected, schema_name):
-                catalog_entry = self._discover_catalog_entry(engine, inspected, schema_name, table_name, is_view)
+            for table_name, is_view in self._get_object_names(
+                engine, inspected, schema_name
+            ):
+                catalog_entry = self._discover_catalog_entry(
+                    engine, inspected, schema_name, table_name, is_view
+                )
                 result.append(catalog_entry.to_dict())
 
         return result

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union, cast
 
 import singer
 import sqlalchemy
+from sqlalchemy.engine import Engine
 from sqlalchemy.engine.reflection import Inspector
 
 from singer_sdk import typing as th
@@ -290,13 +291,18 @@ class SQLConnector:
             "Streams list may be incomplete or `is_view` may be unpopulated."
         )
 
-    def _get_schema_names(self, engine, inspected: Inspector) -> List[str]:
+    def _get_schema_names(self, engine: Engine, inspected: Inspector) -> List[str]:
         return inspected.get_schema_names()
 
     def _get_object_names(
-        self, engine, inspected: Inspector, schema_name: str
+        self, engine: Engine, inspected: Inspector, schema_name: str
     ) -> List[Tuple[str, bool]]:
         """Return a list of syncable objects.
+
+        Args:
+            engine: SQLAlchemy engine
+            inspected: SQLAlchemy inspector instance for engine
+            schema_name: Schema name to inspect
 
         Returns:
             List of tuples (<table_or_view_name>, <is_view>)
@@ -318,7 +324,7 @@ class SQLConnector:
     # TODO maybe should be splitted into smaller parts?
     def _discover_catalog_entry(
         self,
-        engine,
+        engine: Engine,
         inspected: Inspector,
         schema_name: str,
         table_name: str,

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -292,6 +292,15 @@ class SQLConnector:
         )
 
     def get_schema_names(self, engine: Engine, inspected: Inspector) -> List[str]:
+        """Return a list of schema names in DB.
+
+        Args:
+            engine: SQLAlchemy engine
+            inspected: SQLAlchemy inspector instance for engine
+
+        Returns:
+            List of schema names
+        """
         return inspected.get_schema_names()
 
     def get_object_names(
@@ -330,6 +339,18 @@ class SQLConnector:
         table_name: str,
         is_view: bool,
     ) -> CatalogEntry:
+        """Create `CatalogEntry` object for the given table or a view.
+
+        Args:
+            engine: SQLAlchemy engine
+            inspected: SQLAlchemy inspector instance for engine
+            schema_name: Schema name to inspect
+            table_name: Name of the table or a view
+            is_view: Flag whether this object is a view, returned by `get_object_names`
+
+        Returns:
+            `CatalogEntry` object for the given table or a view
+        """
         # Initialize unique stream name
         unique_stream_id = self.get_fully_qualified_name(
             db_name=None,


### PR DESCRIPTION
As discussed in Slack: https://meltano.slack.com/archives/C01PKLU5D1R/p1653575557167359

There are situations when SQLAlchemy inspection behavior should be tweaked. It would be nice to tweak only relevant parts without large copy-paste.

I propose a refactor of `SQLConnector.discover_catalog_entries` and `sample_tap_bigquery` to illustrate why it's needed.

Closes #682