### PR TITLE
fix: Add a to dict method to RecordMessage to improve performance

### DIFF
--- a/singer_sdk/_singerlib/messages.py
+++ b/singer_sdk/_singerlib/messages.py
@@ -47,6 +47,7 @@ class Message:
         Returns:
             A dictionary with the defined message fields.
         """
+
         return asdict(self, dict_factory=exclude_null_dict)
 
     @classmethod
@@ -78,6 +79,18 @@ class RecordMessage(Message):
 
     time_extracted: datetime | None = None
     """The time the record was extracted."""
+
+    def to_dict(self) -> dict[str, t.Any]:
+        result = {
+            'type': 'RECORD',
+            'stream': self.stream,
+            'record': self.record
+        }
+        if self.version is not None:
+            result["version"] = self.version
+        if self.time_extracted is not None:
+            result["time_extracted"] = self.time_extracted
+        return result
 
     def __post_init__(self) -> None:
         """Post-init processing.


### PR DESCRIPTION
In my testing, taps spend about half of their time converting record messages to dicts. This basically reduces that to nothing, doubling the throughput of the average tap.