### PR TITLE
docs: update gitlab refs to github ones

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Let's build together! Please see our [Contributor Guide](https://docs.meltano.co
 for more information on contributing to Meltano.
 
 We believe that everyone can contribute and we welcome all contributions.
-If you're not sure what to work on, here are some [ideas to get you started](https://gitlab.com/groups/meltano/-/issues?label_name%5B%5D=Accepting%20Merge%20Requests).
+If you're not sure what to work on, here are some [ideas to get you started](https://github.com/meltano/meltano/labels/Accepting%20Merge%20Requests).
 
 Chat with us in [#contributing](https://meltano.slack.com/archives/C013Z450LCD) on [Slack](https://meltano.com/slack).
 

--- a/docs/implementation/catalog_metadata.md
+++ b/docs/implementation/catalog_metadata.md
@@ -1,8 +1,8 @@
 # [SDK Implementation Details](./index.md) - Catalog Metadata
 
-_**Note:**: The SDK does not yet generate metadata as a part of catalog discovery output.
-This work is [tracked here](https://gitlab.com/meltano/sdk/-/issues/91) for future
-development._
+The SDK automatically generates catalog metadata during catalog discovery. Selection rules overrided by a user will be respected.
+
+Primary key properties may not be deselected, as these are required for `key_properties` to be declared in stream messages.
 
 ## Additional Singer Metadata References
 


### PR DESCRIPTION
Removes gitlab references.

I did a full text search in the repo for all occurrences of 'gitlab' in the full contents. Ignored these:

- changlog references (pointers to closed MRs and Issues)
- tap-gitlab references
- other pointers to historic gitlab issues which were not migrated and which still offer explanatory value
