### PR TITLE
docs: Update testing.md

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,7 +68,6 @@ StandardTargetTests = get_target_test_class(
 class TestTargetExample(StandardTargetTests):
     """Standard Target Tests."""
 
-    @pytest.fixture(scope="class")
     def resource(self):
         """Generic external resource.
 


### PR DESCRIPTION
I was getting `ScopeMismatch: You tried to access the function scoped fixture runner with a class scoped request object` in target snowflake after I upgraded to 0.29.0. Removing the class scoped fixture allowed it to pass https://github.com/MeltanoLabs/target-snowflake/compare/bump_sdk_0.29.0.

Is this correct? It seems like the scope changed in https://github.com/meltano/sdk/pull/1752 but we might have missed a docs update.