### PR TITLE
fix: Batch storage `split_url` to work with Windows paths

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -97,6 +97,20 @@ To view the code coverage report in HTML format:
 nox -rs coverage -- html && open ./htmlcov/index.html
 ```
 
+### Platform-specific Testing
+
+To mark a test as platform-specific, use the `@pytest.mark.<platform>` decorator:
+
+```python
+import pytest
+
+@pytest.mark.windows
+def test_windows_only():
+    pass
+```
+
+Supported platform markers are `windows`, `darwin`, and `linux`.
+
 ## Testing Updates to Docs
 
 Documentation runs on Sphinx, using ReadtheDocs style template, and hosting from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ known_first_party = ["tests", "samples"]
 addopts = '-vvv --ignore=singer_sdk/helpers/_simpleeval.py -m "not external"'
 markers = [
     "external: Tests relying on external resources",
+    "windows: Tests that only run on Windows",
 ]
 
 [tool.commitizen]

--- a/singer_sdk/helpers/_batch.py
+++ b/singer_sdk/helpers/_batch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import enum
+import platform
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from typing import IO, TYPE_CHECKING, Any, ClassVar, Generator
@@ -129,7 +130,13 @@ class StorageTarget:
         Returns:
             A tuple of the head and tail parts of the URL.
         """
-        return fs.path.split(url)
+        if platform.system() == "Windows" and "\\" in url:
+            # Original code from pyFileSystem split
+            # Augemnted slitly to properly Windows paths
+            split = url.rsplit("\\", 1)
+            return (split[0] or "\\", split[1])
+        else:
+            return fs.path.split(url)
 
     @classmethod
     def from_url(cls, url: str) -> StorageTarget:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import os
 import pathlib
+import platform
 import shutil
 
 import pytest
 from _pytest.config import Config
+
+SYSTEMS = {"linux", "darwin", "windows"}
 
 
 def pytest_collection_modifyitems(config: Config, items: list[pytest.Item]):
@@ -19,6 +22,13 @@ def pytest_collection_modifyitems(config: Config, items: list[pytest.Item]):
         # Mark all tests under tests/external*/ as 'external'
         if rel_path.parts[1].startswith("external"):
             item.add_marker("external")
+
+
+def pytest_runtest_setup(item):
+    supported_systems = SYSTEMS.intersection(mark.name for mark in item.iter_markers())
+    system = platform.system().lower()
+    if supported_systems and system not in supported_systems:
+        pytest.skip(f"cannot run on platform {system}")
 
 
 @pytest.fixture(scope="class")

--- a/tests/core/test_batch.py
+++ b/tests/core/test_batch.py
@@ -63,20 +63,8 @@ def test_storage_from_url(file_url: str, root: str):
             id="s3",
         ),
         pytest.param(
-            "C:\\Users\\sdk\\path\\to\\file",
-            ("C:\\Users\\sdk\\path\\to", "file"),
-            marks=(pytest.mark.windows,),
-            id="windows-local",
-        ),
-        pytest.param(
             "file://C:\\Users\\sdk\\path\\to\\file",
             ("file://C:\\Users\\sdk\\path\\to", "file"),
-            marks=(pytest.mark.windows,),
-            id="windows-local",
-        ),
-        pytest.param(
-            "\\\\remotemachine\\C$\\batches\\file",
-            ("\\\\remotemachine\\C$\\batches", "file"),
             marks=(pytest.mark.windows,),
             id="windows-local",
         ),

--- a/tests/core/test_batch.py
+++ b/tests/core/test_batch.py
@@ -47,3 +47,29 @@ def test_storage_from_url(file_url: str, root: str):
     head, _ = StorageTarget.split_url(file_url)
     target = StorageTarget.from_url(head)
     assert target.root == root
+
+
+@pytest.mark.parametrize(
+    "file_url,expected",
+    [
+        pytest.param(
+            "file:///Users/sdk/path/to/file",
+            ("file:///Users/sdk/path/to", "file"),
+            id="local",
+        ),
+        pytest.param(
+            "s3://bucket/path/to/file",
+            ("s3://bucket/path/to", "file"),
+            id="s3",
+        ),
+        pytest.param(
+            "C:\\Users\\sdk\\path\\to\\file",
+            ("C:\\Users\\sdk\\path\\to", "file"),
+            marks=(pytest.mark.windows,),
+            id="windows-local",
+        ),
+    ],
+)
+def test_storage_split_url(file_url: str, expected: tuple):
+    """Test storage target split URL."""
+    assert StorageTarget.split_url(file_url) == expected

--- a/tests/core/test_batch.py
+++ b/tests/core/test_batch.py
@@ -68,6 +68,24 @@ def test_storage_from_url(file_url: str, root: str):
             marks=(pytest.mark.windows,),
             id="windows-local",
         ),
+        pytest.param(
+            "file://C:\\Users\\sdk\\path\\to\\file",
+            ("file://C:\\Users\\sdk\\path\\to", "file"),
+            marks=(pytest.mark.windows,),
+            id="windows-local",
+        ),
+        pytest.param(
+            "\\\\remotemachine\\C$\\batches\\file",
+            ("\\\\remotemachine\\C$\\batches", "file"),
+            marks=(pytest.mark.windows,),
+            id="windows-local",
+        ),
+        pytest.param(
+            "file://\\\\remotemachine\\C$\\batches\\file",
+            ("file://\\\\remotemachine\\C$\\batches", "file"),
+            marks=(pytest.mark.windows,),
+            id="windows-local",
+        ),
     ],
 )
 def test_storage_split_url(file_url: str, expected: tuple):


### PR DESCRIPTION
A proposed solutions to issue #1042.  This fix for `StorageTarget.split()` adds detection of Windows and the presence of `\` in url.  If it detects both Windows and `\` it splits the url and returns the results. The split logic is a rework of the code from [fs.path.split ](https://docs.pyfilesystem.org/en/latest/_modules/fs/path.html#split). 

Closes #1042 

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1043.org.readthedocs.build/en/1043/

<!-- readthedocs-preview meltano-sdk end -->