### PR TITLE
feat(taps): Catch and retry `ConnectionResetError` exceptions in HTTP taps

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -220,6 +220,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         decorator: Callable = backoff.on_exception(
             self.backoff_wait_generator,
             (
+                ConnectionResetError,
                 RetriableAPIError,
                 requests.exceptions.ReadTimeout,
                 requests.exceptions.ConnectionError,


### PR DESCRIPTION
Closes #1236


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1237.org.readthedocs.build/en/1237/

<!-- readthedocs-preview meltano-sdk end -->