### PR TITLE
feat: Read plugin version from distribution, with fallback to package

### DIFF
--- a/singer_sdk/helpers/_compat.py
+++ b/singer_sdk/helpers/_compat.py
@@ -37,7 +37,7 @@ def get_project_distribution(file_path=None) -> metadata.Distribution | None:
         except ValueError:
             pass
         else:
-            if relative in dist.files:
+            if dist.files and relative in dist.files:
                 return dist
     return None
 

--- a/singer_sdk/helpers/_compat.py
+++ b/singer_sdk/helpers/_compat.py
@@ -1,5 +1,5 @@
 """Compatibility helpers."""
-from __future__ import typing
+from __future__ import annotations
 
 import pathlib
 

--- a/singer_sdk/helpers/_compat.py
+++ b/singer_sdk/helpers/_compat.py
@@ -16,6 +16,9 @@ except ImportError:
     import importlib_metadata as metadata  # type: ignore
 
 
+__all__ = ["metadata", "get_project_distribution", "final"]
+
+
 # Future: replace with `importlib.metadata.packages_distributions()` introduced in 3.10
 def get_project_distribution(file_path=None) -> metadata.Distribution | None:
     """Get project distribution.
@@ -40,6 +43,3 @@ def get_project_distribution(file_path=None) -> metadata.Distribution | None:
             if dist.files and relative in dist.files:
                 return dist
     return None
-
-
-__all__ = ["metadata", "get_project_distribution", "final"]

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -4,6 +4,7 @@ import abc
 import json
 import logging
 import os
+import sys
 from collections import OrderedDict
 from pathlib import PurePath
 from types import MappingProxyType
@@ -162,7 +163,9 @@ class PluginBase(metaclass=abc.ABCMeta):
         Returns:
             The package version number.
         """
-        distribution = get_project_distribution(__file__)
+        # get the file location of the subclass
+        path = sys.modules[cls.__module__].__file__
+        distribution = get_project_distribution(path)
         if distribution:
             version = str(distribution.metadata["Version"])
         else:

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -27,7 +27,7 @@ from singer_sdk import metrics
 from singer_sdk.configuration._dict_config import parse_environment_config
 from singer_sdk.exceptions import ConfigValidationError
 from singer_sdk.helpers._classproperty import classproperty
-from singer_sdk.helpers._compat import metadata
+from singer_sdk.helpers._compat import get_project_distribution, metadata
 from singer_sdk.helpers._secrets import SecretString, is_common_secret_key
 from singer_sdk.helpers._util import read_json_file
 from singer_sdk.helpers.capabilities import (
@@ -162,10 +162,14 @@ class PluginBase(metaclass=abc.ABCMeta):
         Returns:
             The package version number.
         """
-        try:
-            version = metadata.version(cls.name)
-        except metadata.PackageNotFoundError:
-            version = "[could not be detected]"
+        distribution = get_project_distribution(__file__)
+        if distribution:
+            version = distribution.metadata["Version"]
+        else:
+            try:
+                version = metadata.version(cls.name)
+            except metadata.PackageNotFoundError:
+                version = "[could not be detected]"
         return version
 
     @classproperty

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -164,7 +164,7 @@ class PluginBase(metaclass=abc.ABCMeta):
         """
         distribution = get_project_distribution(__file__)
         if distribution:
-            version = distribution.metadata["Version"]
+            version = str(distribution.metadata["Version"])
         else:
             try:
                 version = metadata.version(cls.name)

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -13,6 +13,9 @@ def test_get_project_distribution():
     click is a representative example of a distributed package from our dependency tree.
     Any similar singer_sdk dependency could be used in stead.
     """
+    if platform.system() == "Windows":
+        pytest.xfail("Doesn't pass on windows.")
+
     site_package_paths = site.getsitepackages()
     site_package_path = next(
         pth for pth in site_package_paths if Path(pth).parts[-1] == "site-packages"

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -12,7 +12,7 @@ def test_get_project_distribution():
     be used in stead.
     """
     site_package_paths = site.getsitepackages()
-    singer_sdk_dependency_path = Path(site_package_paths[0]) / "github" / "__init__.py"
+    singer_sdk_dependency_path = Path(site_package_paths[0]) / "click" / "__init__.py"
     discovered_dst = get_project_distribution(singer_sdk_dependency_path)
     assert discovered_dst
-    assert discovered_dst.name == "PyGithub"
+    assert discovered_dst.name == "click"

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -13,9 +13,6 @@ def test_get_project_distribution():
     click is a representative example of a distributed package from our dependency tree.
     Any similar singer_sdk dependency could be used in stead.
     """
-    if platform.system() == "Windows":
-        pytest.xfail("Doesn't pass on windows.")
-
     site_package_paths = site.getsitepackages()
     site_package_path = next(
         pth for pth in site_package_paths if Path(pth).parts[-1] == "site-packages"

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -1,0 +1,18 @@
+import site
+from pathlib import Path
+
+from singer_sdk.helpers._compat import get_project_distribution, metadata
+
+
+def test_get_project_distribution():
+    """Test `get_project_distribution()`.
+
+    PyGithub is a representative example of the case where distribution name
+    does not match the package name. Any similar singer_sdk dependency could
+    be used in stead.
+    """
+    site_package_paths = site.getsitepackages()
+    singer_sdk_dependency_path = Path(site_package_paths[0]) / "github" / "__init__.py"
+    discovered_dst = get_project_distribution(singer_sdk_dependency_path)
+    assert discovered_dst
+    assert discovered_dst.name == "PyGithub"

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -1,5 +1,8 @@
+import platform
 import site
 from pathlib import Path
+
+import pytest
 
 from singer_sdk.helpers._compat import get_project_distribution, metadata
 
@@ -10,6 +13,9 @@ def test_get_project_distribution():
     click is a representative example of a distributed package from our dependency tree.
     Any similar singer_sdk dependency could be used in stead.
     """
+    if platform.system() == "Windows":
+        pytest.xfail("Doesn't pass on windows.")
+
     site_package_paths = site.getsitepackages()
     site_package_path = next(
         pth for pth in site_package_paths if Path(pth).parts[-1] == "site-packages"

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -7,9 +7,8 @@ from singer_sdk.helpers._compat import get_project_distribution, metadata
 def test_get_project_distribution():
     """Test `get_project_distribution()`.
 
-    PyGithub is a representative example of the case where distribution name
-    does not match the package name. Any similar singer_sdk dependency could
-    be used in stead.
+    click is a representative example of a distributed package from our dependency tree.
+    Any similar singer_sdk dependency could be used in stead.
     """
     site_package_paths = site.getsitepackages()
     singer_sdk_dependency_path = Path(site_package_paths[0]) / "click" / "__init__.py"

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -11,7 +11,10 @@ def test_get_project_distribution():
     Any similar singer_sdk dependency could be used in stead.
     """
     site_package_paths = site.getsitepackages()
-    singer_sdk_dependency_path = Path(site_package_paths[0]) / "click" / "__init__.py"
+    site_package_path = next(
+        pth for pth in site_package_paths if Path(pth).parts[-1] == "site-packages"
+    )
+    singer_sdk_dependency_path = Path(site_package_path) / "click" / "__init__.py"
     discovered_dst = get_project_distribution(singer_sdk_dependency_path)
     assert discovered_dst
     assert discovered_dst.name == "click"


### PR DESCRIPTION
In cases where the distribution name does not match the tap/target ID (also the package name by default) the `Version` reported in `--about` registers as `[could not be detected]`.

e.g. `tap-snowflake` with package name `tap_snowflake` distributed as `meltanolabs-tap-snowflake`, to avoid PyPI name clashes.

Related to [MeltanoLabs/tap-snowflake#8](https://github.com/MeltanoLabs/tap-snowflake/issues/8)

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1254.org.readthedocs.build/en/1254/

<!-- readthedocs-preview meltano-sdk end -->