### PR TITLE
Poetry-dev-deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,29 +54,28 @@ docs = ["sphinx", "sphinx-rtd-theme", "sphinx-copybutton", "myst-parser"]
 
 [tool.poetry.dev-dependencies]
 # snowflake-connector-python = "2.0.4" # Removed: Too many version conflicts!
-pytest = "^7.1.2"
 black = "^22.3"
-mypy = "^0.961"
 cookiecutter = "^2.1.1"
+coverage = {extras = ["toml"], version = "^6.4"}
 darglint = "^1.8.0"
-PyYAML = "^6.0"
-flake8-docstrings = "^1.6.0"
 flake8 = "^3.9.0"
-pyarrow = "^8.0.0"
-pandas = ">=1.2.0"
-numpy = ">=1.20.0"
-tox = "^3.25.0"
-freezegun = "^1.2.1"
-viztracer = "^0.15.3"
 flake8-annotations = "^2.9.0"
-darglint = "^1.8.0"
+flake8-docstrings = "^1.6.0"
+freezegun = "^1.2.1"
 isort = "^5.9.3"
+mypy = "^0.961"
+numpy = ">=1.20.0"
+pandas = ">=1.2.0"
+pyarrow = "^8.0.0"
+pytest = "^7.1.2"
 pyupgrade = "^2.34.0"
+PyYAML = "^6.0"
 requests-mock = "^1.9.3"
 sqlalchemy2-stubs = {version = "^0.0.2a24", allow-prereleases = true}
+tox = "^3.25.0"
 types-python-dateutil = "^2.8.17"
 types-requests = "^2.27.30"
-coverage = {extras = ["toml"], version = "^6.4"}
+viztracer = "^0.15.3"
 
 [tool.black]
 exclude = ".*simpleeval.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,27 +55,28 @@ docs = ["sphinx", "sphinx-rtd-theme", "sphinx-copybutton", "myst-parser"]
 [tool.poetry.dev-dependencies]
 # snowflake-connector-python = "2.0.4" # Removed: Too many version conflicts!
 pytest = "^7.1.2"
+black = "^22.3"
 mypy = "^0.961"
 cookiecutter = "^2.1.1"
+darglint = "^1.8.0"
 PyYAML = "^6.0"
+flake8-docstrings = "^1.6.0"
+flake8 = "^3.9.0"
 pyarrow = "^8.0.0"
 pandas = ">=1.2.0"
 numpy = ">=1.20.0"
 tox = "^3.25.0"
 freezegun = "^1.2.1"
 viztracer = "^0.15.3"
+flake8-annotations = "^2.9.0"
+darglint = "^1.8.0"
+isort = "^5.9.3"
+pyupgrade = "^2.34.0"
 requests-mock = "^1.9.3"
 sqlalchemy2-stubs = {version = "^0.0.2a24", allow-prereleases = true}
 types-python-dateutil = "^2.8.17"
 types-requests = "^2.27.30"
 coverage = {extras = ["toml"], version = "^6.4"}
-
-# Cookiecutter tests
-black = "^22.3"
-darglint = "^1.8.0"
-flake8 = "^3.9.0"
-flake8-annotations = "^2.9.0"
-flake8-docstrings = "^1.6.0"
 
 [tool.black]
 exclude = ".*simpleeval.*"


### PR DESCRIPTION
This adds back dev dependencies that may not be _technically_ required now that we have a remote githook. However, they are still helpful at dev-time and I think they make sense to remain as proper dev-dependencies. 

I've also alpha sorted this section of pyproject.toml so dupes as a general best practice, applied as 2 separate commits to aid in review.

The basis for keeping _all_ dev dependencies included is for IDEs that use the poetry environment for dev-time linting. The ideal scenario is that the remote linter basically has 'nothing to do' and the contributor or team member has (as closely as possible) a local dev experience that closely mirrors what will end up in the PR.