### PR TITLE
fix: Add tests for SQL type conversion from JSON schemas

### DIFF
--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -825,7 +825,10 @@ def _jsonschema_type_check(jsonschema_type: dict, type_check: tuple[str]) -> boo
             if jsonschema_type.get("type") in type_check:  # noqa: PLR5501
                 return True
 
-    if any(_jsonschema_type_check(t, type_check) for t in jsonschema_type.get("anyOf", ())):
+    if any(
+        _jsonschema_type_check(t, type_check)
+        for t in jsonschema_type.get("anyOf", ())
+    ):
         return True
 
     return False

--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -825,7 +825,7 @@ def _jsonschema_type_check(jsonschema_type: dict, type_check: tuple[str]) -> boo
             if jsonschema_type.get("type") in type_check:  # noqa: PLR5501
                 return True
 
-    if any(t in type_check for t in jsonschema_type.get("anyOf", ())):
+    if any(_jsonschema_type_check(t, type_check) for t in jsonschema_type.get("anyOf", ())):
         return True
 
     return False

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -295,24 +295,31 @@ def test_conform_primitives():
     assert _conform_primitive_property(1, {"type": "boolean"}) is True
 
 
-
-import sqlalchemy
 import pytest
+import sqlalchemy
+
+
 @pytest.mark.parametrize(
     "jsonschema_type,expected",
     [
-        ({'type': ['string', 'null']}, sqlalchemy.types.VARCHAR),
-        ({'type': ['integer', 'null']}, sqlalchemy.types.INTEGER),
-        ({'type': ['number', 'null']}, sqlalchemy.types.DECIMAL),
-        ({'type': ['boolean', 'null']}, sqlalchemy.types.BOOLEAN),
-        ({'type': "object", "properties": {}}, sqlalchemy.types.VARCHAR),
-        ({'type': "array"}, sqlalchemy.types.VARCHAR),
-        ({ "format": "date", "type": [ "string", "null" ] }, sqlalchemy.types.DATE),
-        ({ "format": "time", "type": [ "string", "null" ] }, sqlalchemy.types.TIME),
-        ({ "format": "date-time", "type": [ "string", "null" ] }, sqlalchemy.types.DATETIME),
-        ({"anyOf": [{"type": "string", "format": "date-time"}, {"type": "null"}]}, sqlalchemy.types.DATETIME),
-        ({ "anyOf": [ {"type": "integer"}, {"type": "null"}, ], }, sqlalchemy.types.INTEGER),
-    ]
+        ({"type": ["string", "null"]}, sqlalchemy.types.VARCHAR),
+        ({"type": ["integer", "null"]}, sqlalchemy.types.INTEGER),
+        ({"type": ["number", "null"]}, sqlalchemy.types.DECIMAL),
+        ({"type": ["boolean", "null"]}, sqlalchemy.types.BOOLEAN),
+        ({"type": "object", "properties": {}}, sqlalchemy.types.VARCHAR),
+        ({"type": "array"}, sqlalchemy.types.VARCHAR),
+        ({"format": "date", "type": ["string", "null"]}, sqlalchemy.types.DATE),
+        ({"format": "time", "type": ["string", "null"]}, sqlalchemy.types.TIME),
+        (
+            {"format": "date-time", "type": ["string", "null"]},
+            sqlalchemy.types.DATETIME,
+        ),
+        (
+            {"anyOf": [{"type": "string", "format": "date-time"}, {"type": "null"}]},
+            sqlalchemy.types.DATETIME,
+        ),
+        ({"anyOf": [{"type": "integer"}, {"type": "null"}]}, sqlalchemy.types.INTEGER),
+    ],
 )
 def test_to_sql_type(jsonschema_type, expected):
     assert isinstance(to_sql_type(jsonschema_type), expected)

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import datetime
 import logging
-import typing as t
 
+import pytest
 import sqlalchemy
 
 from singer_sdk.helpers._typing import (
@@ -21,9 +21,6 @@ from singer_sdk.typing import (
     StringType,
     to_sql_type,
 )
-
-if t.TYPE_CHECKING:
-    import pytest
 
 logger = logging.getLogger("log")
 

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -17,6 +17,7 @@ from singer_sdk.typing import (
     PropertiesList,
     Property,
     StringType,
+    to_sql_type,
 )
 
 if t.TYPE_CHECKING:
@@ -292,3 +293,26 @@ def test_conform_primitives():
     assert _conform_primitive_property(None, {"type": "boolean"}) is None
     assert _conform_primitive_property(0, {"type": "boolean"}) is False
     assert _conform_primitive_property(1, {"type": "boolean"}) is True
+
+
+
+import sqlalchemy
+import pytest
+@pytest.mark.parametrize(
+    "jsonschema_type,expected",
+    [
+        ({'type': ['string', 'null']}, sqlalchemy.types.VARCHAR),
+        ({'type': ['integer', 'null']}, sqlalchemy.types.INTEGER),
+        ({'type': ['number', 'null']}, sqlalchemy.types.DECIMAL),
+        ({'type': ['boolean', 'null']}, sqlalchemy.types.BOOLEAN),
+        ({'type': "object", "properties": {}}, sqlalchemy.types.VARCHAR),
+        ({'type': "array"}, sqlalchemy.types.VARCHAR),
+        ({ "format": "date", "type": [ "string", "null" ] }, sqlalchemy.types.DATE),
+        ({ "format": "time", "type": [ "string", "null" ] }, sqlalchemy.types.TIME),
+        ({ "format": "date-time", "type": [ "string", "null" ] }, sqlalchemy.types.DATETIME),
+        ({"anyOf": [{"type": "string", "format": "date-time"}, {"type": "null"}]}, sqlalchemy.types.DATETIME),
+        ({ "anyOf": [ {"type": "integer"}, {"type": "null"}, ], }, sqlalchemy.types.INTEGER),
+    ]
+)
+def test_to_sql_type(jsonschema_type, expected):
+    assert isinstance(to_sql_type(jsonschema_type), expected)

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -6,6 +6,8 @@ import datetime
 import logging
 import typing as t
 
+import sqlalchemy
+
 from singer_sdk.helpers._typing import (
     TypeConformanceLevel,
     _conform_primitive_property,
@@ -293,10 +295,6 @@ def test_conform_primitives():
     assert _conform_primitive_property(None, {"type": "boolean"}) is None
     assert _conform_primitive_property(0, {"type": "boolean"}) is False
     assert _conform_primitive_property(1, {"type": "boolean"}) is True
-
-
-import pytest
-import sqlalchemy
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes https://github.com/meltano/sdk/issues/1774

I added tests that I let run in CI and they fail https://github.com/meltano/sdk/actions/runs/5315601259/jobs/9624162264 then I pushed the change that fixes them.

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1775.org.readthedocs.build/en/1775/

<!-- readthedocs-preview meltano-sdk end -->