### PR TITLE
Update CI template for tap cookiecutter

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/{% if cookiecutter.include_cicd_sample_template == 'GitHub' %}ci_workflow.yml{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/{% if cookiecutter.include_cicd_sample_template == 'GitHub' %}ci_workflow.yml{%endif%}
@@ -15,15 +15,15 @@ jobs:
         python-version: [3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python {{ '${{ matrix.python-version }}' }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Install Poetry
       run: |
         python -m pip install --upgrade pip
-        pip install poetry==1.2.*
+        pip install poetry==1.3.*
     - name: Install dependencies
       run: |
         poetry install
@@ -38,18 +38,18 @@ jobs:
       GITHUB_TOKEN: {{ '${{secrets.GITHUB_TOKEN}}' }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python {{ '${{ matrix.python-version }}' }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Install Poetry
       run: |
         python -m pip install --upgrade pip
-        pip install poetry==1.2.*
+        pip install poetry==1.3.*
     - name: Install dependencies
       run: |
         poetry install


### PR DESCRIPTION
I just built a fresh tap using the cookiecutter template (which was super cool by the way!), and had to update some parts of the workflow template as below to fix github complaints (and use latest versions of python and poetry).