### PR TITLE
fix(templates): Update `SQLConnector` import for SQL target cookiecutter

### DIFF
--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks.py
@@ -20,7 +20,6 @@ from singer_sdk.connectors import SQLConnector
 
 {%- if sinkclass == "SQLSink" %}
 
-
 class {{ cookiecutter.destination_name }}Connector(SQLConnector):
     """The connector for {{ cookiecutter.destination_name }}.
 

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 
 {%- set sinkclass = sinkclass_mapping[cookiecutter.serialization_method] %}
 
-from singer_sdk.sinks import {% if sinkclass == "SQLSink" %}SQLConnector, {% endif %}{{ sinkclass }}
+from singer_sdk.sinks import {{ sinkclass }}
+
+{%- if sinkclass == "SQLSink" %}
+from singer_sdk.connectors import SQLConnector
+{% endif %}
 
 {%- if sinkclass == "SQLSink" %}
 


### PR DESCRIPTION
It appears, with sdk v0.13.1, the location of the `SQLConnector` class was moved from `singer_sdk.sinks` to `singer_sdk.connectors`. This is intended to reflect this change in the cookiecutter sql-target template.

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1182.org.readthedocs.build/en/1182/

<!-- readthedocs-preview meltano-sdk end -->