### PR TITLE
ci(templates): Use a local reference to the `singer-sdk` instead of PyPI distribution in E2E cookiecutter tests

### DIFF
--- a/e2e-tests/cookiecutters/test_cookiecutter.sh
+++ b/e2e-tests/cookiecutters/test_cookiecutter.sh
@@ -2,6 +2,7 @@
 CC_BUILD_PATH=/tmp
 TAP_TEMPLATE=$(realpath $1)
 REPLAY_FILE=$(realpath $2)
+SDK_DIR=$(realpath $1/../..)
 CC_OUTPUT_DIR=$(basename $REPLAY_FILE .json) # name of replay file without .json
 RUN_LINT=${3:-1}
 
@@ -36,6 +37,7 @@ fi
 cookiecutter --replay-file $REPLAY_FILE $TAP_TEMPLATE -o $CC_BUILD_PATH &&
     cd $CC_TEST_OUTPUT &&
     pwd &&
+    sed -i.bak "s|singer-sdk =.*|singer-sdk = \{ path = \"$SDK_DIR\", develop = true \}|" pyproject.toml &&
     poetry lock &&
     poetry install
 


### PR DESCRIPTION
Fixes #1444 
 - in e2e test for cookiecutter, use local singer-sdk folder as dependency
 - use sed to edit pyproject.toml in place: confirmed working with ubuntu + macos sed :)


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1445.org.readthedocs.build/en/1445/

<!-- readthedocs-preview meltano-sdk end -->