### PR TITLE
docs: Fix broken docs link for `record_metadata` page

### DIFF
--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -228,7 +228,7 @@ class Sink(metaclass=abc.ABCMeta):
         """Populate metadata _sdc columns from incoming record message.
 
         Record metadata specs documented at:
-        https://sdk.meltano.com/en/latest/implementation/record_metadata.md
+        https://sdk.meltano.com/en/latest/implementation/record_metadata.html
 
         Args:
             record: Individual record in the stream.
@@ -251,7 +251,7 @@ class Sink(metaclass=abc.ABCMeta):
         """Add _sdc metadata columns.
 
         Record metadata specs documented at:
-        https://sdk.meltano.com/en/latest/implementation/record_metadata.md
+        https://sdk.meltano.com/en/latest/implementation/record_metadata.html
         """
         properties_dict = self.schema["properties"]
         for col in {
@@ -271,7 +271,7 @@ class Sink(metaclass=abc.ABCMeta):
         """Remove _sdc metadata columns.
 
         Record metadata specs documented at:
-        https://sdk.meltano.com/en/latest/implementation/record_metadata.md
+        https://sdk.meltano.com/en/latest/implementation/record_metadata.html
         """
         properties_dict = self.schema["properties"]
         for col in {
@@ -288,7 +288,7 @@ class Sink(metaclass=abc.ABCMeta):
         """Remove metadata _sdc columns from incoming record message.
 
         Record metadata specs documented at:
-        https://sdk.meltano.com/en/latest/implementation/record_metadata.md
+        https://sdk.meltano.com/en/latest/implementation/record_metadata.html
 
         Args:
             record: Individual record in the stream.


### PR DESCRIPTION
Fixes https://github.com/meltano/sdk/issues/1702

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1703.org.readthedocs.build/en/1703/

<!-- readthedocs-preview meltano-sdk end -->