### PR TITLE
feat: Added `RESTStream.backoff_jitter` to support custom backoff jitter generators

### DIFF
--- a/docs/code_samples.md
+++ b/docs/code_samples.md
@@ -339,6 +339,8 @@ def backoff_wait_generator() -> Callable[..., Generator[int, Any, None]]:
 
 To utilise a response header as a wait value you can use [`backoff_runtime`](singer_sdk.RESTStream.backoff_runtime), and pass a method that returns a wait value:
 
+**Note**: By default there's jitter added which makes this function wait a bit longer than the value provided. To disable jitter override `backoff_jitter`](singer_sdk.RESTStream.backoff_jitter). In sdk versions 0.21.0 the default jitter function will make the function below not work as you would expect without disabling jitter, ([here](https://github.com/meltano/sdk/issues/1477) for more information) to disable jitter override the `request_decorator` and pass `jitter=None` to the `backoff.on_exception` function. 
+
 ```
 def backoff_wait_generator() -> Callable[..., Generator[int, Any, None]]:
     def _backoff_from_headers(retriable_api_error):

--- a/docs/code_samples.md
+++ b/docs/code_samples.md
@@ -330,6 +330,7 @@ Custom backoff and retry behaviour can be added by overriding the methods:
 - [`backoff_wait_generator`](singer_sdk.RESTStream.backoff_wait_generator)
 - [`backoff_max_tries`](singer_sdk.RESTStream.backoff_max_tries)
 - [`backoff_handler`](singer_sdk.RESTStream.backoff_handler)
+- [`backoff_jitter`](singer_sdk.RESTStream.backoff_jitter)
 
 For example, to use a constant retry:
 ```
@@ -340,7 +341,7 @@ def backoff_wait_generator() -> Callable[..., Generator[int, Any, None]]:
 To utilise a response header as a wait value you can use [`backoff_runtime`](singer_sdk.RESTStream.backoff_runtime), and pass a method that returns a wait value:
 
 **Note**: By default jitter makes this function wait a bit longer than the value provided.
-To disable jitter override `backoff_jitter`](singer_sdk.RESTStream.backoff_jitter).
+To disable jitter override [`backoff_jitter`](singer_sdk.RESTStream.backoff_jitter).
 In sdk versions <=0.21.0 the default jitter function will make the function below not work as you would expect without disabling jitter,
 ([here](https://github.com/meltano/sdk/issues/1477) for more information) to disable jitter override the `request_decorator` and pass `jitter=None` to the `backoff.on_exception` function.
 

--- a/docs/code_samples.md
+++ b/docs/code_samples.md
@@ -339,10 +339,10 @@ def backoff_wait_generator() -> Callable[..., Generator[int, Any, None]]:
 
 To utilise a response header as a wait value you can use [`backoff_runtime`](singer_sdk.RESTStream.backoff_runtime), and pass a method that returns a wait value:
 
-**Note**: By default jitter makes this function wait a bit longer than the value provided. 
-To disable jitter override `backoff_jitter`](singer_sdk.RESTStream.backoff_jitter). 
-In sdk versions <=0.21.0 the default jitter function will make the function below not work as you would expect without disabling jitter, 
-([here](https://github.com/meltano/sdk/issues/1477) for more information) to disable jitter override the `request_decorator` and pass `jitter=None` to the `backoff.on_exception` function. 
+**Note**: By default jitter makes this function wait a bit longer than the value provided.
+To disable jitter override `backoff_jitter`](singer_sdk.RESTStream.backoff_jitter).
+In sdk versions <=0.21.0 the default jitter function will make the function below not work as you would expect without disabling jitter,
+([here](https://github.com/meltano/sdk/issues/1477) for more information) to disable jitter override the `request_decorator` and pass `jitter=None` to the `backoff.on_exception` function.
 
 ```
 def backoff_wait_generator() -> Callable[..., Generator[int, Any, None]]:

--- a/docs/code_samples.md
+++ b/docs/code_samples.md
@@ -339,7 +339,10 @@ def backoff_wait_generator() -> Callable[..., Generator[int, Any, None]]:
 
 To utilise a response header as a wait value you can use [`backoff_runtime`](singer_sdk.RESTStream.backoff_runtime), and pass a method that returns a wait value:
 
-**Note**: By default there's jitter added which makes this function wait a bit longer than the value provided. To disable jitter override `backoff_jitter`](singer_sdk.RESTStream.backoff_jitter). In sdk versions 0.21.0 the default jitter function will make the function below not work as you would expect without disabling jitter, ([here](https://github.com/meltano/sdk/issues/1477) for more information) to disable jitter override the `request_decorator` and pass `jitter=None` to the `backoff.on_exception` function. 
+**Note**: By default jitter makes this function wait a bit longer than the value provided. 
+To disable jitter override `backoff_jitter`](singer_sdk.RESTStream.backoff_jitter). 
+In sdk versions <=0.21.0 the default jitter function will make the function below not work as you would expect without disabling jitter, 
+([here](https://github.com/meltano/sdk/issues/1477) for more information) to disable jitter override the `request_decorator` and pass `jitter=None` to the `backoff.on_exception` function. 
 
 ```
 def backoff_wait_generator() -> Callable[..., Generator[int, Any, None]]:

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -596,7 +596,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         """
         return 5
 
-    def backoff_jitter(self, value: float) -> float | None:
+    def backoff_jitter(self, value: float) -> float:
         """Amount of jitter to add.
 
         For more inforamtion see

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -599,19 +599,19 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
     def backoff_jitter(self, value: float) -> float:
         """Amount of jitter to add.
 
-        For more inforamtion see
+        For more information see
         https://github.com/litl/backoff/blob/master/backoff/_jitter.py
 
-        We chose to default to random_jitter instead of full_jitter as we keep
-        some level of default jitter to be "nice" to downstream apis
-        but it's still relatively close to the default value that's passed in
-        to make tap developers life easier.
+        We chose to default to ``random_jitter`` instead of ``full_jitter`` as we keep
+        some level of default jitter to be "nice" to downstream APIs but it's still
+        relatively close to the default value that's passed in to make tap developers'
+        life easier.
 
         Args:
             value: Base amount to wait in seconds
 
         Returns:
-            Time in seconds to wait between the next request
+            Time in seconds to wait until the next request.
         """
         return backoff.random_jitter(value)
 

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -639,8 +639,8 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         It is based on parsing the thrown exception of the decorated method, making it
         possible for response values to be in scope.
 
-        You may want to review `backoff_jitter`(singer_sdk.RESTStream.backoff_jitter)
-        if you're overriding this function.
+        You may want to review :meth:`~singer_sdk.RESTStream.backoff_jitter` if you're
+        overriding this function.
 
         Args:
             value: a callable which takes as input the decorated

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -596,7 +596,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         """
         return 5
     
-    def backoff_jitter(self, value: float) -> float:
+    def backoff_jitter(self, value: float) -> float | None:
         """Amount of jitter to add. 
 
         For more inforamtion see https://github.com/litl/backoff/blob/master/backoff/_jitter.py
@@ -605,6 +605,8 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         some level of default jitter to be "nice" to downstream apis
         but it's still relatively close to the default value that's passed in 
         to make tap developers life easier.
+
+        To disable override this function to return None.
 
         Args:
             value: Base amount to wait in seconds
@@ -637,6 +639,9 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
 
         It is based on parsing the thrown exception of the decorated method, making it
         possible for response values to be in scope.
+
+        You may want to review `backoff_jitter`(singer_sdk.RESTStream.backoff_jitter)
+        if you're overriding this function.
 
         Args:
             value: a callable which takes as input the decorated

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -599,7 +599,8 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
     def backoff_jitter(self, value: float) -> float | None:
         """Amount of jitter to add.
 
-        For more inforamtion see https://github.com/litl/backoff/blob/master/backoff/_jitter.py
+        For more inforamtion see
+        https://github.com/litl/backoff/blob/master/backoff/_jitter.py
 
         We chose to default to random_jitter instead of full_jitter as we keep
         some level of default jitter to be "nice" to downstream apis

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -607,8 +607,6 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         but it's still relatively close to the default value that's passed in
         to make tap developers life easier.
 
-        To disable override this function to return None.
-
         Args:
             value: Base amount to wait in seconds
 

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -234,7 +234,7 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
             ),
             max_tries=self.backoff_max_tries,
             on_backoff=self.backoff_handler,
-            jitter=self.backoff_jitter
+            jitter=self.backoff_jitter,
         )(func)
         return decorator
 
@@ -595,22 +595,22 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
             Number of max retries.
         """
         return 5
-    
+
     def backoff_jitter(self, value: float) -> float | None:
-        """Amount of jitter to add. 
+        """Amount of jitter to add.
 
         For more inforamtion see https://github.com/litl/backoff/blob/master/backoff/_jitter.py
 
         We chose to default to random_jitter instead of full_jitter as we keep
         some level of default jitter to be "nice" to downstream apis
-        but it's still relatively close to the default value that's passed in 
+        but it's still relatively close to the default value that's passed in
         to make tap developers life easier.
 
         To disable override this function to return None.
 
         Args:
             value: Base amount to wait in seconds
-        
+
         Returns:
             Time in seconds to wait between the next request
         """


### PR DESCRIPTION
Closes #1477 

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1480.org.readthedocs.build/en/1480/

<!-- readthedocs-preview meltano-sdk end -->