### PR TITLE
fix: clear target test runner state after each run

### DIFF
--- a/singer_sdk/testing/runners.py
+++ b/singer_sdk/testing/runners.py
@@ -270,6 +270,7 @@ class TargetTestRunner(SingerTestRunner):
         )
         self.stdout, self.stderr = (stdout.read(), stderr.read())
         self.state_messages.extend(self._clean_sync_output(self.stdout))
+        self.target_input = None
 
     def _execute_sync(
         self,


### PR DESCRIPTION
The target test framework had weird behavior where all 14 default tests passed for me but when I looked closer only 1 table was getting created in the destination database. I figured out it was because the input file was getting stuck on the first test's input file.

The test overrides the runner `input_filepath` https://github.com/meltano/sdk/blob/fda24cfba259b917d0ab3a74b355346e7b0027e9/singer_sdk/testing/templates.py#L325 to pass in the path to the test's JSONL data but it only gets used on the first test because the second test uses the runner while it still has self._input state from the previous run so it [skips the logic](https://github.com/meltano/sdk/blob/fda24cfba259b917d0ab3a74b355346e7b0027e9/singer_sdk/testing/runners.py#LL241C17-L241C23) for reading in the new file. Ultimately all following tests get no input so they silently pass but dont actually do anything.

 I confirmed this fix worked in https://github.com/MeltanoLabs/target-snowflake/pull/38.

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1749.org.readthedocs.build/en/1749/

<!-- readthedocs-preview meltano-sdk end -->