### PR TITLE
docs: Remove stale autodoc page for RecordsWitoutSchemaException

### DIFF
--- a/docs/classes/singer_sdk.exceptions.RecordsWitoutSchemaException.rst
+++ b/docs/classes/singer_sdk.exceptions.RecordsWitoutSchemaException.rst
@@ -1,8 +1,0 @@
-﻿singer_sdk.exceptions.RecordsWitoutSchemaException
-==================================================
-
-.. currentmodule:: singer_sdk.exceptions
-
-.. autoclass:: RecordsWitoutSchemaException
-    :members:
-    :special-members: __init__


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--947.org.readthedocs.build/en/947/

<!-- readthedocs-preview meltano-sdk end -->