### PR TITLE
fix: Use column name in `allow_column_alter` error message

### DIFF
--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -873,7 +873,7 @@ class SQLConnector:
         if not self.allow_column_alter:
             raise NotImplementedError(
                 "Altering columns is not supported. "
-                f"Could not convert column '{full_table_name}.column_name' "
+                f"Could not convert column '{full_table_name}.{column_name}' "
                 f"from '{current_type}' to '{compatible_sql_type}'."
             )
 


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1001.org.readthedocs.build/en/1001/

<!-- readthedocs-preview meltano-sdk end -->