### PR TITLE
docs: Cleanup whitespace in backoff code samples

### DIFF
--- a/docs/code_samples.md
+++ b/docs/code_samples.md
@@ -318,9 +318,7 @@ def backoff_wait_generator() -> Callable[..., Generator[int, Any, None]]:
         return int(response_headers.get("Retry-After", 0))
 
     return self.backoff_runtime(value=_backoff_from_headers)
-
 ```
-
 
 ## Additional Resources
 


### PR DESCRIPTION
Found some extra whitespace that might as well be removed.