### PR TITLE
[feat] Add end of pipe clean up hook to Sinks

### DIFF
--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -401,3 +401,7 @@ class Sink(metaclass=abc.ABCMeta):
             "ACTIVATE_VERSION message received but not implemented by this target. "
             "Ignoring."
         )
+
+    def clean_up(self) -> None:
+        """Perform any clean up actions required at end of a stream."""
+        pass

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -273,7 +273,7 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
 
     def _process_endofpipe(self) -> None:
         """Called after all input lines have been read."""
-        self.drain_all()
+        self.drain_all(is_endofpipe=True)
 
     def _process_record_message(self, message_dict: dict) -> None:
         """Process a RECORD message.
@@ -403,15 +403,19 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
     # Sink drain methods
 
     @final
-    def drain_all(self) -> None:
+    def drain_all(self, is_endofpipe=False) -> None:
         """Drains all sinks, starting with those cleared due to changed schema.
 
         This method is internal to the SDK and should not need to be overridden.
         """
         state = copy.deepcopy(self._latest_state)
         self._drain_all(self._sinks_to_clear, 1)
+        if is_endofpipe:
+            (sink.clean_up() for sink in self._sinks_active.values())
         self._sinks_to_clear = []
         self._drain_all(list(self._sinks_active.values()), self.max_parallelism)
+        if is_endofpipe:
+            (sink.clean_up() for sink in self._sinks_to_clear)
         self._write_state_message(state)
         self._reset_max_record_age()
 


### PR DESCRIPTION
This adds a hook to the drain all method which is flagged at endofpipe drain. I can go on to list the ways I think this is useful. From ensuring futures are completed, to tearing down resources, **clearing buckets or stages used in a load**, to cleanup in general. 