### PR TITLE
fix: Targets to fail gracefully when schema message is missing the `properties` key

### DIFF
--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -332,6 +332,7 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
             message_dict: The newly received schema message.
         """
         self._assert_line_requires(message_dict, requires={"stream", "schema"})
+        self._assert_line_requires(message_dict["schema"], requires={"properties"})
 
         stream_name = message_dict["stream"]
         schema = message_dict["schema"]


### PR DESCRIPTION
Closes https://github.com/meltano/sdk/issues/1145

Example implementation https://github.com/MeltanoLabs/target-postgres/commit/41822b548ef99dcb5aa79ea140e872a6beb7892a

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1287.org.readthedocs.build/en/1287/

<!-- readthedocs-preview meltano-sdk end -->