### PR TITLE
chore: Remove unsupported versioning-strategy value

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       timezone: "UTC"
     reviewers: [meltano/engineering]
     labels: [deps]
-    versioning-strategy: "increase-if-necessary"
   - package-ecosystem: pip
     directory: "/.github/workflows"
     schedule:


### PR DESCRIPTION
`increase-if-necessary` is not supported for pip dependencies. I think we can rely on the default behavior for libraries:

> When Dependabot edits a manifest file to update a version, it uses the following overall strategies:
> 
> - For apps, the version requirements are increased, for example: npm, pip and Composer.
> - For libraries, the range of versions is widened, for example: Bundler and Cargo.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy