### PR TITLE
chore: Leverage typing-only imports to avoid importing the base class

### DIFF
--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -19,7 +19,7 @@ from singer_sdk.helpers._util import utc_now
 if t.TYPE_CHECKING:
     import logging
 
-    from singer_sdk.streams import Stream as RESTStreamBase
+    from singer_sdk.streams.rest import RESTStream
 
 
 def _add_parameters(initial_url: str, extra_parameters: dict) -> str:
@@ -83,7 +83,7 @@ class SingletonMeta(type):
 class APIAuthenticatorBase:
     """Base class for offloading API auth."""
 
-    def __init__(self, stream: RESTStreamBase) -> None:
+    def __init__(self, stream: RESTStream) -> None:
         """Init authenticator.
 
         Args:
@@ -172,7 +172,7 @@ class SimpleAuthenticator(APIAuthenticatorBase):
 
     def __init__(
         self,
-        stream: RESTStreamBase,
+        stream: RESTStream,
         auth_headers: dict | None = None,
     ) -> None:
         """Create a new authenticator.
@@ -202,7 +202,7 @@ class APIKeyAuthenticator(APIAuthenticatorBase):
 
     def __init__(
         self,
-        stream: RESTStreamBase,
+        stream: RESTStream,
         key: str,
         value: str,
         location: str = "header",
@@ -237,7 +237,7 @@ class APIKeyAuthenticator(APIAuthenticatorBase):
     @classmethod
     def create_for_stream(
         cls: type[APIKeyAuthenticator],
-        stream: RESTStreamBase,
+        stream: RESTStream,
         key: str,
         value: str,
         location: str,
@@ -265,7 +265,7 @@ class BearerTokenAuthenticator(APIAuthenticatorBase):
     'Bearer '. The token will be merged with HTTP headers on the stream.
     """
 
-    def __init__(self, stream: RESTStreamBase, token: str) -> None:
+    def __init__(self, stream: RESTStream, token: str) -> None:
         """Create a new authenticator.
 
         Args:
@@ -282,7 +282,7 @@ class BearerTokenAuthenticator(APIAuthenticatorBase):
     @classmethod
     def create_for_stream(
         cls: type[BearerTokenAuthenticator],
-        stream: RESTStreamBase,
+        stream: RESTStream,
         token: str,
     ) -> BearerTokenAuthenticator:
         """Create an Authenticator object specific to the Stream class.
@@ -308,7 +308,7 @@ class BasicAuthenticator(APIAuthenticatorBase):
 
     def __init__(
         self,
-        stream: RESTStreamBase,
+        stream: RESTStream,
         username: str,
         password: str,
     ) -> None:
@@ -331,7 +331,7 @@ class BasicAuthenticator(APIAuthenticatorBase):
     @classmethod
     def create_for_stream(
         cls: type[BasicAuthenticator],
-        stream: RESTStreamBase,
+        stream: RESTStream,
         username: str,
         password: str,
     ) -> BasicAuthenticator:
@@ -354,7 +354,7 @@ class OAuthAuthenticator(APIAuthenticatorBase):
 
     def __init__(
         self,
-        stream: RESTStreamBase,
+        stream: RESTStream,
         auth_endpoint: str | None = None,
         oauth_scopes: str | None = None,
         default_expiration: int | None = None,

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -55,7 +55,7 @@ from singer_sdk.mapper import RemoveRecordTransform, SameRecordTransform, Stream
 if t.TYPE_CHECKING:
     import logging
 
-    from singer_sdk.plugin_base import PluginBase as TapBaseClass
+    from singer_sdk.tap_base import Tap
 
 # Replication methods
 REPLICATION_FULL_TABLE = "FULL_TABLE"
@@ -130,7 +130,7 @@ class Stream(metaclass=abc.ABCMeta):
 
     def __init__(
         self,
-        tap: TapBaseClass,
+        tap: Tap,
         schema: str | PathLike | dict[str, t.Any] | singer.Schema | None = None,
         name: str | None = None,
     ) -> None:

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -32,7 +32,7 @@ if t.TYPE_CHECKING:
     from backoff.types import Details
 
     from singer_sdk._singerlib import Schema
-    from singer_sdk.plugin_base import PluginBase as TapBaseClass
+    from singer_sdk.tap_base import Tap
 
     if sys.version_info >= (3, 10):
         from typing import TypeAlias  # noqa: ICN003
@@ -75,7 +75,7 @@ class RESTStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):
 
     def __init__(
         self,
-        tap: TapBaseClass,
+        tap: Tap,
         name: str | None = None,
         schema: dict[str, t.Any] | Schema | None = None,
         path: str | None = None,

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -13,7 +13,7 @@ from singer_sdk.connectors import SQLConnector
 from singer_sdk.streams.core import Stream
 
 if t.TYPE_CHECKING:
-    from singer_sdk.plugin_base import PluginBase as TapBaseClass
+    from singer_sdk.tap_base import Tap
 
 
 class SQLStream(Stream, metaclass=abc.ABCMeta):
@@ -23,7 +23,7 @@ class SQLStream(Stream, metaclass=abc.ABCMeta):
 
     def __init__(
         self,
-        tap: TapBaseClass,
+        tap: Tap,
         catalog_entry: dict,
         connector: SQLConnector | None = None,
     ) -> None:


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1664.org.readthedocs.build/en/1664/

<!-- readthedocs-preview meltano-sdk end -->