### PR TITLE
docs: Document `RESTStream.rest_method`

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -51,6 +51,8 @@ class RESTStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):
 
     _page_size: int = DEFAULT_PAGE_SIZE
     _requests_session: requests.Session | None
+
+    #: HTTP method to use for requests. Defaults to "GET".
     rest_method = "GET"
 
     #: JSONPath expression to extract records from the API response.


### PR DESCRIPTION
The gap was noted in a [slack conversation](https://meltano.slack.com/archives/CMN8HELB0/p1688963575249309).

https://meltano-sdk--1824.org.readthedocs.build/en/1824/classes/singer_sdk.RESTStream.html#singer_sdk.RESTStream.rest_method