### PR TITLE
feat: Allow `allowed_values` and `examples` in any JSON schema type constructor

### DIFF
--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -459,20 +459,20 @@ class ArrayType(JSONTypeHelper[list], Generic[W]):
         return {"type": "array", "items": self.wrapped_type.type_dict, **self.extras}
 
 
-class Property(JSONTypeHelper, Generic[W]):
+class Property(JSONTypeHelper[T], Generic[T]):
     """Generic Property. Should be nested within a `PropertiesList`."""
 
     # TODO: Make some of these arguments keyword-only. This is a breaking change.
     def __init__(
         self,
         name: str,
-        wrapped: W | type[W],
+        wrapped: JSONTypeHelper[T] | type[JSONTypeHelper[T]],
         required: bool = False,  # noqa: FBT001, FBT002
-        default: _JsonValue | None = None,
+        default: T | None = None,
         description: str | None = None,
         secret: bool | None = False,  # noqa: FBT002
-        allowed_values: list[Any] | None = None,
-        examples: list[Any] | None = None,
+        allowed_values: list[T] | None = None,
+        examples: list[T] | None = None,
     ) -> None:
         """Initialize Property object.
 
@@ -661,7 +661,7 @@ class ObjectType(JSONTypeHelper):
             merged_props.update(w.to_dict())
             if not w.optional:
                 required.append(w.name)
-        result: dict = {"type": "object", "properties": merged_props}
+        result: dict[str, Any] = {"type": "object", "properties": merged_props}
 
         if required:
             result["required"] = required

--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -10,6 +10,15 @@ Usage example:
 
         Property("id", IntegerType, required=True),
         Property("foo_or_bar", StringType, allowed_values=["foo", "bar"]),
+        Property(
+            "permissions",
+            ArrayType(
+                th.StringType(
+                    allowed_values=["create", "delete", "insert", "update"],
+                    examples=["insert", "update"],
+                ),
+            ),
+        ),
         Property("ratio", NumberType, examples=[0.25, 0.75, 1.0]),
         Property("days_active", IntegerType),
         Property("updated_on", DateTimeType),
@@ -257,7 +266,16 @@ class JSONTypeHelper(Generic[T]):
 
 
 class StringType(JSONTypeHelper[str]):
-    """String type."""
+    """String type.
+
+    Examples:
+        >>> StringType.type_dict
+        {'type': ['string']}
+        >>> StringType().type_dict
+        {'type': ['string']}
+        >>> StringType(allowed_values=["a", "b"]).type_dict
+        {'type': ['string'], 'enum': ['a', 'b']}
+    """
 
     string_format: str | None = None
     """String format.

--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -413,7 +413,14 @@ class RegexType(StringType):
 
 
 class BooleanType(JSONTypeHelper[bool]):
-    """Boolean type."""
+    """Boolean type.
+
+    Examples:
+        >>> BooleanType.type_dict
+        {'type': ['boolean']}
+        >>> BooleanType().type_dict
+        {'type': ['boolean']}
+    """
 
     @DefaultInstanceProperty
     def type_dict(self) -> dict:
@@ -426,7 +433,16 @@ class BooleanType(JSONTypeHelper[bool]):
 
 
 class IntegerType(JSONTypeHelper):
-    """Integer type."""
+    """Integer type.
+
+    Examples:
+        >>> IntegerType.type_dict
+        {'type': ['integer']}
+        >>> IntegerType().type_dict
+        {'type': ['integer']}
+        >>> IntegerType(allowed_values=[1, 2]).type_dict
+        {'type': ['integer'], 'enum': [1, 2]}
+    """
 
     @DefaultInstanceProperty
     def type_dict(self) -> dict:
@@ -439,7 +455,16 @@ class IntegerType(JSONTypeHelper):
 
 
 class NumberType(JSONTypeHelper[float]):
-    """Number type."""
+    """Number type.
+
+    Examples:
+        >>> NumberType.type_dict
+        {'type': ['number']}
+        >>> NumberType().type_dict
+        {'type': ['number']}
+        >>> NumberType(allowed_values=[1.0, 2.0]).type_dict
+        {'type': ['number'], 'enum': [1.0, 2.0]}
+    """
 
     @DefaultInstanceProperty
     def type_dict(self) -> dict:

--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -13,7 +13,7 @@ Usage example:
         Property(
             "permissions",
             ArrayType(
-                th.StringType(
+                StringType(
                     allowed_values=["create", "delete", "insert", "update"],
                     examples=["insert", "update"],
                 ),

--- a/tests/core/test_jsonschema_helpers.py
+++ b/tests/core/test_jsonschema_helpers.py
@@ -434,6 +434,50 @@ def test_inbuilt_type(json_type: JSONTypeHelper, expected_json_schema: dict):
             },
             {is_integer_type},
         ),
+        (
+            Property(
+                "my_prop10",
+                ArrayType(
+                    StringType(
+                        allowed_values=["create", "delete", "insert", "update"],
+                        examples=["insert", "update"],
+                    ),
+                ),
+            ),
+            {
+                "my_prop10": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "type": ["string"],
+                        "enum": ["create", "delete", "insert", "update"],
+                        "examples": ["insert", "update"],
+                    },
+                },
+            },
+            {is_array_type, is_string_array_type},
+        ),
+        (
+            Property(
+                "my_prop11",
+                ArrayType(
+                    StringType,
+                    allowed_values=[
+                        ["create", "delete"],
+                        ["insert", "update"],
+                    ],
+                ),
+            ),
+            {
+                "my_prop11": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "type": ["string"],
+                    },
+                    "enum": [["create", "delete"], ["insert", "update"]],
+                },
+            },
+            {is_array_type, is_string_array_type},
+        ),
     ],
 )
 def test_property_creation(


### PR DESCRIPTION
Docs updates:

- [`PropertiesList` usage example](https://meltano-sdk--1603.org.readthedocs.build/en/1603/typing.html#usage-example)
- [`StringType` with and without initialization](https://meltano-sdk--1603.org.readthedocs.build/en/1603/classes/typing/singer_sdk.typing.StringType.html)

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1603.org.readthedocs.build/en/1603/

<!-- readthedocs-preview meltano-sdk end -->