### PR TITLE
feat: Retry some streaming and decoding request errors

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -231,6 +231,8 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
                 RetriableAPIError,
                 requests.exceptions.ReadTimeout,
                 requests.exceptions.ConnectionError,
+                requests.exceptions.ChunkedEncodingError,
+                requests.exceptions.ContentDecodingError,
             ),
             max_tries=self.backoff_max_tries,
             on_backoff=self.backoff_handler,


### PR DESCRIPTION
Recieved a few of these errors in production with long running jobs, retries will now save the day!

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1478.org.readthedocs.build/en/1478/

<!-- readthedocs-preview meltano-sdk end -->