### PR TITLE
docs: Fix docs build by specifying OS in RTD config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,6 +2,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 sphinx:
   builder: html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,6 @@ sphinx:
   fail_on_warning: true
 
 python:
-  version: 3.8
   install:
     # - requirements: docs/requirements.txt
     - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+
 sphinx:
   builder: html
   configuration: docs/conf.py


### PR DESCRIPTION
See https://github.com/readthedocs/readthedocs.org/issues/10290 for details on the fix.

Affected docs builds:

* https://github.com/meltano/sdk/pull/1670
* https://github.com/meltano/sdk/pull/1669


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1673.org.readthedocs.build/en/1673/

<!-- readthedocs-preview meltano-sdk end -->