### PR TITLE
ci: Use `MELTYBOT_GITHUB_AUTH_TOKEN` for version bump workflow

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -54,7 +54,7 @@ jobs:
         commit: "false"
         push: "false"
         changelog: "true"
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.MELTYBOT_GITHUB_AUTH_TOKEN }}
         extra_requirements: 'git+https://github.com/meltano/commitizen-version-bump@main'
         changelog_increment_filename: _changelog_fragment.md
 


### PR DESCRIPTION
This token should have the required permissions to read the members of the Meltano org, which is needed to identify third-party contributors.

Relates to meltano/commitizen-version-bump#6