### PR TITLE
feat: Test with Python 3.12 🐍

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         session: [tests]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         sqlalchemy: ["2.*"]
         include:
         - { session: tests,   python-version: "3.11", os: "ubuntu-latest", sqlalchemy: "1.*" }

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,6 +52,13 @@ test_dependencies = [
 ]
 
 
+def _clean_py312_deps(session: Session, dependencies: list[str]) -> None:
+    """Clean dependencies for Python 3.12."""
+    if session.python == "3.12":
+        dependencies.remove("duckdb")
+        dependencies.remove("duckdb-engine")
+
+
 @session(python=main_python_version)
 def mypy(session: Session) -> None:
     """Check types with mypy."""
@@ -77,6 +84,7 @@ def mypy(session: Session) -> None:
 @session(python=python_versions)
 def tests(session: Session) -> None:
     """Execute pytest tests and compute coverage."""
+    _clean_py312_deps(session, test_dependencies)
     session.install(".[s3,parquet]")
     session.install(*test_dependencies)
 
@@ -107,6 +115,7 @@ def tests(session: Session) -> None:
 @session(python=main_python_version)
 def benches(session: Session) -> None:
     """Run benchmarks."""
+    _clean_py312_deps(session, test_dependencies)
     session.install(".[s3]")
     session.install(*test_dependencies)
     sqlalchemy_version = os.environ.get("SQLALCHEMY_VERSION")
@@ -129,6 +138,7 @@ def update_snapshots(session: Session) -> None:
     """Update pytest snapshots."""
     args = session.posargs or ["-m", "snapshot"]
 
+    _clean_py312_deps(session, test_dependencies)
     session.install(".")
     session.install(*test_dependencies)
     session.run("pytest", "--snapshot-update", *args)

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,7 @@ extend-ignore = ["TD002", "TD003", "FIX002"]
 COOKIECUTTER_REPLAY_FILES = list(Path("./e2e-tests/cookiecutters").glob("*.json"))
 
 package = "singer_sdk"
-python_versions = ["3.11", "3.10", "3.9", "3.8", "3.7"]
+python_versions = ["3.12", "3.11", "3.10", "3.9", "3.8", "3.7"]
 main_python_version = "3.11"
 locations = "singer_sdk", "tests", "noxfile.py", "docs/conf.py"
 nox.options.sessions = (

--- a/poetry.lock
+++ b/poetry.lock
@@ -113,6 +113,34 @@ files = [
 ]
 
 [[package]]
+name = "backports-zoneinfo"
+version = "0.2.1"
+description = "Backport of the standard library zoneinfo module"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win32.whl", hash = "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win32.whl", hash = "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win32.whl", hash = "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6"},
+    {file = "backports.zoneinfo-0.2.1.tar.gz", hash = "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"},
+]
+
+[package.extras]
+tzdata = ["tzdata"]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.12.2"
 description = "Screen-scraping library"
@@ -1351,6 +1379,51 @@ files = [
 ]
 
 [[package]]
+name = "numpy"
+version = "1.26.2"
+description = "Fundamental package for array computing in Python"
+optional = true
+python-versions = ">=3.9"
+files = [
+    {file = "numpy-1.26.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3703fc9258a4a122d17043e57b35e5ef1c5a5837c3db8be396c82e04c1cf9b0f"},
+    {file = "numpy-1.26.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cc392fdcbd21d4be6ae1bb4475a03ce3b025cd49a9be5345d76d7585aea69440"},
+    {file = "numpy-1.26.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36340109af8da8805d8851ef1d74761b3b88e81a9bd80b290bbfed61bd2b4f75"},
+    {file = "numpy-1.26.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcc008217145b3d77abd3e4d5ef586e3bdfba8fe17940769f8aa09b99e856c00"},
+    {file = "numpy-1.26.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3ced40d4e9e18242f70dd02d739e44698df3dcb010d31f495ff00a31ef6014fe"},
+    {file = "numpy-1.26.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b272d4cecc32c9e19911891446b72e986157e6a1809b7b56518b4f3755267523"},
+    {file = "numpy-1.26.2-cp310-cp310-win32.whl", hash = "sha256:22f8fc02fdbc829e7a8c578dd8d2e15a9074b630d4da29cda483337e300e3ee9"},
+    {file = "numpy-1.26.2-cp310-cp310-win_amd64.whl", hash = "sha256:26c9d33f8e8b846d5a65dd068c14e04018d05533b348d9eaeef6c1bd787f9919"},
+    {file = "numpy-1.26.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b96e7b9c624ef3ae2ae0e04fa9b460f6b9f17ad8b4bec6d7756510f1f6c0c841"},
+    {file = "numpy-1.26.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aa18428111fb9a591d7a9cc1b48150097ba6a7e8299fb56bdf574df650e7d1f1"},
+    {file = "numpy-1.26.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06fa1ed84aa60ea6ef9f91ba57b5ed963c3729534e6e54055fc151fad0423f0a"},
+    {file = "numpy-1.26.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96ca5482c3dbdd051bcd1fce8034603d6ebfc125a7bd59f55b40d8f5d246832b"},
+    {file = "numpy-1.26.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:854ab91a2906ef29dc3925a064fcd365c7b4da743f84b123002f6139bcb3f8a7"},
+    {file = "numpy-1.26.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f43740ab089277d403aa07567be138fc2a89d4d9892d113b76153e0e412409f8"},
+    {file = "numpy-1.26.2-cp311-cp311-win32.whl", hash = "sha256:a2bbc29fcb1771cd7b7425f98b05307776a6baf43035d3b80c4b0f29e9545186"},
+    {file = "numpy-1.26.2-cp311-cp311-win_amd64.whl", hash = "sha256:2b3fca8a5b00184828d12b073af4d0fc5fdd94b1632c2477526f6bd7842d700d"},
+    {file = "numpy-1.26.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:a4cd6ed4a339c21f1d1b0fdf13426cb3b284555c27ac2f156dfdaaa7e16bfab0"},
+    {file = "numpy-1.26.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5d5244aabd6ed7f312268b9247be47343a654ebea52a60f002dc70c769048e75"},
+    {file = "numpy-1.26.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a3cdb4d9c70e6b8c0814239ead47da00934666f668426fc6e94cce869e13fd7"},
+    {file = "numpy-1.26.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa317b2325f7aa0a9471663e6093c210cb2ae9c0ad824732b307d2c51983d5b6"},
+    {file = "numpy-1.26.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:174a8880739c16c925799c018f3f55b8130c1f7c8e75ab0a6fa9d41cab092fd6"},
+    {file = "numpy-1.26.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:f79b231bf5c16b1f39c7f4875e1ded36abee1591e98742b05d8a0fb55d8a3eec"},
+    {file = "numpy-1.26.2-cp312-cp312-win32.whl", hash = "sha256:4a06263321dfd3598cacb252f51e521a8cb4b6df471bb12a7ee5cbab20ea9167"},
+    {file = "numpy-1.26.2-cp312-cp312-win_amd64.whl", hash = "sha256:b04f5dc6b3efdaab541f7857351aac359e6ae3c126e2edb376929bd3b7f92d7e"},
+    {file = "numpy-1.26.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4eb8df4bf8d3d90d091e0146f6c28492b0be84da3e409ebef54349f71ed271ef"},
+    {file = "numpy-1.26.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1a13860fdcd95de7cf58bd6f8bc5a5ef81c0b0625eb2c9a783948847abbef2c2"},
+    {file = "numpy-1.26.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64308ebc366a8ed63fd0bf426b6a9468060962f1a4339ab1074c228fa6ade8e3"},
+    {file = "numpy-1.26.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baf8aab04a2c0e859da118f0b38617e5ee65d75b83795055fb66c0d5e9e9b818"},
+    {file = "numpy-1.26.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d73a3abcac238250091b11caef9ad12413dab01669511779bc9b29261dd50210"},
+    {file = "numpy-1.26.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b361d369fc7e5e1714cf827b731ca32bff8d411212fccd29ad98ad622449cc36"},
+    {file = "numpy-1.26.2-cp39-cp39-win32.whl", hash = "sha256:bd3f0091e845164a20bd5a326860c840fe2af79fa12e0469a12768a3ec578d80"},
+    {file = "numpy-1.26.2-cp39-cp39-win_amd64.whl", hash = "sha256:2beef57fb031dcc0dc8fa4fe297a742027b954949cabb52a2a376c144e5e6060"},
+    {file = "numpy-1.26.2-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:1cc3d5029a30fb5f06704ad6b23b35e11309491c999838c31f124fee32107c79"},
+    {file = "numpy-1.26.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94cc3c222bb9fb5a12e334d0479b97bb2df446fbe622b470928f5284ffca3f8d"},
+    {file = "numpy-1.26.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:fe6b44fb8fcdf7eda4ef4461b97b3f63c466b27ab151bec2366db8b197387841"},
+    {file = "numpy-1.26.2.tar.gz", hash = "sha256:f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea"},
+]
+
+[[package]]
 name = "packaging"
 version = "23.2"
 description = "Core utilities for Python packages"
@@ -1394,6 +1467,105 @@ files = [
 [package.dependencies]
 python-dateutil = ">=2.6,<3.0"
 pytzdata = ">=2020.1"
+
+[[package]]
+name = "pendulum"
+version = "3.0.0b1"
+description = "Python datetimes made easy"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pendulum-3.0.0b1-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:a0f6c73bb7e551da0dabc133faedeea48b4f47302d1432d467fb42859ecbf7c1"},
+    {file = "pendulum-3.0.0b1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3ce5cf4be2525077cc25361ae4c05e2835f960476ad8df3152a30bc654531b8e"},
+    {file = "pendulum-3.0.0b1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83b0c99a83ff19165707956d45d8198895d35d6acf3cc6072a7342c7b7423f9a"},
+    {file = "pendulum-3.0.0b1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:81c1eecbaedaee5712e643098253f8fef74d4e56800a85f0609bec3da6ed6f85"},
+    {file = "pendulum-3.0.0b1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a57ca5b9b66674b382f6b429462d4ed2a998e7a1a39d099e23bd056576c44ddd"},
+    {file = "pendulum-3.0.0b1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ff2cda697eeec55a2de4bbcb94bc941b2fb28cb6fa2b7d2d4098505892e555d"},
+    {file = "pendulum-3.0.0b1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:47f75b13e69780a26c3f9227695e80fc49f0498b2635483ae9b17843319f018e"},
+    {file = "pendulum-3.0.0b1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d107bf9985a2620cc25c4d4e89638c14b78e571a0a6c02b5982cf31146744c73"},
+    {file = "pendulum-3.0.0b1-cp310-none-win_amd64.whl", hash = "sha256:ba8d8ef32b056dc7e31c5b5ac99186786360fc10993e3dfa0f2d78d23bc74ccd"},
+    {file = "pendulum-3.0.0b1-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:75753c75d5fd8b69b2207afe5d831527a26ff647207a0bc9d9c575f02439a284"},
+    {file = "pendulum-3.0.0b1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ccc6f77da9236ef67021f356696bbdd1790dc8941bfb106a7b937dfca3a4b6e"},
+    {file = "pendulum-3.0.0b1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a83877d59f663e81ef7fca483f9f8ba44c8ed843201cced92ed1298cf2ee162f"},
+    {file = "pendulum-3.0.0b1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b14035b98b75d6d138045565312fef7fd55583e91bc28c27c4a98e3a4cf064e"},
+    {file = "pendulum-3.0.0b1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c58a446d0e1dad9b2c1813847b197d1f9ec1dfdea1cd7d57385591bb414b2a6"},
+    {file = "pendulum-3.0.0b1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca71f8663ddae56685e7f1c1dca5d9c008d4726b37955d97b2b52015ecc1ff6c"},
+    {file = "pendulum-3.0.0b1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:917426a340bde92b03743ca2555c17892d1640de6fdb401c19ce4607ded48ec2"},
+    {file = "pendulum-3.0.0b1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4a06c923ce1118c3e5c64d3a34ff30220eca14583cb51edcba32fdae5c0caf70"},
+    {file = "pendulum-3.0.0b1-cp311-none-win_amd64.whl", hash = "sha256:39154e7f75ee9ff12adb909374189b7ffd521b682223ec8baaf3b04f010fc671"},
+    {file = "pendulum-3.0.0b1-cp311-none-win_arm64.whl", hash = "sha256:13656868bf4190b542bf25505629b4aef24c5d737b9796b5294f94de4d405b5f"},
+    {file = "pendulum-3.0.0b1-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:2b85650e1d6171fdaa4cc29280caa7c1c8385f6db4f0b479ce74acaabe48ba97"},
+    {file = "pendulum-3.0.0b1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5bbbec2198cdbe221d5f4a702f55a28d04a7b081ee3f1c2ef83ebec989628d5"},
+    {file = "pendulum-3.0.0b1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a4cdb9a0d842e1b6bd4f414d0097ae50859b5c8c04828c58f47a1a67474e6708"},
+    {file = "pendulum-3.0.0b1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2f9bcf5166e025e7dfaec27263a13fd4f7deff5449bc93fcceccda3ca4a46e0"},
+    {file = "pendulum-3.0.0b1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7fc77f62b19d04bdd904a841b3e8d1ca1d726572c1d7302fee42ae9cebcbe72"},
+    {file = "pendulum-3.0.0b1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c7f6453db9bccc77506fdb8ed3ca61ef7f53efced70557102114f0c811bcd38"},
+    {file = "pendulum-3.0.0b1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:1d12a537ff1acec48243325b15fb617795ff981efa142a9a584f5a82fc6c237b"},
+    {file = "pendulum-3.0.0b1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0fc8b3643cd04b64e5d931df94fbc1e6ee4117255f93bc2df43e177f42c6ec50"},
+    {file = "pendulum-3.0.0b1-cp312-none-win_amd64.whl", hash = "sha256:597f12938ca48bc11f8dec3e3c742fe2ba2eec9950e1c8db2d2e739a7c62428a"},
+    {file = "pendulum-3.0.0b1-cp312-none-win_arm64.whl", hash = "sha256:bd5335f023832f49309fc9c40021a9a67ce37164c8ba394203fee3e21b081b64"},
+    {file = "pendulum-3.0.0b1-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:6b80fa0186b964cafba0c7709b083f5f8f79934c758e23b065d975e9289cf813"},
+    {file = "pendulum-3.0.0b1-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:30dce113b94cc05353651573a4336fe04e97260befcfd1d618ce632aa3fc7d2f"},
+    {file = "pendulum-3.0.0b1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db8b46f257a436752f78024dd8677e8e4cc15c759fb4a7ceaa258bf9741bf5dc"},
+    {file = "pendulum-3.0.0b1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ba758a373ab3e3ef377d3c1ea4d6d54f27459f0b722e9abad55178b1be6b9d04"},
+    {file = "pendulum-3.0.0b1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:681eb3ac31638170e1cb3ad83a916a8de1677638db8378a103f972980655742b"},
+    {file = "pendulum-3.0.0b1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1d43b37204f47cce0a84d5b4131facdc57bad2e8fef8069249098458f60997b"},
+    {file = "pendulum-3.0.0b1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7ca2e5efc5d27a45e600a48e2ae750341235323da038c11e07ea3c722977d97f"},
+    {file = "pendulum-3.0.0b1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:03080a6b7f1b500b4b966d0f107f19e12386fbd8df477ed2aca9f2c1ea0f0a71"},
+    {file = "pendulum-3.0.0b1-cp37-none-win_amd64.whl", hash = "sha256:0fdb0b98ab23dd9f134e80d18562bc17bf31c4e38b604d822fd87d685df4a984"},
+    {file = "pendulum-3.0.0b1-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:e3793a3511657e1b7be6c1d157915a52de5a6aea789f7452a393138cf1532311"},
+    {file = "pendulum-3.0.0b1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c67e7459e4875dda15e6dc59e990872fc5c25c5aac9e0bdeae213e902ebbce46"},
+    {file = "pendulum-3.0.0b1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32f2568b295f1f4571354edc4b106ed63a5e4d0916b977fff863f7b1c937968b"},
+    {file = "pendulum-3.0.0b1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0dbcbad29f338dd90ffe9a3235c283a2a01f8e565c02ace69b84a3ed049cb9bc"},
+    {file = "pendulum-3.0.0b1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f8a0ead27e7bf8544f1aea9676f60425416a50f44a908afe1008a40a4c45b499"},
+    {file = "pendulum-3.0.0b1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:695b183356bd74f2bd6b665743f1fa6cb21285e15c1154a9d60188ebd356abd5"},
+    {file = "pendulum-3.0.0b1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:92fc9245fea1bb1ddc4cb3b55577a8f1e8c143f9237343bd55b156d3e9b23078"},
+    {file = "pendulum-3.0.0b1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2364a38b60968c67ea96164b166a9b00e6e6cd05e379f9b38dae51a0d027e6b3"},
+    {file = "pendulum-3.0.0b1-cp38-none-win_amd64.whl", hash = "sha256:d562c48affb35fae42ad71c4c5dc445e4a39d4a32ad475b78d66cbd6f217d49f"},
+    {file = "pendulum-3.0.0b1-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:d6e583ab1bfeb77943a485d60cdf0172d0d6be0b175265f7826ec105937981ba"},
+    {file = "pendulum-3.0.0b1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:dbd44cd66bf8d81fe2482d9ae8b4ebb7ddf3c34dd0a7e96a6ad57da8ec424602"},
+    {file = "pendulum-3.0.0b1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ece9f0bf5d2c2ed3c8ca9d0cfe759c2b80c2c0f599e92a8d2cd747d7e358f46"},
+    {file = "pendulum-3.0.0b1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a6b5721fd4f1718326461b2b04a24c0aaec11dfb650dd90ad1185c270c066397"},
+    {file = "pendulum-3.0.0b1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4b0f6d812a87225c0af2d342dbe428bcfd2eec2dce76a21042881f5ee130b02a"},
+    {file = "pendulum-3.0.0b1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e8c406b7c3dedd7db0eaa8f83cc2b78e594aaa424f3e064e38e037bb65a3191"},
+    {file = "pendulum-3.0.0b1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:618e65a703b99c1792a7090ae56c8c7c0220ae58aa363ed2eff95c8562acd02f"},
+    {file = "pendulum-3.0.0b1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:76f158cf8fbd81803303a635e1b617bdac76bb81f78fb4db9a651167043108e2"},
+    {file = "pendulum-3.0.0b1-cp39-none-win_amd64.whl", hash = "sha256:a772c98f724d923bfccbd2a89e2217c2949ab582e4ae784671cb4bdc9be98b5c"},
+    {file = "pendulum-3.0.0b1-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:89b4435add740a33d1b14720a6b4b471edbd7ea7ed42f44e288cabd59e00580b"},
+    {file = "pendulum-3.0.0b1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:7d3cbba1716823d0d450f10bdf455d58d20c1c89f365bcbde7005bd97edd36b9"},
+    {file = "pendulum-3.0.0b1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea8a4bd76fc6e76b30c02cfed3e970574a9247b6dad8f02c88269e9ebbd0993c"},
+    {file = "pendulum-3.0.0b1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82f02593bda744900620eaede23b8f8f6d1de855cb938bc48e077d849755b4cb"},
+    {file = "pendulum-3.0.0b1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f5a1ddf5f34431e550daceafb202cd1cfaa31a3d3e1d53f2c76a1d13c9d2f291"},
+    {file = "pendulum-3.0.0b1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:a5a8d00106888af084223470c2139327766107728fcd7a46b19252f1d878bcd0"},
+    {file = "pendulum-3.0.0b1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cdac9cbf6e2e57766bd064f963ef90c33046251a0646c0a796f8b03408bd9433"},
+    {file = "pendulum-3.0.0b1-pp37-pypy37_pp73-macosx_10_7_x86_64.whl", hash = "sha256:5d23a1aa69a18d168829c2d587dc450163ec8beef644058a9a6275794a1a51ba"},
+    {file = "pendulum-3.0.0b1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:658160760a197b6e72e0012195962f3dd49efb846d8d4887d016fc7c85add5eb"},
+    {file = "pendulum-3.0.0b1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b1cc6de778a99dbea179a86e655aa24d2d6964da5db52b2e147945a108cdb63"},
+    {file = "pendulum-3.0.0b1-pp37-pypy37_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:db993666e3ff78e12d640b724d161fde4b96650d1261071412157e34b1aaf60b"},
+    {file = "pendulum-3.0.0b1-pp37-pypy37_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b5a0646b8f9e6d5b041c94ff0d155c9a762c7f459f9cf69804056ac0593855bd"},
+    {file = "pendulum-3.0.0b1-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:6164b7983fc04a877e4f64ee8b1a063a0e0b34056134789eb53fd3ebf1b1cedb"},
+    {file = "pendulum-3.0.0b1-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:9c455f9ea9130a10cf28a082f6052064062314d87fd02b334b49cab23e033065"},
+    {file = "pendulum-3.0.0b1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9ecda6e0e4f7dbdfa36ed4e92e70e921f748d4337e23ab8a9fb74b8680138d5"},
+    {file = "pendulum-3.0.0b1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b624d0aed4a5b40c5f52bded4bc516c3975c3ff8f1998bf51715e37c6dfc30c"},
+    {file = "pendulum-3.0.0b1-pp38-pypy38_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:791a3ded0929f72e8d89e567dd1f4cebb448e5f255a5c8b33f8d0485c4e40641"},
+    {file = "pendulum-3.0.0b1-pp38-pypy38_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:543a063682d7100569242e43b05c338f91008652ae36fa6ca13b17f7fb5600ea"},
+    {file = "pendulum-3.0.0b1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:57e14edb415d278c794d4f549c1db9e7041cc988de1bda7ca80ea43bcacbb540"},
+    {file = "pendulum-3.0.0b1-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:4b9a841296685be7488a34b6b51df5c8f927963f9370a01f76f75ebe16bf9256"},
+    {file = "pendulum-3.0.0b1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:256fb81c43183f4f3a40bcd9fd2f0914e77eb37334376117183037cf9656800f"},
+    {file = "pendulum-3.0.0b1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:587c09b86e4b179b2a638ada746fba49b1c8afd9cd2a7f1d7e8939f11b2152c0"},
+    {file = "pendulum-3.0.0b1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10edd6a29dc00768c5f15f79a1ef15d7d6b8897383175ed42e9ac60db924efa0"},
+    {file = "pendulum-3.0.0b1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:9574d81702be1f6c713cbc2b5c5ce4069c6a12d7f0f9dc46847bb4e3f09b3b08"},
+    {file = "pendulum-3.0.0b1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:8c3c3f423c4f32964ef3b8664041e13f78e80a49e554258f15b5e3b0622ccc53"},
+    {file = "pendulum-3.0.0b1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:d07dbb86984da99d12fdfffc167209bc470f48a10c3844ed5871d6987e2fecd8"},
+    {file = "pendulum-3.0.0b1.tar.gz", hash = "sha256:5331e3106e9a5690136daf386ac78a7c7e47bd4b777b8dc8925b608633788718"},
+]
+
+[package.dependencies]
+"backports.zoneinfo" = {version = ">=0.2.1,<0.3.0", markers = "python_version < \"3.9\""}
+importlib-resources = {version = ">=5.9.0,<6.0.0", markers = "python_version < \"3.9\""}
+python-dateutil = ">=2.6,<3.0"
+time-machine = {version = ">=2.6.0,<3.0.0", markers = "implementation_name != \"pypy\""}
+tzdata = ">=2020.1"
 
 [[package]]
 name = "pkgutil-resolve-name"
@@ -2799,6 +2971,17 @@ files = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2023.3"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+files = [
+    {file = "tzdata-2023.3-py2.py3-none-any.whl", hash = "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"},
+    {file = "tzdata-2023.3.tar.gz", hash = "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a"},
+]
+
+[[package]]
 name = "urllib3"
 version = "1.26.18"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -2854,11 +3037,11 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [extras]
 docs = ["furo", "myst-parser", "sphinx", "sphinx-autobuild", "sphinx-copybutton", "sphinx-inline-tabs", "sphinx-notfound-page", "sphinx-reredirects"]
-parquet = ["numpy", "numpy", "pyarrow", "pyarrow"]
+parquet = ["numpy", "numpy", "numpy", "pyarrow", "pyarrow"]
 s3 = ["fs-s3fs"]
 testing = ["pytest", "pytest-durations"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.1"
-content-hash = "1d7a9452561b176ec6f539af3f3120856deb3c228613fc6d24d813dea719ca7d"
+content-hash = "da1b1a71c8ebbd16ab59a1541c36a42828f345ebcd94aa4d666adcdd73194b12"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3044,4 +3044,4 @@ testing = ["pytest", "pytest-durations"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.1"
-content-hash = "da1b1a71c8ebbd16ab59a1541c36a42828f345ebcd94aa4d666adcdd73194b12"
+content-hash = "da331fe462131cb8d6eed319a54142818657bc4ea80f0e61ff6a1dcbcb09a47e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Typing :: Typed",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,8 +125,11 @@ coverage = [
     {extras = ["toml"], version = ">=7.2,<7.3", python = "<3.8"},
     {extras = ["toml"], version = ">=7.2", python = ">=3.8"},
 ]
-duckdb = ">=0.8.0"
-duckdb-engine = ">=0.9.4"
+
+# TODO: Remove the Python 3.12 marker when DuckDB supports it
+duckdb = { version = ">=0.8.0", python = "<3.12" }
+duckdb-engine = { version = ">=0.9.4", python = "<3.12" }
+
 mypy = [
     { version = ">=1.0,<1.5", python = "<3.8" },
     { version = ">=1.0", python = ">=3.8" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,10 @@ jsonschema = [
 ]
 memoization = { version = ">=0.3.2,<0.5.0", python = "<4" }
 packaging = ">=23.1"
-pendulum = ">=2.1.0"
+pendulum = [
+    {version = ">=2.1.0,<3", python = "<3.8"},
+    {version = ">=2.1.0,<4", python = ">=3.8", allow-prereleases = true},
+]
 PyJWT = "~=2.4"
 python-dateutil = ">=2.8.2"
 python-dotenv = ">=0.20"
@@ -87,7 +90,8 @@ fs-s3fs = {version = ">=1.1.1", optional = true}
 # Parquet file dependencies installed as optional 'parquet' extras
 numpy = [
     { version = "<1.22", python = "<3.8", optional = true },
-    { version = ">=1.22", python = ">=3.8", optional = true },
+    { version = ">=1.22,<1.25", python = ">=3.8,<3.9", optional = true },
+    { version = ">=1.22", python = ">=3.9", optional = true },
 ]
 pyarrow = [
     { version = ">=11,<13", python = "<3.8", optional = true },

--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -485,7 +485,7 @@ class OAuthAuthenticator(APIAuthenticatorBase):
             return False
         if not self.expires_in:
             return True
-        return self.expires_in > (utc_now() - self.last_refreshed).total_seconds()  # type: ignore[no-any-return]
+        return self.expires_in > (utc_now() - self.last_refreshed).total_seconds()
 
     # Authentication and refresh
     def update_access_token(self) -> None:

--- a/tests/core/rest/test_pagination.py
+++ b/tests/core/rest/test_pagination.py
@@ -27,7 +27,7 @@ def test_paginator_base_missing_implementation():
 
     with pytest.raises(
         TypeError,
-        match="Can't instantiate abstract class .* get_next",
+        match="Can't instantiate abstract class .* '?get_next'?",
     ):
         BaseAPIPaginator(0)
 
@@ -52,7 +52,7 @@ def test_paginator_page_number_missing_implementation():
 
     with pytest.raises(
         TypeError,
-        match="Can't instantiate abstract class .* has_more",
+        match="Can't instantiate abstract class .* '?has_more'?",
     ):
         BasePageNumberPaginator(1)
 
@@ -62,7 +62,7 @@ def test_paginator_offset_missing_implementation():
 
     with pytest.raises(
         TypeError,
-        match="Can't instantiate abstract class .* has_more",
+        match="Can't instantiate abstract class .* '?has_more'?",
     ):
         BaseOffsetPaginator(0, 100)
 
@@ -72,7 +72,7 @@ def test_paginator_hateoas_missing_implementation():
 
     with pytest.raises(
         TypeError,
-        match="Can't instantiate abstract class .* get_next_url",
+        match="Can't instantiate abstract class .* '?get_next_url'?",
     ):
         BaseHATEOASPaginator()
 

--- a/tests/core/test_connector_sql.py
+++ b/tests/core/test_connector_sql.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import typing as t
 from decimal import Decimal
 from unittest import mock
@@ -7,6 +8,7 @@ from unittest import mock
 import pytest
 import sqlalchemy
 from sqlalchemy.dialects import registry, sqlite
+from sqlalchemy.exc import NoSuchModuleError
 
 from singer_sdk.connectors import SQLConnector
 from singer_sdk.exceptions import ConfigValidationError
@@ -308,6 +310,11 @@ class DuckDBConnector(SQLConnector):
         )
 
 
+@pytest.mark.xfail(
+    reason="DuckDB does not build on Python 3.12 yet",
+    condition=sys.version_info >= (3, 12),
+    raises=NoSuchModuleError,
+)
 class TestDuckDBConnector:
     @pytest.fixture
     def connector(self):


### PR DESCRIPTION
Blockers:

* [ ] #1858 [Pendulum](https://pypi.org/project/pendulum/) doesn't have wheels for 3.10+

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1733.org.readthedocs.build/en/1733/

<!-- readthedocs-preview meltano-sdk end -->