### PR TITLE
fix(templates): Use a version of `isort` compatible with Python 3.8

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -14,18 +14,18 @@ python = "<3.12,>=3.7.1"
 singer-sdk = { version="^0.19.0"}
 fs-s3fs = { version = "^1.1.1", optional = true}
 {%- if cookiecutter.stream_type in ["REST", "GraphQL"] %}
-requests = "^2.28.1"
+requests = "^2.28.2"
 {%- endif %}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.1"
 flake8 = "^5.0.4"
-black = "^22.12.0"
-pydocstyle = "^6.2.1"
-mypy = "^0.991"
-isort = "^5.12.0"
+black = "^23.1.0"
+pydocstyle = "^6.3.0"
+mypy = "^1.0.0"
+isort = "^5.11.5"
 {%- if cookiecutter.stream_type in ["REST", "GraphQL"] %}
-types-requests = "^2.28.11.7"
+types-requests = "^2.28.11.12"
 {%- endif %}
 
 [tool.poetry.extras]

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -14,18 +14,18 @@ python = "<3.12,>=3.7.1"
 singer-sdk = { version="^0.19.0"}
 fs-s3fs = { version = "^1.1.1", optional = true}
 {%- if cookiecutter.serialization_method != "SQL" %}
-requests = "^2.28.1"
+requests = "^2.28.2"
 {%- endif %}
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.1"
 flake8 = "^5.0.4"
-black = "^22.12.0"
-pydocstyle = "^6.2.1"
-mypy = "^0.991"
-isort = "^5.12.0"
+black = "^23.1.0"
+pydocstyle = "^6.3.0"
+mypy = "^1.0.0"
+isort = "^5.11.5"
 {%- if cookiecutter.serialization_method != "SQL" %}
-types-requests = "^2.28.11.7"
+types-requests = "^2.28.11.12"
 {%- endif %}
 
 [tool.poetry.extras]


### PR DESCRIPTION
See https://github.com/pycqa/isort/blob/main/CHANGELOG.md#5115-january-30-2023-hotfix

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1406.org.readthedocs.build/en/1406/

<!-- readthedocs-preview meltano-sdk end -->