### PR TITLE
fix: Conform metric field `type` to Singer spec

### DIFF
--- a/docs/implementation/logging.md
+++ b/docs/implementation/logging.md
@@ -51,7 +51,7 @@ version: 1
 disable_existing_loggers: false
 formatters:
   metrics:
-    format: "{asctime} {message}"
+    format: "{asctime} {levelname} {message}"
     style: "{"
 handlers:
   metrics:

--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -8,7 +8,7 @@ import json
 import logging
 import logging.config
 import os
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING, Any, Generic, Mapping, TypeVar
@@ -79,7 +79,15 @@ class Point(Generic[_TVal]):
         Returns:
             A JSON object.
         """
-        return json.dumps(asdict(self), default=str)
+        return json.dumps(
+            {
+                "type": self.metric_type,
+                "metric": self.metric.value,
+                "value": self.value,
+                "tags": self.tags,
+            },
+            default=str,
+        )
 
 
 def log(logger: logging.Logger, point: Point) -> None:

--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -97,7 +97,7 @@ def log(logger: logging.Logger, point: Point) -> None:
         logger: An logger instance.
         point: A measurement.
     """
-    logger.info("INFO METRIC: %s", point)
+    logger.info("METRIC: %s", point)
 
 
 class Meter(metaclass=abc.ABCMeta):

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -59,7 +59,7 @@ def test_record_counter(caplog: pytest.LogCaptureFixture):
 
     for record in caplog.records:
         assert record.levelname == "INFO"
-        assert record.msg == "INFO METRIC: %s"
+        assert record.msg == "METRIC: %s"
         assert "test=1" in record.message
 
         point: metrics.Point[int] = record.args[0]
@@ -89,7 +89,7 @@ def test_sync_timer(caplog: pytest.LogCaptureFixture):
 
     record = caplog.records[0]
     assert record.levelname == "INFO"
-    assert record.msg == "INFO METRIC: %s"
+    assert record.msg == "METRIC: %s"
 
     point: metrics.Point[float] = record.args[0]
     assert point.metric_type == "timer"


### PR DESCRIPTION
According to the [Singer Spec](https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md#metric-messages), the correct field name is `type` and not `metric_type`.


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1574.org.readthedocs.build/en/1574/

<!-- readthedocs-preview meltano-sdk end -->