### PR TITLE
fix: Remove tox dependency from tap/target template

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -19,7 +19,6 @@ requests = "^2.28.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"
-tox = "^4.1.3"
 flake8 = "^3.9.2"
 black = "^22.12.0"
 pydocstyle = "^6.2.1"

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -19,7 +19,6 @@ requests = "^2.28.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"
-tox = "^4.1.3"
 flake8 = "^3.9.2"
 black = "^22.12.0"
 pydocstyle = "^6.2.1"

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -39,16 +39,20 @@ for more information on differences between a target's `Sink` class versus a tap
 
 ## Building a New Tap or Target
 
-First, install [cookiecutter](https://cookiecutter.readthedocs.io) if you haven't
-done so already:
+First, install [cookiecutter](https://cookiecutter.readthedocs.io),
+[Poetry](https://python-poetry.org/docs/), and optionally [Tox](https://tox.wiki/):
 
 ```bash
 # Install pipx if you haven't already
-pip3 install pipx
+pip install pipx
 pipx ensurepath
+
 # Restart your terminal here, if needed, to get the updated PATH
 pipx install cookiecutter
 pipx install poetry
+
+# Optional: Install Tox if you want to use it to run auto-formatters, linters, tests, etc.
+pipx install tox
 ```
 
 Now you can initialize your new project with the Cookiecutter template for taps:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1583,7 +1583,7 @@ files = [
 cffi = ">=1.4.1"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
+docs = ["sphinx (>=1.6.5)", "sphinx_rtd_theme"]
 tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]
@@ -1750,13 +1750,6 @@ files = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
-    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
-    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},


### PR DESCRIPTION
Per @edgarrmondragon's [suggestion](https://github.com/meltano/sdk/issues/1311#issuecomment-1402682760), the documentation has been updated to suggest it be installed using `pipx`

Closes #1311

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1345.org.readthedocs.build/en/1345/

<!-- readthedocs-preview meltano-sdk end -->