### PR TITLE
ci: Update workflow because GitHub dependency review can only run in PRs

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,8 +2,6 @@ name: Dependency Review
 
 on:
   pull_request: {}
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs: {}
 


### PR DESCRIPTION
```
Error: This run was triggered by the "push" event, which is unsupported. Please ensure you are using the "pull_request" event for this workflow.
```