### PR TITLE
chore: Change upstream deps review action back to `actions/dependency-review-action`

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,8 +20,9 @@ jobs:
 
       - name: GitHub dependency vulnerability check
         if: ${{ github.event_name == 'pull_request_target' }}
-        # Use this fork until https://github.com/actions/dependency-review-action/pull/165 is merged
-        uses: WillDaSilva/dependency-review-action@main
+        uses: actions/dependency-review-action@v3.0.3
+        with:
+          fail-on-severity: high
 
       - name: FOSSA dependency license check
         run: |


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1468.org.readthedocs.build/en/1468/

<!-- readthedocs-preview meltano-sdk end -->