### PR TITLE
fix(templates): Install dependencies in CI and bump dev dependencies

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/{% if cookiecutter.include_cicd_sample_template == 'GitHub' %}ci_workflow.yml{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/{% if cookiecutter.include_cicd_sample_template == 'GitHub' %}ci_workflow.yml{%endif%}
@@ -24,6 +24,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry==1.2.*
+    - name: Install dependencies
+      run: |
+        poetry install
     - name: Run lint command from tox.ini
       run: |
         poetry run tox -e lint

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -15,11 +15,11 @@ requests = "^2.25.1"
 singer-sdk = { version="^0.16.0"}
 fs-s3fs = { version = "^1.1.1", optional = true}
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^6.2.5"
 tox = "^3.24.4"
 flake8 = "^3.9.2"
-black = "^21.9b0"
+black = "^22.12.0"
 pydocstyle = "^6.1.1"
 mypy = "^0.910"
 types-requests = "^2.26.1"

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -10,20 +10,20 @@ keywords = [
 license = "Apache 2.0"
 
 [tool.poetry.dependencies]
-python = "<3.11,>=3.7.1"
-requests = "^2.25.1"
+python = "<3.12,>=3.7.1"
+requests = "^2.28.1"
 singer-sdk = { version="^0.16.0"}
 fs-s3fs = { version = "^1.1.1", optional = true}
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^6.2.5"
-tox = "^3.24.4"
+pytest = "^7.2.0"
+tox = "^4.1.3"
 flake8 = "^3.9.2"
 black = "^22.12.0"
-pydocstyle = "^6.1.1"
-mypy = "^0.910"
-types-requests = "^2.26.1"
-isort = "^5.10.1"
+pydocstyle = "^6.2.1"
+mypy = "^0.991"
+types-requests = "^2.28.11.7"
+isort = "^5.11.4"
 
 [tool.poetry.extras]
 s3 = ["fs-s3fs"]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/tox.ini
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/tox.ini
@@ -6,7 +6,7 @@ envlist = py38
 isolated_build = true
 
 [testenv]
-whitelist_externals = poetry
+allowlist_externals = poetry
 
 commands =
     poetry install -v

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -10,20 +10,20 @@ keywords = [
 license = "Apache 2.0"
 
 [tool.poetry.dependencies]
-python = "<3.11,>=3.7.1"
-requests = "^2.25.1"
+python = "<3.12,>=3.7.1"
+requests = "^2.28.1"
 singer-sdk = { version="^0.16.0"}
 fs-s3fs = { version = "^1.1.1", optional = true}
 
 [tool.poetry.dev-dependencies]
-pytest = "^6.2.5"
-tox = "^3.24.4"
+pytest = "^7.2.0"
+tox = "^4.1.3"
 flake8 = "^3.9.2"
-black = "^21.9b0"
-pydocstyle = "^6.1.1"
-mypy = "^0.910"
-types-requests = "^2.26.1"
-isort = "^5.10.1"
+black = "^22.12.0"
+pydocstyle = "^6.2.1"
+mypy = "^0.991"
+types-requests = "^2.28.11.7"
+isort = "^5.11.4"
 
 [tool.poetry.extras]
 s3 = ["fs-s3fs"]


### PR DESCRIPTION
Closes https://github.com/meltano/sdk/issues/1223 and https://github.com/meltano/sdk/issues/1225

I ran into these same bugs when using the cookiecutter for https://github.com/pnadolny13/tap-cloudwatch and had to resolve them for my implementation. Heres what ended up working for me.

- github action install poetry dependencies before running tox
- bump black version
- migrate from legacy poetry dev dependencies to group.dev. I removed black then readded it and poetry did this automatically for me with a warning.

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1305.org.readthedocs.build/en/1305/

<!-- readthedocs-preview meltano-sdk end -->