### PR TITLE
chore: Enable `ISC` Ruff checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,7 @@ select = [
     "ANN",  # flake8-annotations
     "COM",  # flake8-commas
     "T10",  # flake8-debugger
+    "ISC",  # flake8-implicit-str-concat
     "ICN",  # flake8-import-conventions
     "PIE",  # flake8-pie
     "PT",   # flake8-pytest-style

--- a/samples/sample_tap_gitlab/gitlab_graphql_streams.py
+++ b/samples/sample_tap_gitlab/gitlab_graphql_streams.py
@@ -55,4 +55,4 @@ class GraphQLProjectsStream(GitlabGraphQLStream):
     @property
     def query(self) -> str:
         """Return dynamic GraphQL query."""
-        return f"project(fullPath: {self.config['project_id']}" " { name }"
+        return f"project(fullPath: {self.config['project_id']} {{ name }}"

--- a/singer_sdk/_singerlib/messages.py
+++ b/singer_sdk/_singerlib/messages.py
@@ -112,7 +112,7 @@ class RecordMessage(Message):
         if self.time_extracted and not self.time_extracted.tzinfo:
             raise ValueError(
                 "'time_extracted' must be either None "
-                + "or an aware datetime (with a time zone)",
+                "or an aware datetime (with a time zone)",
             )
 
         if self.time_extracted:

--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -260,7 +260,7 @@ def log_sort_error(
     partition_record_count: int,
 ) -> None:
     """Log a sort error."""
-    msg = f"Sorting error detected in '{stream_name}'." f"on record #{record_count}. "
+    msg = f"Sorting error detected in '{stream_name}' on record #{record_count}. "
     if partition_record_count != record_count:
         msg += (
             f"Record was partition record "

--- a/singer_sdk/helpers/capabilities.py
+++ b/singer_sdk/helpers/capabilities.py
@@ -23,9 +23,11 @@ STREAM_MAPS_CONFIG = PropertiesList(
     Property(
         "stream_maps",
         ObjectType(),
-        description="Config object for stream maps capability. "
-        + "For more information check out "
-        + "[Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html).",
+        description=(
+            "Config object for stream maps capability. "
+            "For more information check out "
+            "[Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html)."
+        ),
     ),
     Property(
         "stream_map_config",

--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -190,7 +190,7 @@ class SQLSink(BatchSink):
         if duplicates:
             raise ConformedNameClashException(
                 "Duplicate stream properties produced when "
-                + f"conforming property names: {duplicates}",
+                f"conforming property names: {duplicates}",
             )
 
     def conform_schema(self, schema: dict) -> dict:

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -499,8 +499,8 @@ class RESTStream(Stream, Generic[_TToken], metaclass=abc.ABCMeta):
         if hasattr(self, "get_next_page_token"):
             warn(
                 "`RESTStream.get_next_page_token` is deprecated and will not be used "
-                + "in a future version of the Meltano Singer SDK. "
-                + "Override `RESTStream.get_new_paginator` instead.",
+                "in a future version of the Meltano Singer SDK. "
+                "Override `RESTStream.get_new_paginator` instead.",
                 DeprecationWarning,
             )
             return LegacyStreamPaginator(self)  # type: ignore

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -413,8 +413,8 @@ class Tap(PluginBase, metaclass=abc.ABCMeta):
             default=CliTestOptionValue.Disabled,
             help=(
                 "Use --test to sync a single record for each stream. "
-                + "Use --test=schema to test schema output without syncing "
-                + "records."
+                "Use --test=schema to test schema output without syncing "
+                "records."
             ),
         )
         @click.option(

--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -445,8 +445,8 @@ class Property(JSONTypeHelper, Generic[W]):
         if isinstance(wrapped, type) and not isinstance(wrapped.type_dict, Mapping):
             raise ValueError(
                 f"Type dict for {wrapped} is not defined. "
-                + "Try instantiating it with a nested type such as "
-                + f"{wrapped.__name__}(StringType).",
+                "Try instantiating it with a nested type such as "
+                f"{wrapped.__name__}(StringType).",
             )
 
         return cast(dict, wrapped.type_dict)

--- a/tests/core/test_jsonschema_helpers.py
+++ b/tests/core/test_jsonschema_helpers.py
@@ -457,7 +457,7 @@ def test_wrapped_type_dict():
         ValueError,
         match=re.escape(
             "Type dict for <class 'singer_sdk.typing.ArrayType'> is not defined. "
-            + "Try instantiating it with a nested type such as ArrayType(StringType).",
+            "Try instantiating it with a nested type such as ArrayType(StringType).",
         ),
     ):
         Property("bad_array_prop", ArrayType).to_dict()
@@ -466,7 +466,7 @@ def test_wrapped_type_dict():
         ValueError,
         match=re.escape(
             "Type dict for <class 'singer_sdk.typing.ObjectType'> is not defined. "
-            + "Try instantiating it with a nested type such as ObjectType(StringType).",
+            "Try instantiating it with a nested type such as ObjectType(StringType).",
         ),
     ):
         Property("bad_object_prop", ObjectType).to_dict()


### PR DESCRIPTION
Motivation for [`flake8-implicit-str-concat`](https://pypi.org/project/flake8-implicit-str-concat/):

> This is a plugin for the Python code-checking tool Flake8 to encourage correct string literal concatenation.
>
> It looks for style problems like implicitly concatenated string literals on the same line (which can be introduced by the code-formatting tool Black), or unnecessary plus operators for explicit string literal concatenation.


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1499.org.readthedocs.build/en/1499/

<!-- readthedocs-preview meltano-sdk end -->