### PR TITLE
chore: Revert release v0.12.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Singer SDK Version
       description: Version of the library you are using
-      placeholder: "0.12.0"
+      placeholder: "0.11.0"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-## v0.12.0 (2022-09-27)
-
-### 🐛 Fixes
-
-- [#999](https://github.com/meltano/sdk/issues/999) Absolute file paths created by taps running in BATCH mode can't be processed by the Sink
-
-### 📚 Documentation Improvements
-
-- Change `targetUrl` of semantic PR title check to point to SDK docs
-
 ## v0.11.0 (2022-09-23)
 
 ### ✨ New

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -12,7 +12,7 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = "<3.11,>=3.7.1"
 requests = "^2.25.1"
-singer-sdk = "^0.12.0"
+singer-sdk = "^0.11.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -12,7 +12,7 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = "<3.11,>=3.7.1"
 requests = "^2.25.1"
-singer-sdk = "^0.12.0"
+singer-sdk = "^0.11.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ copyright = "2021, Meltano Core Team and Contributors"
 author = "Meltano Core Team and Contributors"
 
 # The full version, including alpha/beta/rc tags
-release = "0.12.0"
+release = "0.11.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "singer-sdk"
-version = "0.12.0"
+version = "0.11.0"
 description = "A framework for building Singer taps"
 authors = ["Meltano Team and Contributors"]
 maintainers = ["Meltano Team and Contributors"]
@@ -115,7 +115,7 @@ markers = [
 
 [tool.commitizen]
 name = "cz_version_bump"
-version = "0.12.0"
+version = "0.11.0"
 tag_format = "v$major.$minor.$patch$prerelease"
 version_files = [
     "docs/conf.py",


### PR DESCRIPTION
This reverts commit 308847fe177d105dffa10ae623f199b1097d03f0.


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1004.org.readthedocs.build/en/1004/

<!-- readthedocs-preview meltano-sdk end -->