### PR TITLE
fix: Add explicit dependency on `packaging` library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2708,4 +2708,4 @@ testing = ["pytest", "pytest-durations"]
 [metadata]
 lock-version = "2.0"
 python-versions = "<3.12,>=3.7.1"
-content-hash = "53c3e577e500c322fffa5a7f3e5fcebe34a2657894d35a9d5768b951320448d0"
+content-hash = "1cfb42db582744ae6f7afa862f0dc7554c8827499ff5806525e869879cc75db5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ python-dotenv = ">=0.20,<0.22"
 typing-extensions = "^4.2.0"
 simplejson = "^3.17.6"
 jsonschema = "^4.16.0"
+packaging = ">=23.1"
 pytz = ">=2022.2.1,<2024.0.0"
 PyYAML = "^6.0"
 # urllib3 2.0 is not compatible with botocore


### PR DESCRIPTION
Closes #1822

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1827.org.readthedocs.build/en/1827/

<!-- readthedocs-preview meltano-sdk end -->