### PR TITLE
fix: Address SQLAlchemy 2.0 deprecation warnings

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -92,6 +92,9 @@ def tests(session: Session) -> None:
             "-v",
             "--durations=10",
             *session.posargs,
+            env={
+                "SQLALCHEMY_WARN_20": "1",
+            },
         )
     finally:
         if session.interactive:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,9 @@ exclude = ".*simpleeval.*"
 
 [tool.pytest.ini_options]
 addopts = '-vvv --ignore=singer_sdk/helpers/_simpleeval.py -m "not external"'
+filterwarnings = [
+    "error::sqlalchemy.exc.RemovedIn20Warning",
+]
 markers = [
     "external: Tests relying on external resources",
     "windows: Tests that only run on Windows",

--- a/samples/sample_tap_sqlite/__init__.py
+++ b/samples/sample_tap_sqlite/__init__.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import sqlalchemy
-
 from singer_sdk import SQLConnector, SQLStream, SQLTap
 from singer_sdk import typing as th
 
@@ -21,21 +19,6 @@ class SQLiteConnector(SQLConnector):
     def get_sqlalchemy_url(self, config: dict[str, Any]) -> str:
         """Generates a SQLAlchemy URL for SQLite."""
         return f"sqlite:///{config[DB_PATH_CONFIG]}"
-
-    def create_sqlalchemy_connection(self) -> sqlalchemy.engine.Connection:
-        """Return a new SQLAlchemy connection using the provided config.
-
-        This override simply provides a more helpful error message on failure.
-
-        Returns:
-            A newly created SQLAlchemy engine object.
-        """
-        try:
-            return super().create_sqlalchemy_connection()
-        except Exception as ex:
-            raise RuntimeError(
-                f"Error connecting to DB at '{self.config[DB_PATH_CONFIG]}': {ex}"
-            ) from ex
 
 
 class SQLiteStream(SQLStream):

--- a/samples/sample_target_sqlite/__init__.py
+++ b/samples/sample_target_sqlite/__init__.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import sqlalchemy
-
 from singer_sdk import SQLConnector, SQLSink, SQLTarget
 from singer_sdk import typing as th
 
@@ -25,21 +23,6 @@ class SQLiteConnector(SQLConnector):
     def get_sqlalchemy_url(self, config: dict[str, Any]) -> str:
         """Generates a SQLAlchemy URL for SQLite."""
         return f"sqlite:///{config[DB_PATH_CONFIG]}"
-
-    def create_sqlalchemy_connection(self) -> sqlalchemy.engine.Connection:
-        """Return a new SQLAlchemy connection using the provided config.
-
-        This override simply provides a more helpful error message on failure.
-
-        Returns:
-            A newly created SQLAlchemy engine object.
-        """
-        try:
-            return super().create_sqlalchemy_connection()
-        except Exception as ex:
-            raise RuntimeError(
-                f"Error connecting to DB at '{self.config[DB_PATH_CONFIG]}'"
-            ) from ex
 
 
 class SQLiteSink(SQLSink):

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -683,7 +683,7 @@ class SQLConnector:
         column_add_ddl = self.get_column_add_ddl(
             table_name=full_table_name, column_name=column_name, column_type=sql_type
         )
-        with self._connect() as conn:
+        with self._connect() as conn, conn.begin():
             conn.execute(column_add_ddl)
 
     def prepare_schema(self, schema_name: str) -> None:

--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -374,8 +374,10 @@ class SQLSink(BatchSink):
         if self.config.get("hard_delete", True):
             with self.connector._connect() as conn, conn.begin():
                 conn.execute(
-                    f"DELETE FROM {self.full_table_name} "
-                    f"WHERE {self.version_column_name} <= {new_version}"
+                    sqlalchemy.text(
+                        f"DELETE FROM {self.full_table_name} "
+                        f"WHERE {self.version_column_name} <= {new_version}"
+                    )
                 )
             return
 

--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -324,7 +324,8 @@ class SQLSink(BatchSink):
             else (self.conform_record(record) for record in records)
         )
         self.logger.info("Inserting with SQL: %s", insert_sql)
-        self.connector.connection.execute(insert_sql, conformed_records)
+        with self.connector._connect() as conn, conn.begin():
+            conn.execute(insert_sql, conformed_records)
         return len(conformed_records) if isinstance(conformed_records, list) else None
 
     def merge_upsert_from_table(
@@ -371,10 +372,11 @@ class SQLSink(BatchSink):
             )
 
         if self.config.get("hard_delete", True):
-            self.connection.execute(
-                f"DELETE FROM {self.full_table_name} "
-                f"WHERE {self.version_column_name} <= {new_version}"
-            )
+            with self.connector._connect() as conn, conn.begin():
+                conn.execute(
+                    f"DELETE FROM {self.full_table_name} "
+                    f"WHERE {self.version_column_name} <= {new_version}"
+                )
             return
 
         if not self.connector.column_exists(
@@ -397,7 +399,8 @@ class SQLSink(BatchSink):
             bindparam("deletedate", value=deleted_at, type_=sqlalchemy.types.DateTime),
             bindparam("version", value=new_version, type_=sqlalchemy.types.Integer),
         )
-        self.connector.connection.execute(query)
+        with self.connector._connect() as conn, conn.begin():
+            conn.execute(query)
 
 
 __all__ = ["SQLSink", "SQLConnector"]

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -197,8 +197,9 @@ class SQLStream(Stream, metaclass=abc.ABCMeta):
         if self._MAX_RECORDS_LIMIT is not None:
             query = query.limit(self._MAX_RECORDS_LIMIT)
 
-        for record in self.connector.connection.execute(query):
-            yield dict(record)
+        with self.connector._connect() as conn:
+            for record in conn.execute(query):
+                yield dict(record._mapping)
 
 
 __all__ = ["SQLStream", "SQLConnector"]

--- a/tests/core/test_connector_sql.py
+++ b/tests/core/test_connector_sql.py
@@ -170,7 +170,7 @@ class TestConnectorSQL:
         with pytest.raises(
             sqlalchemy.exc.OperationalError
         ) as _, connector._connect() as conn:
-            conn.execute("SELECT * FROM fake_table")
+            conn.execute(sqlalchemy.text("SELECT * FROM fake_table"))
 
     def test_rename_column_uses_connect_correctly(self, connector):
         attached_engine = connector._engine

--- a/tests/samples/conftest.py
+++ b/tests/samples/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from sqlalchemy import text
 
 from samples.sample_tap_sqlite import SQLiteConnector, SQLiteTap
 from singer_sdk._singerlib import Catalog
@@ -20,15 +21,14 @@ def csv_config(outdir: str) -> dict:
 @pytest.fixture
 def _sqlite_sample_db(sqlite_connector):
     """Return a path to a newly constructed sample DB."""
-    for t in range(3):
-        sqlite_connector.connection.execute(f"DROP TABLE IF EXISTS t{t}")
-        sqlite_connector.connection.execute(
-            f"CREATE TABLE t{t} (c1 int PRIMARY KEY, c2 varchar(10))"
-        )
-        for x in range(100):
-            sqlite_connector.connection.execute(
-                f"INSERT INTO t{t} VALUES ({x}, 'x={x}')"
+    with sqlite_connector._connect() as conn, conn.begin():
+        for t in range(3):
+            conn.execute(text(f"DROP TABLE IF EXISTS t{t}"))
+            conn.execute(
+                text(f"CREATE TABLE t{t} (c1 int PRIMARY KEY, c2 varchar(10))")
             )
+            for x in range(100):
+                conn.execute(text(f"INSERT INTO t{t} VALUES ({x}, 'x={x}')"))
 
 
 @pytest.fixture

--- a/tests/samples/test_target_sqlite.py
+++ b/tests/samples/test_target_sqlite.py
@@ -47,10 +47,7 @@ def sqlite_sample_target(sqlite_target_test_config):
 @pytest.fixture
 def sqlite_sample_target_soft_delete(sqlite_target_test_config):
     """Get a sample target object with hard_delete disabled."""
-    conf = sqlite_target_test_config
-    conf["hard_delete"] = False
-
-    return SQLiteTarget(conf)
+    return SQLiteTarget({**sqlite_target_test_config, "hard_delete": False})
 
 
 @pytest.fixture


### PR DESCRIPTION
This doesn't yet add support for SQLAlchemy 2.0 (https://github.com/meltano/sdk/pull/1484/), since downstream SQL taps and targets may need to either pin the SDK or set an upper limit for SQLAlchemy.

https://docs.sqlalchemy.org/en/20/changelog/migration_20.html

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1487.org.readthedocs.build/en/1487/

<!-- readthedocs-preview meltano-sdk end -->