### PR TITLE
fix: Cookiecutter bearer auth config

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'REST' == cookiecutter.stream_type %}client.py{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/{%if 'REST' == cookiecutter.stream_type %}client.py{%endif%}
@@ -86,7 +86,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         return APIKeyAuthenticator.create_for_stream(
             self,
             key="x-api-key",
-            value=self.config.get("api_key", ""),
+            value=self.config.get("auth_token", ""),
             location="header",
         )
 
@@ -101,7 +101,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """
         return BearerTokenAuthenticator.create_for_stream(
             self,
-            token=self.config.get("api_key", ""),
+            token=self.config.get("auth_token", ""),
         )
 
 {%- elif cookiecutter.auth_method == "Basic Auth" %}


### PR DESCRIPTION
Change config key for bearer auth for REST APIs so that it is consistent across files and works out of the box.

Closes #1452

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1454.org.readthedocs.build/en/1454/

<!-- readthedocs-preview meltano-sdk end -->