### PR TITLE
feat: refactor SQLConnector connection handling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1012,6 +1012,7 @@ category = "main"
 optional = true
 python-versions = "*"
 files = [
+    {file = "livereload-2.6.3-py2.py3-none-any.whl", hash = "sha256:ad4ac6f53b2d62bb6ce1a5e6e96f1f00976a32348afedcb4b6d68df2a1d346e4"},
     {file = "livereload-2.6.3.tar.gz", hash = "sha256:776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869"},
 ]
 
@@ -1596,7 +1597,7 @@ files = [
 cffi = ">=1.4.1"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5)", "sphinx_rtd_theme"]
+docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
 tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]


### PR DESCRIPTION
This is a draft PR that proposes a solution to issue #1393.

Broad overview:
- We are no longer storing an open connection on this object. Instead, we store an engine. Wherever we were previously making a new engine, we instead access the connector's existing engine. When a connection is needed, we open one at that time.
- When connections are opened, they're opened using `self._connect()` as a context manager. This rule is put into place where it's possible to do so without making a breaking change.
- Several methods are prepared for deprecation, but their function is preserved. 
    - (Breaking change) `_connection` is removed altogether. The tap no longer accepts that argument on init, and we don't store a single connection at all
        - This is a breaking change for any subclasses that were using this property
        - This is a breaking change for any subclasses that counted on a single connection being reused throughout the lifetime of the instance
        - This is a breaking change for any cases where an external method call counted on a single connection being returned each time that `create_sqlalchemy_connection` was called (or for anyone who didn't respect the protectedness of _connection).
    - (Slightly breaking) `connection` still exists, it just calls `create_sqlalchemy_connection`. So this is a slightly breaking change—- it returns a new connection instead of the _connection that prviously had been preserved on the instance.
    - `create_sqlalchemy_engine` now just returns self._engine, since we have an engine on this object anyway.
    - `create_sqlalchemy_connection` now opens a connection using self._engine and returns the open connection.
    
    
Detailed changes in functionality:
1. `self._connect()` is added. This is the correct way to open connections now—- you use it as a context manager, exactly as you would sqlalchemy.engine.connect()... in fact currently it just directly wraps that.
2. We now create and cache a single engine for this instance. It's accessed as a protected property under `_engine`.
2. `create_sqlalchemy_connection` calls `self._engine` now instead of `self.create_sqlalchemy_engine`, since the connector now has an engine. This and the next item help extricate and disconnect these soon-to-be-deprecated methods.
3. `create_sqlalchemy_engine` now calls `self._engine` instead of making the engine itself.
4. Everywhere else in the SQLConnector that connection.execute was called now uses the correct/new _connect strategy.
5. Internal calls to create_sqlalchemy_engine now just call _engine (this is just a change to discover_catalog_entries).
