### PR TITLE
chore: Use `commitizen-action@0.16.3`

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Bump version
       id: cz-bump
-      uses: commitizen-tools/commitizen-action@0.16.2
+      uses: commitizen-tools/commitizen-action@0.16.3
       with:
         increment: ${{ github.event.inputs.bump != 'auto' && github.event.inputs.bump || '' }}
         prerelease: ${{ github.event.inputs.prerelease != 'none' && github.event.inputs.prerelease || '' }}


### PR DESCRIPTION
Release notes: https://github.com/commitizen-tools/commitizen-action/releases/tag/0.16.3

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1408.org.readthedocs.build/en/1408/

<!-- readthedocs-preview meltano-sdk end -->