### PR TITLE
fix: `SQLConnector.table_exists()` to use separate `table_name` and `schema_name` instead of fully qualified name

### DIFF
--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -491,7 +491,7 @@ class SQLConnector:
         else:
             return cast(
                 bool,
-                sqlalchemy.inspect(self._engine).has_table(table_name, schema_name),
+                sqlalchemy.inspect(self._engine).has_table(table_name),
             )
 
     def schema_exists(self, schema_name: str) -> bool:

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -483,16 +483,11 @@ class SQLConnector:
         )
         table_name: str = pftn[2]
         schema_name: str = pftn[1]
-        if schema_name:
-            return cast(
-                bool,
-                sqlalchemy.inspect(self._engine).has_table(table_name, schema_name),
-            )
-        else:
-            return cast(
-                bool,
-                sqlalchemy.inspect(self._engine).has_table(table_name),
-            )
+
+        return cast(
+            bool,
+            sqlalchemy.inspect(self._engine).has_table(table_name, schema_name),
+        )
 
     def schema_exists(self, schema_name: str) -> bool:
         """Determine if the target database schema already exists.

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -669,9 +669,7 @@ class SQLConnector:
             partition_keys: list of partition keys.
             as_temp_table: True to create a temp table.
         """
-        self.logger.info(f"Preparing table {full_table_name}")
         if not self.table_exists(full_table_name=full_table_name):
-            self.logger.info(f"Table {full_table_name} does not exist")
             self.create_empty_table(
                 full_table_name=full_table_name,
                 schema=schema,
@@ -680,7 +678,7 @@ class SQLConnector:
                 as_temp_table=as_temp_table,
             )
             return
-        self.logger.info(f"Found table {full_table_name}, going to prepare columns")
+
         for property_name, property_def in schema["properties"].items():
             self.prepare_column(
                 full_table_name, property_name, self.to_sql_type(property_def)

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -477,10 +477,22 @@ class SQLConnector:
         Returns:
             True if table exists, False if not, None if unsure or undetectable.
         """
-        return cast(
-            bool,
-            sqlalchemy.inspect(self._engine).has_table(full_table_name),
+        # pftn -> Parsed Full Table Name [0] = db, [1] = schema, [2] = table
+        pftn: tuple = SQLConnector.parse_full_table_name(
+            self, full_table_name=full_table_name
         )
+        table_name: str = pftn[2]
+        schema_name: str = pftn[1]
+        if schema_name:
+            return cast(
+                bool,
+                sqlalchemy.inspect(self._engine).has_table(table_name, schema_name),
+            )
+        else:
+            return cast(
+                bool,
+                sqlalchemy.inspect(self._engine).has_table(table_name, schema_name),
+            )
 
     def schema_exists(self, schema_name: str) -> bool:
         """Determine if the target database schema already exists.
@@ -662,7 +674,9 @@ class SQLConnector:
             partition_keys: list of partition keys.
             as_temp_table: True to create a temp table.
         """
+        self.logger.info(f"Preparing table {full_table_name}")
         if not self.table_exists(full_table_name=full_table_name):
+            self.logger.info(f"Table {full_table_name} does not exist")
             self.create_empty_table(
                 full_table_name=full_table_name,
                 schema=schema,
@@ -671,7 +685,7 @@ class SQLConnector:
                 as_temp_table=as_temp_table,
             )
             return
-
+        self.logger.info(f"Found table {full_table_name}, going to prepare columns")
         for property_name, property_def in schema["properties"].items():
             self.prepare_column(
                 full_table_name, property_name, self.to_sql_type(property_def)

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -477,12 +477,9 @@ class SQLConnector:
         Returns:
             True if table exists, False if not, None if unsure or undetectable.
         """
-        # pftn -> Parsed Full Table Name [0] = db, [1] = schema, [2] = table
-        pftn: tuple = SQLConnector.parse_full_table_name(
-            self, full_table_name=full_table_name
+        _, schema_name, table_name = self.parse_full_table_name(
+            full_table_name=full_table_name
         )
-        table_name: str = pftn[2]
-        schema_name: str = pftn[1]
 
         return cast(
             bool,

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -477,9 +477,7 @@ class SQLConnector:
         Returns:
             True if table exists, False if not, None if unsure or undetectable.
         """
-        _, schema_name, table_name = self.parse_full_table_name(
-            full_table_name=full_table_name
-        )
+        _, schema_name, table_name = self.parse_full_table_name(full_table_name)
 
         return cast(
             bool,


### PR DESCRIPTION
Attempt to fix `table_exists()` to use the parsed `full_table_name` parts table and schema instead of a combined multipart name.

Fixes #1167  

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1168.org.readthedocs.build/en/1168/

<!-- readthedocs-preview meltano-sdk end -->