### PR TITLE
feat: add `--discover` capability for all SQL targets

### DIFF
--- a/singer_sdk/cli/common_options.py
+++ b/singer_sdk/cli/common_options.py
@@ -35,3 +35,9 @@ PLUGIN_FILE_INPUT = click.option(
     help="A path to read messages from instead of from standard in.",
     type=click.File("r"),
 )
+
+PLUGIN_DISCOVERY = click.option(
+    "--discover",
+    is_flag=True,
+    help="Run in discovery mode.",
+)

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -398,11 +398,7 @@ class Tap(PluginBase, metaclass=abc.ABCMeta):
         @common_options.PLUGIN_ABOUT
         @common_options.PLUGIN_ABOUT_FORMAT
         @common_options.PLUGIN_CONFIG
-        @click.option(
-            "--discover",
-            is_flag=True,
-            help="Run the tap in discovery mode.",
-        )
+        @common_options.PLUGIN_DISCOVERY
         @click.option(
             "--test",
             is_flag=False,

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -675,9 +675,6 @@ class SQLTarget(Target):
     def tap_class(cls) -> type[SQLTap]:
         """Return a SQLTap class to emulate Tap capabilities.
 
-        Args:
-            config: The config object to use when initializing the tap.
-
         Returns:
             A basic SQLTap object using the default SQLConnector from the target's
             default sink.

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -9,7 +9,7 @@ import sys
 import time
 from io import FileIO
 from pathlib import Path, PurePath
-from typing import IO, Callable, Counter, Dict, List, Optional, Tuple, Type, Union
+from typing import IO, Callable, Counter
 
 import click
 from joblib import Parallel, delayed, parallel_backend

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -44,11 +44,11 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
 
     # Default class to use for creating new sink objects.
     # Required if `Target.get_sink_class()` is not defined.
-    default_sink_class: Optional[Type[Sink]] = None
+    default_sink_class: type[Sink] | None = None
 
     def __init__(
         self,
-        config: Optional[Union[dict, PurePath, str, List[Union[PurePath, str]]]] = None,
+        config: dict | PurePath | str | list[PurePath | str] | None = None,
         parse_env_config: bool = False,
         validate_config: bool = True,
     ) -> None:
@@ -68,11 +68,11 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
             validate_config=validate_config,
         )
 
-        self._latest_state: Dict[str, dict] = {}
-        self._drained_state: Dict[str, dict] = {}
-        self._sinks_active: Dict[str, Sink] = {}
-        self._sinks_to_clear: List[Sink] = []
-        self._max_parallelism: Optional[int] = _MAX_PARALLELISM
+        self._latest_state: dict[str, dict] = {}
+        self._drained_state: dict[str, dict] = {}
+        self._sinks_active: dict[str, Sink] = {}
+        self._sinks_to_clear: list[Sink] = []
+        self._max_parallelism: int | None = _MAX_PARALLELISM
 
         # Approximated for max record age enforcement
         self._last_full_drain_at: float = time.time()
@@ -85,7 +85,7 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
         )
 
     @classproperty
-    def capabilities(self) -> List[CapabilitiesEnum]:
+    def capabilities(self) -> list[CapabilitiesEnum]:
         """Get target capabilities.
 
         Returns:
@@ -126,9 +126,9 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
         self,
         stream_name: str,
         *,
-        record: Optional[dict] = None,
-        schema: Optional[dict] = None,
-        key_properties: Optional[List[str]] = None,
+        record: dict | None = None,
+        schema: dict | None = None,
+        key_properties: list[str] | None = None,
     ) -> Sink:
         """Return a sink for the given stream name.
 
@@ -174,7 +174,7 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
 
         return existing_sink
 
-    def get_sink_class(self, stream_name: str) -> Type[Sink]:
+    def get_sink_class(self, stream_name: str) -> type[Sink]:
         """Get sink for a stream.
 
         Developers can override this method to return a custom Sink type depending
@@ -212,7 +212,7 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
 
     @final
     def add_sink(
-        self, stream_name: str, schema: dict, key_properties: Optional[List[str]] = None
+        self, stream_name: str, schema: dict, key_properties: list[str] | None = None
     ) -> Sink:
         """Create a sink and register it.
 
@@ -465,7 +465,7 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
         sink.process_batch(draining_status)
         sink.mark_drained()
 
-    def _drain_all(self, sink_list: List[Sink], parallelism: int) -> None:
+    def _drain_all(self, sink_list: list[Sink], parallelism: int) -> None:
         if parallelism == 1:
             for sink in sink_list:
                 self.drain_one(sink)
@@ -510,7 +510,7 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
         def cli(
             version: bool = False,
             about: bool = False,
-            config: Tuple[str, ...] = (),
+            config: tuple[str, ...] = (),
             format: str = None,
             file_input: FileIO = None,
         ) -> None:
@@ -543,7 +543,7 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
             cls.print_version(print_fn=cls.logger.info)
 
             parse_env_config = False
-            config_files: List[PurePath] = []
+            config_files: list[PurePath] = []
             for config_path in config:
                 if config_path == "ENV":
                     # Allow parse from env vars:
@@ -574,7 +574,7 @@ class SQLTarget(Target):
     """Target implementation for SQL destinations."""
 
     # SQLTarget tightens constraint to type `SQLSink` and non-null.
-    default_sink_class: Type[SQLSink]
+    default_sink_class: type[SQLSink]
 
     @classproperty
     def cli(cls) -> Callable:
@@ -601,7 +601,7 @@ class SQLTarget(Target):
             version: bool = False,
             about: bool = False,
             discover: bool = False,
-            config: Tuple[str, ...] = (),
+            config: tuple[str, ...] = (),
             format: str = None,
             file_input: FileIO = None,
         ) -> None:
@@ -638,7 +638,7 @@ class SQLTarget(Target):
             cls.print_version(print_fn=cls.logger.info)
 
             parse_env_config = False
-            config_files: List[PurePath] = []
+            config_files: list[PurePath] = []
             for config_path in config:
                 if config_path == "ENV":
                     # Allow parse from env vars:

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -684,9 +684,12 @@ class SQLTarget(Target):
         """
 
         class TargetStreamClass(SQLStream):
+            """Custom stream class, reusing target's connector."""
+
             connector_class = cls.default_sink_class.connector_class
 
         class TargetTapClass(SQLTap):
+            """Custom tap class, reusing target config."""
 
             name = f"tap-from-{cls.name}"
             default_stream_class = TargetStreamClass


### PR DESCRIPTION
This was an experiment which actually turned out to be simpler than expected.

Todo:

- [ ] Tests
- [ ] Docs
- [ ] Discussion

Note:

The primary value of this operation is to be able to analyze and version the schema of targets. This is important because when trying to understand destination schema in the target, we can't necessarily assume that the target schema will be identical with the schema of upstream tap streams. Stream maps and selection rules can change this, of course, but also factors like `schema_mappings` and `_sdc_*` metadata columns.

Potentially this could be extended further to actually querying data from the target directly - but that is not in scope any time in the near future.

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1120.org.readthedocs.build/en/1120/

<!-- readthedocs-preview meltano-sdk end -->