### PR TITLE
feat: add `ConnectionError` to list of backoff exceptions for auto-retry

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -213,6 +213,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
             (
                 RetriableAPIError,
                 requests.exceptions.ReadTimeout,
+                requests.exceptions.ConnectionError,
             ),
             max_tries=self.backoff_max_tries,
             on_backoff=self.backoff_handler,


### PR DESCRIPTION
I was running into an error similar to [this on Github](https://stackoverflow.com/questions/52051989/requests-exceptions-connectionerror-connection-aborted-connectionreseterro). So I decided to address it by adding it to the list of back off exceptions.

This fixed the issue for me.