### PR TITLE
fix(templates): Update cookiecutter copyright assignment to cookiecutter user

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{%if 'Apache-2.0' == cookiecutter.license %}LICENSE{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{%if 'Apache-2.0' == cookiecutter.license %}LICENSE{%endif%}
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   
+
    Copyright {% now 'utc', '%Y' %} {{ cookiecutter.admin_name }}
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{%if 'Apache-2.0' == cookiecutter.license %}LICENSE{%endif%}
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{%if 'Apache-2.0' == cookiecutter.license %}LICENSE{%endif%}
@@ -186,7 +186,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Meltano
+   
+   Copyright {% now 'utc', '%Y' %} {{ cookiecutter.admin_name }}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/{%if 'Apache-2.0' == cookiecutter.license %}LICENSE{%endif%}
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/{%if 'Apache-2.0' == cookiecutter.license %}LICENSE{%endif%}
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Meltano
+   Copyright {% now 'utc', '%Y' %} {{ cookiecutter.admin_name }}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Addresses
- #1828 

Assigns copyright in the current year (not 2021) and to the `admin_name` set in the cookiecutter workflow.

---

Should this be merged, I'd happily submit a PR to do the same for:
- #1807 

This is, of course, conditional on whether or not we want to encourage MIT licensing within the Meltano/Singer community (as Apache-2 comes with explicit patent usage license, whereas MIT does not).

Closes #1828

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1829.org.readthedocs.build/en/1829/

<!-- readthedocs-preview meltano-sdk end -->