### PR TITLE
ci: Fix missing PK in GitLab external tests

### DIFF
--- a/samples/sample_tap_gitlab/schemas/epic_issues.json
+++ b/samples/sample_tap_gitlab/schemas/epic_issues.json
@@ -1,26 +1,286 @@
 {
-    "type": "object",
-    "properties": {
-        "group_id": {
-            "type": "integer"
+  "properties": {
+    "_links": {
+      "properties": {
+        "award_emoji": {
+          "type": "string"
         },
-        "epic_iid": {
-            "type": "integer"
+        "notes": {
+          "type": "string"
         },
-        "epic_issue_id": {
-            "type": "integer"
+        "project": {
+          "type": "string"
         },
-        "issue_id": {
-            "type": "integer"
+        "self": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "award_emoji",
+        "notes",
+        "project",
+        "self"
+      ],
+      "type": "object"
+    },
+    "assignee": {
+      "properties": {
+        "avatar_url": {
+          "type": "string"
         },
-        "issue_iid": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "avatar_url",
+        "id",
+        "name",
+        "state",
+        "username",
+        "web_url"
+      ],
+      "type": "object"
+    },
+    "assignees": {
+      "items": {
+        "properties": {
+          "avatar_url": {
+            "type": "string"
+          },
+          "id": {
             "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "web_url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "avatar_url",
+          "id",
+          "name",
+          "state",
+          "username",
+          "web_url"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "author": {
+      "properties": {
+        "avatar_url": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "web_url": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "avatar_url",
+        "id",
+        "name",
+        "state",
+        "username",
+        "web_url"
+      ],
+      "type": "object"
+    },
+    "closed_at": {
+      "type": "null"
+    },
+    "confidential": {
+      "type": "boolean"
+    },
+    "created_at": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "discussion_locked": {
+      "type": "null"
+    },
+    "downvotes": {
+      "type": "integer"
+    },
+    "due_date": {
+      "type": "null"
+    },
+    "epic_issue_id": {
+      "type": "integer"
+    },
+    "id": {
+      "type": "integer"
+    },
+    "iid": {
+      "type": "integer"
+    },
+    "labels": {
+      "items": {
+        "properties": {},
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "milestone": {
+      "properties": {
+        "created_at": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "due_date": {
+          "type": "null"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "iid": {
+          "type": "integer"
         },
         "project_id": {
-            "type": ["null", "integer"]
+          "type": "integer"
         },
-        "relative_position": {
-            "type": ["null", "integer"]
+        "start_date": {
+          "type": "null"
+        },
+        "state": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "type": "string"
         }
+      },
+      "required": [
+        "created_at",
+        "description",
+        "due_date",
+        "id",
+        "iid",
+        "project_id",
+        "start_date",
+        "state",
+        "title",
+        "updated_at"
+      ],
+      "type": "object"
+    },
+    "project_id": {
+      "type": "integer"
+    },
+    "state": {
+      "type": "string"
+    },
+    "time_stats": {
+      "properties": {
+        "human_time_estimate": {
+          "type": "null"
+        },
+        "human_total_time_spent": {
+          "type": "null"
+        },
+        "time_estimate": {
+          "type": "integer"
+        },
+        "total_time_spent": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "human_time_estimate",
+        "human_total_time_spent",
+        "time_estimate",
+        "total_time_spent"
+      ],
+      "type": "object"
+    },
+    "title": {
+      "type": "string"
+    },
+    "updated_at": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "upvotes": {
+      "type": "integer"
+    },
+    "user_notes_count": {
+      "type": "integer"
+    },
+    "web_url": {
+      "type": "string"
+    },
+    "weight": {
+      "type": "null"
     }
+  },
+  "required": [
+    "_links",
+    "assignee",
+    "assignees",
+    "author",
+    "closed_at",
+    "confidential",
+    "created_at",
+    "description",
+    "discussion_locked",
+    "downvotes",
+    "due_date",
+    "epic_issue_id",
+    "id",
+    "iid",
+    "labels",
+    "milestone",
+    "project_id",
+    "state",
+    "time_stats",
+    "title",
+    "updated_at",
+    "upvotes",
+    "user_notes_count",
+    "web_url",
+    "weight"
+  ],
+  "type": "object"
 }


### PR DESCRIPTION
This error (a missing PK) was uncovered after https://github.com/meltano/sdk/pull/829/ landed on `main`.

Schema generated with https://github.com/edgarrmondragon/jsonschema-infer-tool/ from the example in the GitLab API docs.

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--944.org.readthedocs.build/en/944/

<!-- readthedocs-preview meltano-sdk end -->