### PR TITLE
chore: Remove `poetry-lock` pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,6 @@ ci:
   autofix_prs: true
   autoupdate_schedule: weekly
   autoupdate_commit_msg: 'chore: pre-commit autoupdate'
-  skip: [poetry-lock]
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,5 +72,3 @@ repos:
   rev: 1.4.0
   hooks:
   - id: poetry-check
-  - id: poetry-lock
-    args: [--no-update]


### PR DESCRIPTION
Dependabot is still on Poetry 1.3 and our pre-commit check is on 1.4.0 so this is causing local pre-commit checks to fail and update the `poetry.lock` after a Dependabot PR was merged.


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1647.org.readthedocs.build/en/1647/

<!-- readthedocs-preview meltano-sdk end -->