### PR TITLE
feat: Support optional headers for OAuth request

### DIFF
--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -367,21 +367,19 @@ class OAuthAuthenticator(APIAuthenticatorBase):
             auth_endpoint: The OAuth 2.0 authorization endpoint.
             oauth_scopes: A comma-separated list of OAuth scopes.
             default_expiration: Default token expiry in seconds.
+            oauth_headers: An optional dict of headers required to get a token.
         """
         super().__init__(stream=stream)
         self._auth_endpoint = auth_endpoint
         self._default_expiration = default_expiration
         self._oauth_scopes = oauth_scopes
+        self._oauth_headers = oauth_headers or {}
 
         # Initialize internal tracking attributes
         self.access_token: str | None = None
         self.refresh_token: str | None = None
         self.last_refreshed: datetime | None = None
         self.expires_in: int | None = None
-        if self._auth_headers is None:
-            self._auth_headers = {}
-        if oauth_headers:
-            self._auth_headers.update(oauth_headers)
 
     @property
     def auth_headers(self) -> dict:
@@ -504,7 +502,7 @@ class OAuthAuthenticator(APIAuthenticatorBase):
         auth_request_payload = self.oauth_request_payload
         token_response = requests.post(
             self.auth_endpoint,
-            headers=self._auth_headers,
+            headers=self._oauth_headers,
             data=auth_request_payload,
             timeout=60,
         )
@@ -518,7 +516,8 @@ class OAuthAuthenticator(APIAuthenticatorBase):
 
         token_json = token_response.json()
         self.access_token = token_json["access_token"]
-        self.expires_in = int(token_json.get("expires_in", self._default_expiration))
+        expiration = token_json.get("expires_in", self._default_expiration)
+        self.expires_in = int(expiration) if expiration else None
         if self.expires_in is None:
             self.logger.debug(
                 "No expires_in receied in OAuth response and no "


### PR DESCRIPTION
Adding support for adding a header to an OAuth request for tokens. In a few instances an API has a requirement to have headers added to the request for an OAuth Token. An example of the type of header is a subscription key.

This extends the current OAuth Authenticator to accept a new **optional** parameter `oauth_headers`.

The PR also explicitly converts the returned `expires_in` value to int rather than assuming it is an integer. I had an example where it was returned as an string from this API.

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1815.org.readthedocs.build/en/1815/

<!-- readthedocs-preview meltano-sdk end -->