### PR TITLE
fix(templates): add environment support to the cookie cutter for `meltano.yml`

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/meltano.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/meltano.yml
@@ -1,10 +1,9 @@
 version: 1
 send_anonymous_usage_stats: true
 project_id: "{{cookiecutter.tap_id}}"
+default_environment: test
 environments:
-- name: dev
-- name: staging
-- name: prod
+- name: test
 plugins:
   extractors:
   - name: "{{cookiecutter.tap_id}}"

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/meltano.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/meltano.yml
@@ -1,6 +1,10 @@
 version: 1
 send_anonymous_usage_stats: true
 project_id: "{{cookiecutter.tap_id}}"
+environments:
+- name: dev
+- name: staging
+- name: prod
 plugins:
   extractors:
   - name: "{{cookiecutter.tap_id}}"

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/meltano.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/meltano.yml
@@ -13,6 +13,8 @@ plugins:
     - state
     - catalog
     - discover
+    - about
+    - stream-maps
     config:
       start_date: '2010-01-01T00:00:00Z'
     settings:

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/meltano.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/meltano.yml
@@ -11,9 +11,9 @@ plugins:
     namespace: "{{cookiecutter.library_name}}"
     pip_url: -e .
     capabilities:
-    - state
-    - catalog
-    - discover
+    - about
+    - stream-maps
+    - record-flattening
     config:
       start_date: '2010-01-01T00:00:00Z'
     settings:

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/meltano.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/meltano.yml
@@ -1,6 +1,9 @@
 version: 1
 send_anonymous_usage_stats: true
 project_id: "{{cookiecutter.target_id}}"
+default_environment: test
+environments:
+- name: test
 plugins:
   extractors: []
   loaders:


### PR DESCRIPTION
Closes https://github.com/meltano/sdk/issues/1092

Related to slack thread https://meltano.slack.com/archives/C01TCRBBJD7/p1666232552939149

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1093.org.readthedocs.build/en/1093/

<!-- readthedocs-preview meltano-sdk end -->