### PR TITLE
ci: Fail CI if upload to Codecov fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,3 +175,5 @@ jobs:
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v3.1.4
+      with:
+        fail_ci_if_error: true


### PR DESCRIPTION
https://github.com/codecov/codecov-action#arguments


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1729.org.readthedocs.build/en/1729/

<!-- readthedocs-preview meltano-sdk end -->