### PR TITLE
fix(targets): Include SCHEMA message count in target logs

### DIFF
--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -294,9 +294,10 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
 
         self.logger.info(
             "Target '%s' completed reading %d lines of input "
-            "(%d records, %d batch manifests, %d state messages).",
+            "(%d schemas, %d records, %d batch manifests, %d state messages).",
             self.name,
             line_count,
+            counter[SingerMessageType.SCHEMA],
             counter[SingerMessageType.RECORD],
             counter[SingerMessageType.BATCH],
             counter[SingerMessageType.STATE],


### PR DESCRIPTION
From a (private) [Slack conversation](https://meltano.slack.com/archives/C05FP72408K/p1688678721243459), it seems that we're missing the SCHEMA message count which makes it seem that the total is missing something.

Example of new output:

```
2023-07-07 12:46:08,109 | INFO     | target-csv           | Target 'target-csv' completed reading 262 lines of input (2 schemas, 257 records, 0 batch manifests, 3 state messages).
```
