### PR TITLE
ci: Change `targetUrl` of semantic PR title check to point to SDK docs

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -4,7 +4,7 @@
 titleOnly: true
 
 # Provides a custom URL for the "Details" link, which appears next to the success/failure message from the app:
-targetUrl: https://github.com/meltano/sdk/blob/main/CONTRIBUTING.md#semantic-pull-requests
+targetUrl: https://sdk.meltano.com/en/latest/CONTRIBUTING.html#semantic-pull-requests
 
 # The values allowed for the "type" part of the PR title/commit message.
 # e.g. for a PR title/commit message of "feat: add some stuff", the type would be "feat"


### PR DESCRIPTION
`CONTRIBUTING.md` was moved to the docs a while ago.

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--991.org.readthedocs.build/en/991/

<!-- readthedocs-preview meltano-sdk end -->