### PR TITLE
feat: Validate records against stream schema in standard tap tests

### DIFF
--- a/samples/sample_tap_gitlab/schemas/epic_issues.json
+++ b/samples/sample_tap_gitlab/schemas/epic_issues.json
@@ -101,7 +101,8 @@
       "type": "object"
     },
     "closed_at": {
-      "type": "null"
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "confidential": {
       "type": "boolean"
@@ -120,7 +121,8 @@
       "type": "integer"
     },
     "due_date": {
-      "type": "null"
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "epic_issue_id": {
       "type": "integer"
@@ -133,8 +135,7 @@
     },
     "labels": {
       "items": {
-        "properties": {},
-        "type": "object"
+        "type": "string"
       },
       "type": "array"
     },
@@ -148,7 +149,8 @@
           "type": "string"
         },
         "due_date": {
-          "type": "null"
+          "type": ["string", "null"],
+          "format": "date-time"
         },
         "id": {
           "type": "integer"
@@ -160,7 +162,8 @@
           "type": "integer"
         },
         "start_date": {
-          "type": "null"
+          "type": ["string", "null"],
+          "format": "date-time"
         },
         "state": {
           "type": "string"
@@ -179,7 +182,6 @@
         "due_date",
         "id",
         "iid",
-        "project_id",
         "start_date",
         "state",
         "title",

--- a/samples/sample_tap_gitlab/schemas/epic_issues.json
+++ b/samples/sample_tap_gitlab/schemas/epic_issues.json
@@ -235,7 +235,7 @@
       "type": "string"
     },
     "weight": {
-      "type": "null"
+      "type": ["integer", "null"]
     }
   },
   "required": [

--- a/samples/sample_tap_gitlab/schemas/epic_issues.json
+++ b/samples/sample_tap_gitlab/schemas/epic_issues.json
@@ -198,10 +198,10 @@
     "time_stats": {
       "properties": {
         "human_time_estimate": {
-          "type": "null"
+          "type": ["string", "null"]
         },
         "human_total_time_spent": {
-          "type": "null"
+          "type": ["string", "null"]
         },
         "time_estimate": {
           "type": "integer"

--- a/samples/sample_tap_gitlab/schemas/issues.json
+++ b/samples/sample_tap_gitlab/schemas/issues.json
@@ -31,7 +31,33 @@
         "assignees": {
             "type": "array",
             "items": {
-                "type": "integer"
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "avatar_url": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    },
+                    "web_url": {
+                        "type": [
+                            "null",
+                            "string"
+                        ]
+                    }
+                }
             }
         },
         "closed_by_id": {

--- a/singer_sdk/testing/suites.py
+++ b/singer_sdk/testing/suites.py
@@ -14,6 +14,7 @@ from .tap_tests import (
     AttributeNotNullTest,
     StreamCatalogSchemaMatchesRecordTest,
     StreamPrimaryKeysTest,
+    StreamRecordMatchesStreamSchema,
     StreamRecordSchemaMatchesCatalogTest,
     StreamReturnsRecordTest,
     TapCLIPrintsTest,
@@ -61,6 +62,7 @@ tap_stream_tests = TestSuite(
     kind="tap_stream",
     tests=[
         StreamCatalogSchemaMatchesRecordTest,
+        StreamRecordMatchesStreamSchema,
         StreamRecordSchemaMatchesCatalogTest,
         StreamReturnsRecordTest,
         StreamPrimaryKeysTest,

--- a/singer_sdk/testing/tap_tests.py
+++ b/singer_sdk/testing/tap_tests.py
@@ -123,7 +123,11 @@ class StreamRecordMatchesStreamSchema(StreamTestTemplate):
         for record in self.stream_records:
             errors = list(validator.iter_errors(record))
             error_messages = "\n".join(
-                [f"{e.message} (path: {'.'.join(e.path)})" for e in errors if e.path],
+                [
+                    f"{e.message} (path: {'.'.join(str(p) for p in e.path)})"
+                    for e in errors
+                    if e.path
+                ],
             )
             assert not errors, f"Record does not match stream schema: {error_messages}"
 

--- a/singer_sdk/testing/tap_tests.py
+++ b/singer_sdk/testing/tap_tests.py
@@ -6,6 +6,7 @@ import typing as t
 import warnings
 
 from dateutil import parser
+from jsonschema import Draft7Validator
 
 import singer_sdk.helpers._typing as th
 from singer_sdk import Tap
@@ -105,6 +106,26 @@ class StreamRecordSchemaMatchesCatalogTest(StreamTestTemplate):
         stream_record_keys = set().union(*(d.keys() for d in self.stream_records))
         diff = stream_record_keys - stream_catalog_keys
         assert not diff, f"Fields in records but not in catalog: ({diff})"
+
+
+class StreamRecordMatchesStreamSchema(StreamTestTemplate):
+    """Test all attributes in the record schema are present in the catalog schema."""
+
+    name = "record_matches_stream_schema"
+
+    def test(self) -> None:
+        """Run test."""
+        schema = self.stream.schema
+        validator = Draft7Validator(
+            schema,
+            format_checker=Draft7Validator.FORMAT_CHECKER,
+        )
+        for record in self.stream_records:
+            errors = list(validator.iter_errors(record))
+            error_messages = "\n".join(
+                [f"{e.message} (path: {'.'.join(e.path)})" for e in errors if e.path],
+            )
+            assert not errors, f"Record does not match stream schema: {error_messages}"
 
 
 class StreamPrimaryKeysTest(StreamTestTemplate):


### PR DESCRIPTION
Failure example:

```
FAILED tests/external/test_tap_gitlab.py::TestSampleTapGitlab::test_tap_stream_record_matches_stream_schema[epic_issues] - AssertionError: Record does not match stream schema: '2021-11-03T15:21:07.350Z' is not of type 'null' (path: closed_at)
'flow::Review' is not of type 'object' (path: labels.0)
'kind::Feature' is not of type 'object' (path: labels.1)
'valuestream::Hub' is not of type 'object' (path: labels.2)
'2021-11-05' is not of type 'null' (path: milestone.due_date)
'2021-10-30' is not of type 'null' (path: milestone.start_date)
'project_id' is a required property (path: milestone)
FAILED tests/external/test_tap_gitlab.py::TestSampleTapGitlab::test_tap_stream_record_matches_stream_schema[issues] - AssertionError: Record does not match stream schema: {'id': 1134865, 'username': 'edgarrmondragon', 'name': 'Edgar R. Mondragón', 'state': 'active', 'avatar_url': 'https://gitlab.com/uploads/-/system/user/avatar/1134865/avatar.png', 'web_url': 'https://gitlab.com/edgarrmondragon'} is not of type 'integer' (path: assignees.0)
```

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1711.org.readthedocs.build/en/1711/

<!-- readthedocs-preview meltano-sdk end -->