### PR TITLE
Output full path in error messages

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -16,6 +16,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from urllib.parse import urlparse
 
 import backoff
 import requests
@@ -186,6 +187,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         Returns:
             str: The error message
         """
+        full_path = urlparse(response.url).path
         if 400 <= response.status_code < 500:
             error_type = "Client"
         else:
@@ -193,7 +195,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
 
         return (
             f"{response.status_code} {error_type} Error: "
-            f"{response.reason} for path: {self.path}"
+            f"{response.reason} for path: {full_path}"
         )
 
     def request_decorator(self, func: Callable) -> Callable:


### PR DESCRIPTION
Output actual full path in `response_error_message` instead of `"{self.path}"`