### PR TITLE
chore(templates): Add dependabot updates for Python dependencies on cookiecutters

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,15 @@ updates:
       interval: weekly
     reviewers: [meltano/engineering]
     labels: [deps]
+  - package-ecosystem: pip
+    directory: "./cookiecutter/tap-template/{{cookiecutter.tap_id}}"
+    schedule:
+      interval: weekly
+    reviewers: [meltano/engineering]
+    labels: [deps]
+  - package-ecosystem: pip
+    directory: "./cookiecutter/target-template/{{cookiecutter.tap_id}}"
+    schedule:
+      interval: weekly
+    reviewers: [meltano/engineering]
+    labels: [deps]


### PR DESCRIPTION
While looking at https://github.com/meltano/sdk/issues/825 I noticed the `pyproject.toml` files were out of sync between the two cookiecutter projects (tap and target). Thought about a way to fix this without copy pasting over and over again

Doesn't work yet, need to run a cookiecutter for a test project right before checking with Dependabot.