### PR TITLE
fix(taps): Update return type for `backoff_max_tries` to reflect it accepts a callable that returns an integer

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -19,8 +19,8 @@ from typing import (
 from urllib.parse import urlparse
 
 import backoff
-from backoff._typing import _MaybeCallable
 import requests
+from backoff._typing import _MaybeCallable
 from singer.schema import Schema
 
 from singer_sdk.authenticators import APIAuthenticatorBase, SimpleAuthenticator

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -20,7 +20,6 @@ from urllib.parse import urlparse
 
 import backoff
 import requests
-from backoff._typing import _MaybeCallable
 from singer.schema import Schema
 
 from singer_sdk.authenticators import APIAuthenticatorBase, SimpleAuthenticator
@@ -33,6 +32,8 @@ DEFAULT_PAGE_SIZE = 1000
 DEFAULT_REQUEST_TIMEOUT = 300  # 5 minutes
 
 _TToken = TypeVar("_TToken")
+_MaybeCallable = Union[T, Callable[[], T]]
+
 
 
 class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -32,7 +32,7 @@ DEFAULT_PAGE_SIZE = 1000
 DEFAULT_REQUEST_TIMEOUT = 300  # 5 minutes
 
 _TToken = TypeVar("_TToken")
-_MaybeCallable = Union[T, Callable[[], T]]
+_MaybeCallable = Union[_TToken, Callable[[], _TToken]]
 
 
 

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -547,7 +547,8 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
     def backoff_max_tries(self) -> Optional[_MaybeCallable[int]]:
         """The number of attempts before giving up when retrying requests.
 
-        Setting to None will retry indefinitely.
+        Can be an integer, a zero-argument callable that returns an integer,
+        or ``None`` to retry indefinitely.
 
         Returns:
             int: limit

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -32,7 +32,8 @@ DEFAULT_PAGE_SIZE = 1000
 DEFAULT_REQUEST_TIMEOUT = 300  # 5 minutes
 
 _TToken = TypeVar("_TToken")
-_MaybeCallable = Union[_TToken, Callable[[], _TToken]]
+_T = TypeVar("_T")
+_MaybeCallable = Union[_T, Callable[[], _T]]
 
 
 class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -19,6 +19,7 @@ from typing import (
 from urllib.parse import urlparse
 
 import backoff
+from backoff._typing import _MaybeCallable
 import requests
 from singer.schema import Schema
 
@@ -542,7 +543,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         """
         return backoff.expo(factor=2)  # type: ignore # ignore 'Returning Any'
 
-    def backoff_max_tries(self) -> int:
+    def backoff_max_tries(self) -> Optional[_MaybeCallable[int]]:
         """The number of attempts before giving up when retrying requests.
 
         Setting to None will retry indefinitely.

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -1,21 +1,12 @@
 """Abstract base class for API-type streams."""
 
+from __future__ import annotations
+
 import abc
 import copy
 import logging
 from datetime import datetime
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generator,
-    Generic,
-    Iterable,
-    List,
-    Optional,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Generator, Generic, Iterable, TypeVar, Union
 from urllib.parse import urlparse
 
 import backoff
@@ -40,18 +31,18 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
     """Abstract base class for REST API streams."""
 
     _page_size: int = DEFAULT_PAGE_SIZE
-    _requests_session: Optional[requests.Session]
+    _requests_session: requests.Session | None
     rest_method = "GET"
 
     #: JSONPath expression to extract records from the API response.
     records_jsonpath: str = "$[*]"
 
     #: Response code reference for rate limit retries
-    extra_retry_statuses: List[int] = [429]
+    extra_retry_statuses: list[int] = [429]
 
     #: Optional JSONPath expression to extract a pagination token from the API response.
     #: Example: `"$.next_page"`
-    next_page_token_jsonpath: Optional[str] = None
+    next_page_token_jsonpath: str | None = None
 
     # Private constants. May not be supported in future releases:
     _LOG_REQUEST_METRICS: bool = True
@@ -67,9 +58,9 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
     def __init__(
         self,
         tap: TapBaseClass,
-        name: Optional[str] = None,
-        schema: Optional[Union[Dict[str, Any], Schema]] = None,
-        path: Optional[str] = None,
+        name: str | None = None,
+        schema: dict[str, Any] | Schema | None = None,
+        path: str | None = None,
     ) -> None:
         """Initialize the REST stream.
 
@@ -88,7 +79,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         self._next_page_token_compiled_jsonpath = None
 
     @staticmethod
-    def _url_encode(val: Union[str, datetime, bool, int, List[str]]) -> str:
+    def _url_encode(val: str | datetime | bool | int | list[str]) -> str:
         """Encode the val argument as url-compatible string.
 
         Args:
@@ -103,7 +94,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
             result = str(val)
         return result
 
-    def get_url(self, context: Optional[dict]) -> str:
+    def get_url(self, context: dict | None) -> str:
         """Get stream entity URL.
 
         Developers override this method to perform dynamic URL generation.
@@ -229,7 +220,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         return decorator
 
     def _request(
-        self, prepared_request: requests.PreparedRequest, context: Optional[dict]
+        self, prepared_request: requests.PreparedRequest, context: dict | None
     ) -> requests.Response:
         """TODO.
 
@@ -256,8 +247,8 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         return response
 
     def get_url_params(
-        self, context: Optional[dict], next_page_token: Optional[_TToken]
-    ) -> Dict[str, Any]:
+        self, context: dict | None, next_page_token: _TToken | None
+    ) -> dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization.
 
         If paging is supported, developers may override with specific paging logic.
@@ -273,7 +264,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         return {}
 
     def prepare_request(
-        self, context: Optional[dict], next_page_token: Optional[_TToken]
+        self, context: dict | None, next_page_token: _TToken | None
     ) -> requests.PreparedRequest:
         """Prepare a request object.
 
@@ -312,7 +303,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         )
         return request
 
-    def request_records(self, context: Optional[dict]) -> Iterable[dict]:
+    def request_records(self, context: dict | None) -> Iterable[dict]:
         """Request records from REST endpoint(s), returning response records.
 
         If pagination is detected, pages will be recursed automatically.
@@ -327,7 +318,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
             RuntimeError: If a loop in pagination is detected. That is, when two
                 consecutive pagination tokens are identical.
         """
-        next_page_token: Optional[_TToken] = None
+        next_page_token: _TToken | None = None
         finished = False
         decorated_request = self.request_decorator(self._request)
 
@@ -354,8 +345,8 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         self,
         request: requests.PreparedRequest,
         response: requests.Response,
-        context: Optional[Dict],
-    ) -> Dict[str, int]:
+        context: dict | None,
+    ) -> dict[str, int]:
         """Update internal calculation of Sync costs.
 
         Args:
@@ -380,8 +371,8 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         self,
         request: requests.PreparedRequest,
         response: requests.Response,
-        context: Optional[Dict],
-    ) -> Dict[str, int]:
+        context: dict | None,
+    ) -> dict[str, int]:
         """Calculate the cost of the last API call made.
 
         This method can optionally be implemented in streams to calculate
@@ -408,8 +399,8 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         return {}
 
     def prepare_request_payload(
-        self, context: Optional[dict], next_page_token: Optional[_TToken]
-    ) -> Optional[dict]:
+        self, context: dict | None, next_page_token: _TToken | None
+    ) -> dict | None:
         """Prepare the data payload for the REST API request.
 
         By default, no payload will be sent (return None).
@@ -431,8 +422,8 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
     def get_next_page_token(
         self,
         response: requests.Response,
-        previous_token: Optional[_TToken],
-    ) -> Optional[_TToken]:
+        previous_token: _TToken | None,
+    ) -> _TToken | None:
         """Return token identifying next page or None if all records have been read.
 
         Args:
@@ -484,7 +475,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
 
     # Records iterator
 
-    def get_records(self, context: Optional[dict]) -> Iterable[Dict[str, Any]]:
+    def get_records(self, context: dict | None) -> Iterable[dict[str, Any]]:
         """Return a generator of row-type dictionary objects.
 
         Each row emitted should be a dictionary of property names to their values.
@@ -519,7 +510,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
     # Abstract methods:
 
     @property
-    def authenticator(self) -> Optional[APIAuthenticatorBase]:
+    def authenticator(self) -> APIAuthenticatorBase | None:
         """Return or set the authenticator for managing HTTP auth headers.
 
         If an authenticator is not specified, REST-based taps will simply pass
@@ -544,14 +535,15 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         """
         return backoff.expo(factor=2)  # type: ignore # ignore 'Returning Any'
 
-    def backoff_max_tries(self) -> Optional[_MaybeCallable[int]]:
+    def backoff_max_tries(self) -> _MaybeCallable[int] | None:
         """The number of attempts before giving up when retrying requests.
 
         Can be an integer, a zero-argument callable that returns an integer,
         or ``None`` to retry indefinitely.
 
         Returns:
-            int: limit
+            int | Callable[[], int] | None: Number of max retries, callable or
+            ``None``.
         """
         return 5
 

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -35,7 +35,6 @@ _TToken = TypeVar("_TToken")
 _MaybeCallable = Union[_TToken, Callable[[], _TToken]]
 
 
-
 class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
     """Abstract base class for REST API streams."""
 


### PR DESCRIPTION
closes #784 