### PR TITLE
refactor(taps): Change `SQLStream.schema` into a cached property

### DIFF
--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -12,6 +12,7 @@ from singer_sdk._singerlib import CatalogEntry, MetadataMapping
 from singer_sdk.connectors import SQLConnector
 from singer_sdk.streams.core import Stream
 
+
 class SQLStream(Stream, metaclass=abc.ABCMeta):
     """Base class for SQLAlchemy-based streams."""
 
@@ -71,7 +72,7 @@ class SQLStream(Stream, metaclass=abc.ABCMeta):
         """
         return self._singer_catalog_entry.metadata
 
-    @property # TODO: Investigate @cached_property after py > 3.7
+    @property  # TODO: Investigate @cached_property after py > 3.7
     def schema(self) -> dict:
         """Return metadata object (dict) as specified in the Singer spec.
 
@@ -81,8 +82,10 @@ class SQLStream(Stream, metaclass=abc.ABCMeta):
             The schema object.
         """
         if not self._cached_schema:
-          self._cached_schema = t.cast(dict, self._singer_catalog_entry.schema.to_dict()) 
-        
+            self._cached_schema = t.cast(
+                dict, self._singer_catalog_entry.schema.to_dict()
+            )
+
         return self._cached_schema
 
     @property

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -78,7 +78,7 @@ class SQLStream(Stream, metaclass=abc.ABCMeta):
         return self._singer_catalog_entry.metadata
 
     @property
-    @lru_cache  # TODO: Combine decorators into @cached_property after py > 3.7
+    @lru_cache()  # TODO: Combine decorators into @cached_property after py > 3.7
     def schema(self) -> dict:
         """Return metadata object (dict) as specified in the Singer spec.
 

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -6,10 +6,8 @@ import abc
 import sys
 import typing as t
 
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from cached_property import cached_property
+# TODO: Replace with cached_property when moving to py > 3.7
+from functools import lru_cache
 
 import sqlalchemy
 
@@ -80,7 +78,8 @@ class SQLStream(Stream, metaclass=abc.ABCMeta):
         """
         return self._singer_catalog_entry.metadata
 
-    @cached_property
+    @property
+    @lru_cache # TODO: Combine decorators into @cached_property after py > 3.7
     def schema(self) -> dict:
         """Return metadata object (dict) as specified in the Singer spec.
 

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -12,8 +12,9 @@ from singer_sdk._singerlib import CatalogEntry, MetadataMapping
 from singer_sdk.connectors import SQLConnector
 from singer_sdk.streams.core import Stream
 
-if t.TYPE_CHECKING:	
+if t.TYPE_CHECKING:
     from singer_sdk.tap_base import Tap
+
 
 class SQLStream(Stream, metaclass=abc.ABCMeta):
     """Base class for SQLAlchemy-based streams."""
@@ -85,7 +86,8 @@ class SQLStream(Stream, metaclass=abc.ABCMeta):
         """
         if not self._cached_schema:
             self._cached_schema = t.cast(
-                dict, self._singer_catalog_entry.schema.to_dict()
+                dict,
+                self._singer_catalog_entry.schema.to_dict(),
             )
 
         return self._cached_schema

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import abc
-import sys
 import typing as t
 
 # TODO: Replace with cached_property when moving to py > 3.7
@@ -79,7 +78,7 @@ class SQLStream(Stream, metaclass=abc.ABCMeta):
         return self._singer_catalog_entry.metadata
 
     @property
-    @lru_cache # TODO: Combine decorators into @cached_property after py > 3.7
+    @lru_cache  # TODO: Combine decorators into @cached_property after py > 3.7
     def schema(self) -> dict:
         """Return metadata object (dict) as specified in the Singer spec.
 

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -14,8 +14,12 @@ from singer_sdk.streams.core import Stream
 
 if t.TYPE_CHECKING:
     from singer_sdk.tap_base import Tap
-    F = t.TypeVar('F', Callable)
-    def lru_cache(f: F) -> F: pass
+
+    F = t.TypeVar("F", Callable)
+
+    def lru_cache(f: F) -> F:
+        pass
+
 else:
     # TODO: Replace with cached_property when moving to py > 3.7
     from functools import lru_cache

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+import sys
 import typing as t
 
 if sys.version_info >= (3, 8):

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import abc
 import typing as t
 
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from cached_property import cached_property
+
 import sqlalchemy
 
 import singer_sdk.helpers._catalog as catalog
@@ -74,7 +79,7 @@ class SQLStream(Stream, metaclass=abc.ABCMeta):
         """
         return self._singer_catalog_entry.metadata
 
-    @property
+    @cached_property
     def schema(self) -> dict:
         """Return metadata object (dict) as specified in the Singer spec.
 

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -12,6 +12,8 @@ from singer_sdk._singerlib import CatalogEntry, MetadataMapping
 from singer_sdk.connectors import SQLConnector
 from singer_sdk.streams.core import Stream
 
+if t.TYPE_CHECKING:	
+    from singer_sdk.tap_base import Tap
 
 class SQLStream(Stream, metaclass=abc.ABCMeta):
     """Base class for SQLAlchemy-based streams."""

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import abc
 import typing as t
 
-# TODO: Replace with cached_property when moving to py > 3.7
-from functools import lru_cache
-
 import sqlalchemy
 
 import singer_sdk.helpers._catalog as catalog
@@ -17,6 +14,11 @@ from singer_sdk.streams.core import Stream
 
 if t.TYPE_CHECKING:
     from singer_sdk.tap_base import Tap
+    F = t.TypeVar('F', Callable)
+    def lru_cache(f: F) -> F: pass
+else:
+    # TODO: Replace with cached_property when moving to py > 3.7
+    from functools import lru_cache
 
 
 class SQLStream(Stream, metaclass=abc.ABCMeta):


### PR DESCRIPTION
Schema is called at least once per record and does not change within a stream, so it should be cached for performance benefits.

https://app.slack.com/client/TFG99TU9K/C013Z450LCD/thread/C013Z450LCD-1685703921.187269

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1745.org.readthedocs.build/en/1745/

<!-- readthedocs-preview meltano-sdk end -->