### PR TITLE
chore: Remove `python3.10` requirement from black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,6 @@ repos:
   rev: 22.6.0
   hooks:
   - id: black
-    language_version: python3.10
     exclude: |
         (?x)^(
             cookiecutter/.*|


### PR DESCRIPTION
Closes #821 

I don't see a downside to this, maybe there's a reason this config setting was used?