### PR TITLE
feat: Extend `allowed_values` option of JSONSchema for `Property(ArrayType)`

### DIFF
--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -10,6 +10,12 @@ Usage example:
 
         Property("id", IntegerType, required=True),
         Property("foo_or_bar", StringType, allowed_values=["foo", "bar"]),
+        Property(
+            "permissions",
+            ArrayType(th.StringType),
+            allowed_values=["create", "delete", "insert", "update"],
+            examples=["insert", "update"],
+        ),
         Property("ratio", NumberType, examples=[0.25, 0.75, 1.0]),
         Property("days_active", IntegerType),
         Property("updated_on", DateTimeType),
@@ -68,6 +74,7 @@ from singer_sdk.helpers._typing import (
     JSONSCHEMA_ANNOTATION_WRITEONLY,
     append_type,
     get_datelike_property_type,
+    is_array_type,
 )
 
 if TYPE_CHECKING:
@@ -477,7 +484,12 @@ class Property(JSONTypeHelper, Generic[W]):
                 },
             )
         if self.allowed_values:
-            type_dict.update({"enum": self.allowed_values})
+            type_enum = {"enum": self.allowed_values}
+
+            if is_array_type(self.type_dict):
+                type_dict["items"].update(type_enum)
+            else:
+                type_dict.update(type_enum)
         if self.examples:
             type_dict.update({"examples": self.examples})
         return {self.name: type_dict}

--- a/tests/core/test_jsonschema_helpers.py
+++ b/tests/core/test_jsonschema_helpers.py
@@ -434,6 +434,25 @@ def test_inbuilt_type(json_type: JSONTypeHelper, expected_json_schema: dict):
             },
             {is_integer_type},
         ),
+        (
+            Property(
+                "my_prop10",
+                ArrayType(StringType),
+                allowed_values=["create", "delete", "insert", "update"],
+                examples=["insert", "update"],
+            ),
+            {
+                "my_prop10": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "type": ["string"],
+                        "enum": ["create", "delete", "insert", "update"],
+                    },
+                    "examples": ["insert", "update"],
+                },
+            },
+            {is_array_type, is_string_array_type},
+        ),
     ],
 )
 def test_property_creation(


### PR DESCRIPTION
Closes https://github.com/meltano/sdk/issues/1600 (what a number! 🎉)

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1602.org.readthedocs.build/en/1602/

<!-- readthedocs-preview meltano-sdk end -->