### PR TITLE
fix: Use pipx to run tox in CI template

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/{% if cookiecutter.include_cicd_sample_template == 'GitHub' %}ci_workflow.yml{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/{% if cookiecutter.include_cicd_sample_template == 'GitHub' %}ci_workflow.yml{%endif%}
@@ -7,52 +7,43 @@ on: [push]
 
 jobs:
   linting:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # Only lint using the primary version used for dev
-        python-version: [3.9]
-
+        python-version: ["3.9"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python {{ '${{ matrix.python-version }}' }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
-    - name: Install Poetry
+    - name: Install pipx and Poetry
       run: |
-        python -m pip install --upgrade pip
-        pip install poetry==1.2.*
-    - name: Install dependencies
-      run: |
-        poetry install
+        pip install pipx poetry
     - name: Run lint command from tox.ini
       run: |
-        poetry run tox -e lint
+        pipx run tox -e lint
 
   pytest:
-
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: {{ '${{secrets.GITHUB_TOKEN}}' }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
-
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python {{ '${{ matrix.python-version }}' }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Install Poetry
       run: |
-        python -m pip install --upgrade pip
-        pip install poetry==1.2.*
+        pip install poetry
     - name: Install dependencies
       run: |
         poetry install
     - name: Test with pytest
       run: |
-        poetry run pytest --capture=no
+        poetry run pytest

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/tox.ini
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/tox.ini
@@ -1,13 +1,11 @@
 # This file can be used to customize tox tests as well as other test frameworks like flake8 and mypy
 
 [tox]
-envlist = py38
-; envlist = py37, py38, py39
+envlist = py39
 isolated_build = true
 
 [testenv]
 allowlist_externals = poetry
-
 commands =
     poetry install -v
     poetry run pytest
@@ -19,7 +17,7 @@ commands =
 [testenv:pytest]
 # Run the python tests.
 # To execute, run `tox -e pytest`
-envlist = py37, py38, py39
+envlist = py37, py38, py39, py310, py311
 commands =
     poetry install -v
     poetry run pytest


### PR DESCRIPTION
Plus some related cleanup. Poetry still needs to be installed before running `pipx run tox ...` because tox is configured to use poetry from the external environment, rather than installing it into the tox venv.

Supersedes:
- https://github.com/meltano/sdk/pull/1476

Closes #1481

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1482.org.readthedocs.build/en/1482/

<!-- readthedocs-preview meltano-sdk end -->