### PR TITLE
docs: Add PyCharm debugging tips to docs

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -215,7 +215,7 @@ An example launch configuration, added to your `launch.json`, might be as follow
 
 #### PyCharm Debugging
 
-See the JetBrain's [PyCharm documentation](https://www.jetbrains.com/help/pycharm/run-debug-configuration.html) for more detail 
+See the JetBrain's [PyCharm documentation](https://www.jetbrains.com/help/pycharm/run-debug-configuration.html) for more detail
 
 To launch the PyCharm debugger you can select "Edit Configuration" in the main menu to open the debugger configuration.
 Click "Add new run configuration". Set the script path to the full path to your tap.py and parameters to something like `--config .secrets/config.json`.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -179,13 +179,17 @@ For a list of sample CLI commands you can run, [click here](./cli_commands.md).
 
 We've collected some [Python tips](python_tips.md) which may be helpful for new SDK users.
 
-### VSCode Tips
+### IDE Tips
 
-Ensure the intrepreter you're using in VSCode is set to use poetry.
-You can change this by using the command pallete to go to intrepeter settings.
+Using the debugger features of your IDE can help you develop and fix bugs easier and faster.
+Also using breakpoints is a great way to become familiar with the internals of the SDK itself.
+
+#### VSCode Debugging
+
+Ensure the interpreter you're using in VSCode is set to use poetry.
+You can change this by using the command palette to go to interpreter settings.
 Doing this will also help with autocompletion.
 
-#### Debugging
 
 In order to launch your plugin via it's CLI with the built-in debugger, VSCode requires a [Launch configuration](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations).
 An example launch configuration, added to your `launch.json`, might be as follows:
@@ -209,7 +213,17 @@ An example launch configuration, added to your `launch.json`, might be as follow
 }
 ```
 
-The above `module` value relies on an equivalent to the following snippet being added to the end of your `tap.py` or `target.py` file:
+#### PyCharm Debugging
+
+See the JetBrain's [PyCharm documentation](https://www.jetbrains.com/help/pycharm/run-debug-configuration.html) for more detail 
+
+To launch the PyCharm debugger you can select "Edit Configuration" in the main menu to open the debugger configuration.
+Click "Add new run configuration". Set the script path to the full path to your tap.py and parameters to something like `--config .secrets/config.json`.
+You can pass in additional parameters like `--discover` or `--state my_state_file.json` to test the discovery or state workflows.
+
+#### Main Method
+
+The above debugging configurations rely on an equivalent to the following snippet being added to the end of your `tap.py` or `target.py` file:
 
 ```python
 if __name__ == "__main__":


### PR DESCRIPTION
Theres already a VS section in the docs for debugging but I've seen a couple people in slack get hung up when using PyCharm. I found also found this article https://medium.com/@danthelion/meltano-development-how-to-debug-singer-taps-in-pycharm-18c481a55c47.

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1685.org.readthedocs.build/en/1685/

<!-- readthedocs-preview meltano-sdk end -->