### PR TITLE
fix: Cookiecutter pydocstring formatting updates

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/tap.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/tap.py
@@ -52,8 +52,10 @@ class Tap{{ cookiecutter.source_name }}({{ 'SQL' if cookiecutter.stream_type == 
     def discover_streams(self) -> list[streams.{{ cookiecutter.source_name }}Stream]:
         """Return a list of discovered streams.
 
-        Returns:
+        Returns
+        -------
             A list of discovered streams.
+
         """
         return [
             streams.GroupsStream(self),

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'GraphQL' == cookiecutter.stream_type %}client.py{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'GraphQL' == cookiecutter.stream_type %}client.py{%endif%}
@@ -67,7 +67,6 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """Parse the response and return an iterator of result records.
 
         Args:
-        -----
             response: The HTTP ``requests.Response`` object.
 
         Yields
@@ -84,7 +83,6 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """As needed, append or transform raw data to match expected structure.
 
         Args:
-        -----
             row: An individual record from the stream.
             context: The stream context.
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'GraphQL' == cookiecutter.stream_type %}client.py{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'GraphQL' == cookiecutter.stream_type %}client.py{%endif%}
@@ -21,8 +21,10 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     def url_base(self) -> str:
         """Return the API URL root, configurable via tap settings.
 
-        Returns:
+        Returns
+        -------
             The base URL for all requests.
+
         """
         return self.config["api_url"]
 
@@ -34,8 +36,10 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     def authenticator(self) -> {{ cookiecutter.source_name }}Authenticator:
         """Return a new authenticator object.
 
-        Returns:
+        Returns
+        -------
             An authenticator instance.
+
         """
         return {{ cookiecutter.source_name }}Authenticator.create_for_stream(self)
 
@@ -45,8 +49,10 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     def http_headers(self) -> dict:
         """Return the http headers needed.
 
-        Returns:
+        Returns
+        -------
             A dictionary of HTTP headers.
+
         """
         headers = {}
         if "user_agent" in self.config:
@@ -61,10 +67,13 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """Parse the response and return an iterator of result records.
 
         Args:
+        -----
             response: The HTTP ``requests.Response`` object.
 
-        Yields:
+        Yields
+        ------
             Each record from the source.
+
         """
         # TODO: Parse response body and return a set of records.
         resp_json = response.json()
@@ -75,11 +84,14 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """As needed, append or transform raw data to match expected structure.
 
         Args:
+        -----
             row: An individual record from the stream.
             context: The stream context.
 
-        Returns:
+        Returns
+        -------
             The updated record dictionary, or ``None`` to skip the record.
+
         """
         # TODO: Delete this method if not needed.
         return row

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'REST' == cookiecutter.stream_type %}client.py{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'REST' == cookiecutter.stream_type %}client.py{%endif%}
@@ -229,8 +229,8 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         -----
             response: The HTTP ``requests.Response`` object.
 
-        Yields:
-        -------
+        Yields
+        ------
             Each record from the source.
 
         """

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'REST' == cookiecutter.stream_type %}client.py{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'REST' == cookiecutter.stream_type %}client.py{%endif%}
@@ -69,8 +69,10 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     def authenticator(self) -> _Auth:
         """Return a new authenticator object.
 
-        Returns:
+        Returns
+        -------
             An authenticator instance.
+
         """
         return {{ cookiecutter.source_name }}Authenticator.create_for_stream(self)
 
@@ -80,8 +82,10 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     def authenticator(self) -> APIKeyAuthenticator:
         """Return a new authenticator object.
 
-        Returns:
+        Returns
+        -------
             An authenticator instance.
+
         """
         return APIKeyAuthenticator.create_for_stream(
             self,
@@ -96,8 +100,10 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     def authenticator(self) -> BearerTokenAuthenticator:
         """Return a new authenticator object.
 
-        Returns:
+        Returns
+        -------
             An authenticator instance.
+
         """
         return BearerTokenAuthenticator.create_for_stream(
             self,
@@ -125,8 +131,10 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     def http_headers(self) -> dict:
         """Return the http headers needed.
 
-        Returns:
+        Returns
+        -------
             A dictionary of HTTP headers.
+
         """
         headers = {}
         if "user_agent" in self.config:
@@ -145,11 +153,14 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """Return a token for identifying next page or None if no more pages.
 
         Args:
+        -----
             response: The HTTP ``requests.Response`` object.
             previous_token: The previous page token value.
 
-        Returns:
+        Returns
+        -------
             The next pagination token.
+
         """
         # TODO: If pagination is required, return a token which can be used to get the
         #       next page. If this is the final page, return "None" to end the
@@ -173,11 +184,14 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """Return a dictionary of values to be used in URL parameterization.
 
         Args:
+        -----
             context: The stream context.
             next_page_token: The next page index or value.
 
-        Returns:
+        Returns
+        -------
             A dictionary of URL query parameters.
+
         """
         params: dict = {}
         if next_page_token:
@@ -200,8 +214,10 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
             context: The stream context.
             next_page_token: The next page index or value.
 
-        Returns:
+        Returns
+        -------
             A dictionary with the JSON body for a POST requests.
+
         """
         # TODO: Delete this method if no payload is required. (Most REST APIs.)
         return None
@@ -210,10 +226,13 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """Parse the response and return an iterator of result records.
 
         Args:
+        -----
             response: The HTTP ``requests.Response`` object.
 
         Yields:
+        -------
             Each record from the source.
+
         """
         # TODO: Parse response body and return a set of records.
         yield from extract_jsonpath(self.records_jsonpath, input=response.json())
@@ -222,11 +241,14 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """As needed, append or transform raw data to match expected structure.
 
         Args:
+        -----
             row: An individual record from the stream.
             context: The stream context.
 
-        Returns:
+        Returns
+        -------
             The updated record dictionary, or ``None`` to skip the record.
+
         """
         # TODO: Delete this method if not needed.
         return row

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'REST' == cookiecutter.stream_type %}client.py{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'REST' == cookiecutter.stream_type %}client.py{%endif%}
@@ -153,7 +153,6 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """Return a token for identifying next page or None if no more pages.
 
         Args:
-        -----
             response: The HTTP ``requests.Response`` object.
             previous_token: The previous page token value.
 
@@ -184,7 +183,6 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """Return a dictionary of values to be used in URL parameterization.
 
         Args:
-        -----
             context: The stream context.
             next_page_token: The next page index or value.
 
@@ -226,7 +224,6 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """Parse the response and return an iterator of result records.
 
         Args:
-        -----
             response: The HTTP ``requests.Response`` object.
 
         Yields
@@ -241,7 +238,6 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """As needed, append or transform raw data to match expected structure.
 
         Args:
-        -----
             row: An individual record from the stream.
             context: The stream context.
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'SQL' == cookiecutter.stream_type %}client.py{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'SQL' == cookiecutter.stream_type %}client.py{%endif%}
@@ -18,7 +18,6 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
         """Concatenate a SQLAlchemy URL for use in connecting to the source.
 
         Args:
-        -----
             config: A dict with connection parameters
 
         Returns
@@ -47,7 +46,6 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
         implementation inherited from the base class.
 
         Args:
-        -----
             from_type: The SQL type as a string or as a TypeEngine. If a TypeEngine is
                 provided, it may be provided as a class or a specific object instance.
 
@@ -68,7 +66,6 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
         implementation inherited from the base class.
 
         Args:
-        -----
             jsonschema_type: A dict
 
         Returns
@@ -93,7 +90,6 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
         implementation inherited from the base class.
 
         Args:
-        -----
             partition: If provided, will read specifically from this data slice.
 
         Yields

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'SQL' == cookiecutter.stream_type %}client.py{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'SQL' == cookiecutter.stream_type %}client.py{%endif%}
@@ -18,10 +18,13 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
         """Concatenate a SQLAlchemy URL for use in connecting to the source.
 
         Args:
+        -----
             config: A dict with connection parameters
 
-        Returns:
+        Returns
+        -------
             SQLAlchemy connection string
+
         """
         # TODO: Replace this with a valid connection string for your source:
         return (
@@ -44,11 +47,14 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
         implementation inherited from the base class.
 
         Args:
+        -----
             from_type: The SQL type as a string or as a TypeEngine. If a TypeEngine is
                 provided, it may be provided as a class or a specific object instance.
 
-        Returns:
+        Returns
+        -------
             A compatible JSON Schema type definition.
+
         """
         # Optionally, add custom logic before calling the parent SQLConnector method.
         # You may delete this method if overrides are not needed.
@@ -62,10 +68,13 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
         implementation inherited from the base class.
 
         Args:
+        -----
             jsonschema_type: A dict
 
-        Returns:
+        Returns
+        -------
             SQLAlchemy type
+
         """
         # Optionally, add custom logic before calling the parent SQLConnector method.
         # You may delete this method if overrides are not needed.
@@ -84,10 +93,13 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
         implementation inherited from the base class.
 
         Args:
+        -----
             partition: If provided, will read specifically from this data slice.
 
-        Yields:
+        Yields
+        ------
             One dict per record.
+
         """
         # Optionally, add custom logic instead of calling the super().
         # This is helpful if the source database provides batch-optimized record

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if cookiecutter.auth_method in ('OAuth2', 'JWT')%}auth.py{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if cookiecutter.auth_method in ('OAuth2', 'JWT')%}auth.py{%endif%}
@@ -40,7 +40,6 @@ class {{ cookiecutter.source_name }}Authenticator(OAuthAuthenticator, metaclass=
         """Instantiate an authenticator for a specific Singer stream.
 
         Args:
-        -----
             stream: The Singer stream instance.
 
         Returns
@@ -66,12 +65,12 @@ class {{ cookiecutter.source_name }}Authenticator(OAuthJWTAuthenticator):
         """Instantiate an authenticator for a specific Singer stream.
 
         Args:
-        -----
             stream: The Singer stream instance.
 
         Returns
-        ------
+        -------
             A new authenticator.
+
         """
         return cls(
             stream=stream,

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if cookiecutter.auth_method in ('OAuth2', 'JWT')%}auth.py{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if cookiecutter.auth_method in ('OAuth2', 'JWT')%}auth.py{%endif%}
@@ -20,8 +20,10 @@ class {{ cookiecutter.source_name }}Authenticator(OAuthAuthenticator, metaclass=
     def oauth_request_body(self) -> dict:
         """Define the OAuth request body for the AutomaticTestTap API.
 
-        Returns:
+        Returns
+        -------
             A dict with the request body
+
         """
         # TODO: Define the request body needed for the API.
         return {
@@ -38,10 +40,13 @@ class {{ cookiecutter.source_name }}Authenticator(OAuthAuthenticator, metaclass=
         """Instantiate an authenticator for a specific Singer stream.
 
         Args:
+        -----
             stream: The Singer stream instance.
 
-        Returns:
+        Returns
+        -------
             A new authenticator.
+
         """
         return cls(
             stream=stream,
@@ -61,9 +66,11 @@ class {{ cookiecutter.source_name }}Authenticator(OAuthJWTAuthenticator):
         """Instantiate an authenticator for a specific Singer stream.
 
         Args:
+        -----
             stream: The Singer stream instance.
 
-        Returns:
+        Returns
+        ------
             A new authenticator.
         """
         return cls(


### PR DESCRIPTION
When creating a new tap that includes the github CI action, the pydocstyle tests fails on a number of issues - I'm guessing because of updates to the pydocstyle guide.

These changes are to update formatting of docstring so that `poetry run pydocstyle <tap-name>` does not return errors on a cleanly generated template.

Alternatively, disabling rule D406 and D407 would go a long way in resolving this.

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1449.org.readthedocs.build/en/1449/

<!-- readthedocs-preview meltano-sdk end -->