### PR TITLE
ci: Use `pull_request_target` for dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,12 +1,12 @@
 name: Dependency Review
 
 on:
-  pull_request: {}
+  pull_request_target: {}
   workflow_dispatch:
     inputs: {}
 
 env:
-  FOSSA_CLI_VERSION: '3.3.9'
+  FOSSA_CLI_INSTALLER_VERSION: '3.3.10'
 
 permissions:
   contents: read
@@ -19,11 +19,14 @@ jobs:
         uses: actions/checkout@v3.0.2
 
       - name: GitHub dependency vulnerability check
-        uses: actions/dependency-review-action@v2
+        if: ${{ github.event_name == 'pull_request_target' }}
+        # Use this fork until https://github.com/actions/dependency-review-action/pull/165 is merged
+        uses: WillDaSilva/dependency-review-action@main
 
       - name: FOSSA dependency license check
         run: |
-          curl --no-progress-meter -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/v${FOSSA_CLI_VERSION}/install-latest.sh | bash
+          # `$FOSSA_CLI_INSTALLER_VERSION` only controls the version of the installer used - the latest version of `fossa-cli` will always be used.
+          curl --no-progress-meter -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/v${FOSSA_CLI_INSTALLER_VERSION}/install-latest.sh | bash
 
           echo '## FOSSA dependency license check' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Closes #841

This will make this workflow work for PRs from external contributors, since it'll run in the context of the base, and therefore have access to our secrets.