### PR TITLE
Ensure all streams log sync costs

### DIFF
--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -378,6 +378,10 @@ class Tap(PluginBase, metaclass=abc.ABCMeta):
 
             stream.sync()
             stream.finalize_state_progress_markers()
+
+        # this second loop is needed for all streams to print out their costs
+        # including child streams which are otherwise skipped in the loop above
+        for stream in self.streams.values():
             stream.log_sync_costs()
 
     # Command Line Execution


### PR DESCRIPTION
This PR reverts commit https://github.com/meltano/sdk/commit/ad0c4483c8b2742d5f83383f3e413c7111d68947 in PR #704 which prevented child streams from logging their costs.

See my comment https://github.com/meltano/sdk/pull/704#discussion_r906090944 for additional context.