### PR TITLE
fix: Add deprecation warning when importing legacy testing helpers

### DIFF
--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -11,3 +11,5 @@ incompatible way, following their deprecation, as indicated in the
   [`RESTStream.get_new_paginator`](singer_sdk.RESTStream.get_new_paginator).
 
   See the [migration guide](./guides/pagination-classes.md) for more information.
+
+- The `singer_sdk.testing.get_standard_tap_tests` and `singer_sdk.testing.get_standard_target_tests` functions will be removed. Replace them with `singer_sdk.testing.get_standard_tap_target_tests` and `singer_sdk.testing.get_standard_tap_target_tests` functions respective to generate a richer test suite.

--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -12,4 +12,4 @@ incompatible way, following their deprecation, as indicated in the
 
   See the [migration guide](./guides/pagination-classes.md) for more information.
 
-- The `singer_sdk.testing.get_standard_tap_tests` and `singer_sdk.testing.get_standard_target_tests` functions will be removed. Replace them with `singer_sdk.testing.get_standard_tap_target_tests` and `singer_sdk.testing.get_standard_tap_target_tests` functions respective to generate a richer test suite.
+- The `singer_sdk.testing.get_standard_tap_tests` and `singer_sdk.testing.get_standard_target_tests` functions will be removed. Replace them with `singer_sdk.testing.get_tap_test_class` and `singer_sdk.testing.get_target_test_class` functions respective to generate a richer test suite.

--- a/singer_sdk/testing/__init__.py
+++ b/singer_sdk/testing/__init__.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import typing as t
+import warnings
+
 from .config import SuiteConfig
 from .factory import get_tap_test_class, get_target_test_class
 from .legacy import (
     _get_tap_catalog,
     _select_all,
-    get_standard_tap_tests,
-    get_standard_target_tests,
     sync_end_to_end,
     tap_sync_test,
     tap_to_target_sync_test,
@@ -16,13 +17,42 @@ from .legacy import (
 )
 from .runners import SingerTestRunner, TapTestRunner, TargetTestRunner
 
+
+def __getattr__(name: str) -> t.Any:  # noqa: ANN401
+    if name == "get_standard_tap_tests":
+        warnings.warn(
+            "The function singer_sdk.testing.get_standard_tap_tests is deprecated "
+            "and will be removed in a future release. Use get_tap_test_class instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        from .legacy import get_standard_tap_tests
+
+        return get_standard_tap_tests
+
+    if name == "get_standard_target_tests":
+        warnings.warn(
+            "The function singer_sdk.testing.get_standard_target_tests is deprecated "
+            "and will be removed in a future release. Use get_target_test_class "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        from .legacy import get_standard_target_tests
+
+        return get_standard_target_tests
+
+    msg = f"module {__name__} has no attribute {name}"
+    raise AttributeError(msg)
+
+
 __all__ = [
     "get_tap_test_class",
     "get_target_test_class",
     "_get_tap_catalog",
     "_select_all",
-    "get_standard_tap_tests",
-    "get_standard_target_tests",
     "sync_end_to_end",
     "tap_sync_test",
     "tap_to_target_sync_test",

--- a/tests/core/test_testing.py
+++ b/tests/core/test_testing.py
@@ -11,3 +11,11 @@ def test_module_deprecations():
 
     with pytest.deprecated_call():
         from singer_sdk.testing import get_standard_target_tests  # noqa: F401
+
+    from singer_sdk import testing
+
+    with pytest.raises(
+        AttributeError,
+        match="module singer_sdk.testing has no attribute",
+    ):
+        testing.foo  # noqa: B018

--- a/tests/core/test_testing.py
+++ b/tests/core/test_testing.py
@@ -1,0 +1,13 @@
+"""Test the plugin testing helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_module_deprecations():
+    with pytest.deprecated_call():
+        from singer_sdk.testing import get_standard_tap_tests  # noqa: F401
+
+    with pytest.deprecated_call():
+        from singer_sdk.testing import get_standard_target_tests  # noqa: F401


### PR DESCRIPTION
In preparation for https://github.com/meltano/sdk/issues/1354 in v1


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1838.org.readthedocs.build/en/1838/

<!-- readthedocs-preview meltano-sdk end -->