### PR TITLE
docs: Fix HATEOAS pagination example

### DIFF
--- a/docs/guides/pagination-classes.md
+++ b/docs/guides/pagination-classes.md
@@ -25,7 +25,7 @@ The new pagination classes are designed to be more flexible, easier to understan
 
 ### Example: HATEOAS pagination, a.k.a. "next" links
 
-Acommon pattern in REST APIs is to use a `next` field in the response to indicate the
+A common pattern in REST APIs is to use a `next` field in the response to indicate the
 URL of the next page of results. The [`BaseHATEOASPaginator`](../../classes/singer_sdk.pagination.BaseHATEOASPaginator)
 class can be used to handle this pattern.
 
@@ -59,8 +59,8 @@ class MyPaginator(BaseHATEOASPaginator):
 
 
 class MyStream(RESTStream):
-    def get_new_paginator(self) -> RESTPaginator:
-        return BaseHATEOASPaginator()
+    def get_new_paginator(self):
+        return MyPaginator()
 
     def get_url_params(self, context, next_page_token):
         params = {}
@@ -90,7 +90,7 @@ class MyPaginator(BaseOffsetPaginator):
 
 
 class MyStream(RESTStream):
-    def get_new_paginator(self) -> RESTPaginator:
+    def get_new_paginator(self):
         return BaseOffsetPaginator(start_value=0, page_size=250)
 
     def get_url_params(self, context, next_page_token):


### PR DESCRIPTION
* Get rid of confusing type annotations
* Use the right classes


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1518.org.readthedocs.build/en/1518/

<!-- readthedocs-preview meltano-sdk end -->