### PR TITLE
fix: Write a valid final state message at the end of each stream sync

### DIFF
--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -380,6 +380,7 @@ class Tap(PluginBase, metaclass=abc.ABCMeta):
 
             stream.sync()
             stream.finalize_state_progress_markers()
+            stream._write_state_message()
 
         # this second loop is needed for all streams to print out their costs
         # including child streams which are otherwise skipped in the loop above

--- a/tests/core/test_countries_sync.py
+++ b/tests/core/test_countries_sync.py
@@ -130,4 +130,4 @@ def test_batch_mode(monkeypatch, outdir):
     assert counter["SCHEMA", "countries"] == 1
     assert counter["BATCH", "countries"] == 1
 
-    assert counter[("STATE",)] == 2
+    assert counter[("STATE",)] == 4


### PR DESCRIPTION
Refer to this [slack thread](https://meltano.slack.com/archives/C01PKLU5D1R/p1668012985498759).

This PR adds a call to issue a final (valid) state message at the end of each stream sync.

In some cases, messages sent by the tap were invalid. For instance, if `state_partitioning_keys` is overridden in a stream, the stream would never issue a valid state message, making incremental syncs impossible.

Here is an example of the last message issued by `tap-github` when running on the `issue_comments` stream (which has `state_partitioning_keys` overridden). `progress_markers` should not be present in the output, and `replication_key_value` should have been promoted one level up.

```json
{"type": "STATE", "value": {"bookmarks": {
    "tempStream": {},
    "repositories": {"partitions": [{"context": {"org": "nextcloud", "repo": "server", "repo_id": 60243197}}]},
    "issue_comments": {
        "partitions": [{"context": {"org": "nextcloud", "repo": "server"}, 
        "replication_key_signpost": "2022-11-09T16:44:57.220041+00:00",
        "starting_replication_value": "2022-11-07",
        "progress_markers": {"Note": "Progress is not resumable if interrupted.", "replication_key": "updated_at", "replication_key_value": "2022-11-09T16:41:17Z"}
        }]
    }
}}}
```

There are probably some other use cases where the final state message is never sent.

I will try to add a useful test case around this, but it would also be helpful to come up with some more general tests for taps using the sdk, to validate messages they produce.

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1164.org.readthedocs.build/en/1164/

<!-- readthedocs-preview meltano-sdk end -->