### PR TITLE
fix(taps): Ensure metric tags coming from stream context can be JSON-serialized

### DIFF
--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -77,7 +77,7 @@ class Point(Generic[_TVal]):
         Returns:
             A JSON object.
         """
-        return json.dumps(asdict(self))
+        return json.dumps(asdict(self), default=str)
 
 
 def log(logger: logging.Logger, point: Point) -> None:


### PR DESCRIPTION
Otherwise adding objects in a streams `context` that can't be JSON-serialized cause the tap to fail.

For example, pendulum objects in [tap-lastfm](https://github.com/rabidaudio/tap-lastfm/blob/606b4608355a37609e81be0827d2283f4cb94cd4/tap_lastfm/streams.py#L58-L63).

Closes https://github.com/meltano/sdk/issues/1239