### PR TITLE
chore(templates): Include singer-sdk[testing] in templates dev dependencies

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -21,8 +21,8 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "<3.12,>=3.7.1"
-singer-sdk = { version="^0.21.0"}
-fs-s3fs = { version = "^1.1.1", optional = true}
+singer-sdk = { version="^0.21.0" }
+fs-s3fs = { version = "^1.1.1", optional = true }
 {%- if cookiecutter.stream_type in ["REST", "GraphQL"] %}
 requests = "^2.28.2"
 {%- endif %}
@@ -38,6 +38,7 @@ black = "^23.1.0"
 pyupgrade = "^3.3.1"
 mypy = "^1.0.0"
 isort = "^5.11.5"
+singer-sdk = { version="^0.21.0", extras = ["testing"] }
 {%- if cookiecutter.stream_type in ["REST", "GraphQL"] %}
 types-requests = "^2.28.11.12"
 {%- endif %}

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -21,8 +21,8 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "<3.12,>=3.7.1"
-singer-sdk = { version="^0.21.0"}
-fs-s3fs = { version = "^1.1.1", optional = true}
+singer-sdk = { version="^0.21.0" }
+fs-s3fs = { version = "^1.1.1", optional = true }
 {%- if cookiecutter.serialization_method != "SQL" %}
 requests = "^2.28.2"
 {%- endif %}
@@ -35,6 +35,7 @@ black = "^23.1.0"
 pyupgrade = "^3.3.1"
 mypy = "^1.0.0"
 isort = "^5.11.5"
+singer-sdk = { version="^0.21.0", extras = ["testing"] }
 {%- if cookiecutter.serialization_method != "SQL" %}
 types-requests = "^2.28.11.12"
 {%- endif %}


### PR DESCRIPTION
Just to be more explicit, we could remove `pytest` later since it's now an extra transitive dependency.

cc @kgpayne 


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1483.org.readthedocs.build/en/1483/

<!-- readthedocs-preview meltano-sdk end -->