### PR TITLE
docs: Remove unsupported `previous_token` from HATEOAS example

### DIFF
--- a/docs/guides/pagination-classes.md
+++ b/docs/guides/pagination-classes.md
@@ -53,7 +53,7 @@ class MyStream(RESTStream):
 from singer_sdk.pagination import BaseHATEOASPaginator
 
 class MyPaginator(BaseHATEOASPaginator):
-    def get_next_url(self, response, previous_token):
+    def get_next_url(self, response):
         data = response.json()
         return data.get("next")
 


### PR DESCRIPTION
See https://github.com/MeltanoLabs/tap-klaviyo/pull/14#discussion_r1200898728


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1721.org.readthedocs.build/en/1721/

<!-- readthedocs-preview meltano-sdk end -->