### PR TITLE
fix: Handle missing `type` value when checking JSON schema types

### DIFF
--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -252,7 +252,7 @@ def is_boolean_type(property_schema: dict) -> bool | None:
         return None  # Could not detect data type
     for property_type in property_schema.get("anyOf", [property_schema.get("type")]):
         if isinstance(property_type, dict):
-            property_type = property_type.get("type")
+            property_type = property_type.get("type", [])
         if "boolean" in property_type or property_type == "boolean":
             return True
     return False
@@ -264,7 +264,7 @@ def is_integer_type(property_schema: dict) -> bool | None:
         return None  # Could not detect data type
     for property_type in property_schema.get("anyOf", [property_schema.get("type")]):
         if isinstance(property_type, dict):
-            property_type = property_type.get("type")
+            property_type = property_type.get("type", [])
         if "integer" in property_type or property_type == "integer":
             return True
     return False
@@ -276,7 +276,7 @@ def is_string_type(property_schema: dict) -> bool | None:
         return None  # Could not detect data type
     for property_type in property_schema.get("anyOf", [property_schema.get("type")]):
         if isinstance(property_type, dict):
-            property_type = property_type.get("type")
+            property_type = property_type.get("type", [])
         if "string" in property_type or property_type == "string":
             return True
     return False
@@ -288,7 +288,7 @@ def is_null_type(property_schema: dict) -> bool | None:
         return None  # Could not detect data type
     for property_type in property_schema.get("anyOf", [property_schema.get("type")]):
         if isinstance(property_type, dict):
-            property_type = property_type.get("type")
+            property_type = property_type.get("type", [])
         if "null" in property_type or property_type == "null":
             return True
     return False
@@ -300,7 +300,7 @@ def is_number_type(property_schema: dict) -> bool | None:
         return None  # Could not detect data type
     for property_type in property_schema.get("anyOf", [property_schema.get("type")]):
         if isinstance(property_type, dict):
-            property_type = property_type.get("type")
+            property_type = property_type.get("type", [])
         if "number" in property_type or property_type == "number":
             return True
     return False

--- a/tests/core/test_jsonschema_helpers.py
+++ b/tests/core/test_jsonschema_helpers.py
@@ -751,6 +751,18 @@ def test_custom_type():
             [is_number_type],
             [True],
         ),
+        (
+            [
+                {
+                    "anyOf": [
+                        {"enum": ["developer", "team", "enterprise"]},
+                        {"type": "string"},
+                    ],
+                },
+            ],
+            [is_string_type],
+            [True],
+        ),
     ],
 )
 def test_type_check_variations(property_schemas, type_check_functions, results):


### PR DESCRIPTION
Uncovered in https://github.com/MeltanoLabs/tap-dbt/pull/119


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1526.org.readthedocs.build/en/1526/

<!-- readthedocs-preview meltano-sdk end -->