### PR TITLE
docs: Document inherited `PluginBase` attributes and methods

### DIFF
--- a/docs/_templates/plugin_class.rst
+++ b/docs/_templates/plugin_class.rst
@@ -1,0 +1,10 @@
+{{ fullname }}
+{{ "=" * fullname|length }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ name }}
+    :members:
+    :show-inheritance:
+    :inherited-members:
+    :special-members: __init__

--- a/docs/classes/singer_sdk.InlineMapper.rst
+++ b/docs/classes/singer_sdk.InlineMapper.rst
@@ -5,4 +5,6 @@
 
 .. autoclass:: InlineMapper
     :members:
+    :show-inheritance:
+    :inherited-members:
     :special-members: __init__

--- a/docs/classes/singer_sdk.SQLTap.rst
+++ b/docs/classes/singer_sdk.SQLTap.rst
@@ -5,4 +5,6 @@
 
 .. autoclass:: SQLTap
     :members:
+    :show-inheritance:
+    :inherited-members:
     :special-members: __init__

--- a/docs/classes/singer_sdk.SQLTarget.rst
+++ b/docs/classes/singer_sdk.SQLTarget.rst
@@ -5,4 +5,6 @@
 
 .. autoclass:: SQLTarget
     :members:
+    :show-inheritance:
+    :inherited-members:
     :special-members: __init__

--- a/docs/classes/singer_sdk.Tap.rst
+++ b/docs/classes/singer_sdk.Tap.rst
@@ -5,4 +5,6 @@
 
 .. autoclass:: Tap
     :members:
+    :show-inheritance:
+    :inherited-members:
     :special-members: __init__

--- a/docs/classes/singer_sdk.Target.rst
+++ b/docs/classes/singer_sdk.Target.rst
@@ -5,4 +5,6 @@
 
 .. autoclass:: Target
     :members:
+    :show-inheritance:
+    :inherited-members:
     :special-members: __init__

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -8,7 +8,7 @@ Plugin Classes
 
 .. autosummary::
     :toctree: classes
-    :template: class.rst
+    :template: plugin_class.rst
 
     Tap
     Target

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -277,7 +277,9 @@ class PluginBase(metaclass=abc.ABCMeta):
 
         Args:
             print_fn: A function to use to display the plugin version.
-                Defaults to :function:`print`.
+                Defaults to `print`_.
+
+        .. _print: https://docs.python.org/3/library/functions.html#print
         """
         print_fn(f"{cls.name} v{cls.plugin_version}, Meltano SDK v{cls.sdk_version}")
 


### PR DESCRIPTION
Some attributes and methods, such as `Tap.print_version`, weren't documented because we exclude `PluginBase` from the docs (probably with good reason, since developers should seldom need to subclass it directly).

Now they're documented: https://meltano-sdk--1243.org.readthedocs.build/en/1243/classes/singer_sdk.Tap.html#singer_sdk.Tap.print_version


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1243.org.readthedocs.build/en/1243/

<!-- readthedocs-preview meltano-sdk end -->