### PR TITLE
ci: Limit test job concurrency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
   workflow_dispatch:
     inputs: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   FORCE_COLOR: "1"
 


### PR DESCRIPTION
Cancels running jobs when new commits are pushed.

Copied from @WillDaSilva's work on `meltano/meltano`.
