### PR TITLE
docs: Add docs preview links to PR description

### DIFF
--- a/.github/workflows/pr-preview-links.yml
+++ b/.github/workflows/pr-preview-links.yml
@@ -1,0 +1,17 @@
+name: Read the Docs Pull Request Preview
+
+on:
+  pull_request_target:
+    types:
+    - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  pr-preview-links:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: readthedocs/actions/preview@v1
+      with:
+        project-slug: "meltano-sdk"


### PR DESCRIPTION
Add docs preview links to PR description. Will be available after this lands on `main`.
