### PR TITLE
Taps should use the same connector

### DIFF
--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -595,10 +595,8 @@ class SQLTap(Tap):
         if self.input_catalog:
             return self.input_catalog.to_dict()
 
-        connector = self.default_stream_class.connector_class(dict(self.config))
-
         result: dict[str, list[dict]] = {"streams": []}
-        result["streams"].extend(connector.discover_catalog_entries())
+        result["streams"].extend(self.connector.discover_catalog_entries())
 
         self._catalog_dict = result
         return self._catalog_dict


### PR DESCRIPTION
Right now we're generating a new connector, which negates defining self.connector() in the Tap. This fixes that issue

This came up while adding the SSH Tunnel feature here https://github.com/MeltanoLabs/tap-postgres/pull/94 . We're really specific about how sqlalchemy_url is passed to the `connector` and can't rely on what is set in `config` as we have to alter it dynamically. Most folks don't change the sqlalchemy_url which is why no one noticed

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1611.org.readthedocs.build/en/1611/

<!-- readthedocs-preview meltano-sdk end -->