### PR TITLE
fix(taps): Replace hyphens with underscores when generating expected env var name `<PLUGIN_NAME>_LOGLEVEL`

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -175,7 +175,7 @@ This repo uses the [semantic-prs](https://github.com/Ezard/semantic-prs) GitHub 
 
 Pull requests should be named according to the conventional commit syntax to streamline changelog and release notes management. We encourage (but do not require) the use of conventional commits in commit messages as well.
 
-In general, PR titles should follow the format "<type>: <desc>", where type is any one of these:
+In general, PR titles should follow the format `<type>: <desc>`, where type is any one of these:
 
 - `ci`
 - `chore`

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -63,7 +63,8 @@ class PluginBase(metaclass=abc.ABCMeta):
             Plugin logger.
         """
         # Get the level from <PLUGIN_NAME>_LOGLEVEL or LOGLEVEL environment variables
-        LOGLEVEL = os.environ.get(f"{cls.name.upper()}_LOGLEVEL") or os.environ.get(
+        plugin_env_prefix = f"{cls.name.upper().replace('-', '_')}_"
+        LOGLEVEL = os.environ.get(f"{plugin_env_prefix}LOGLEVEL") or os.environ.get(
             "LOGLEVEL"
         )
 


### PR DESCRIPTION
Currently, we're looking for `cls.name.upper()`, with hyphens intact. Since hyphens are not allowed in shell variable names, this makes it impossible to set the loglevel for a single tap. This change makes this variable match other plugin specific variables by replacing hyphens with underscores.

Also, fix a formatting glitch in the contributing guide.

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1308.org.readthedocs.build/en/1308/

<!-- readthedocs-preview meltano-sdk end -->