### PR TITLE
fix: Ensure all expected tap parameters are passed to `SQLTap` initializer

### DIFF
--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -613,37 +613,17 @@ class SQLTap(Tap):
     # Stream class used to initialize new SQL streams from their catalog declarations.
     default_stream_class: type[SQLStream]
 
-    def __init__(
-        self,
-        *,
-        config: dict | PurePath | str | list[PurePath | str] | None = None,
-        catalog: PurePath | str | dict | None = None,
-        state: PurePath | str | dict | None = None,
-        parse_env_config: bool = False,
-        validate_config: bool = True,
-    ) -> None:
+    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
         """Initialize the SQL tap.
 
         The SQLTap initializer additionally creates a cache variable for _catalog_dict.
 
         Args:
-            config: Tap configuration. Can be a dictionary, a single path to a
-                configuration file, or a list of paths to multiple configuration
-                files.
-            catalog: Tap catalog. Can be a dictionary or a path to the catalog file.
-            state: Tap state. Can be dictionary or a path to the state file.
-            parse_env_config: Whether to look for configuration values in environment
-                variables.
-            validate_config: True to require validation of config settings.
+            *args: Positional arguments for the Tap initializer.
+            **kwargs: Keyword arguments for the Tap initializer.
         """
         self._catalog_dict: dict | None = None
-        super().__init__(
-            config=config,
-            catalog=catalog,
-            state=state,
-            parse_env_config=parse_env_config,
-            validate_config=validate_config,
-        )
+        super().__init__(*args, **kwargs)
 
     @property
     def catalog_dict(self) -> dict:

--- a/tests/samples/conftest.py
+++ b/tests/samples/conftest.py
@@ -73,7 +73,7 @@ def path_to_sample_data_db(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def sqlite_sample_db_config(path_to_sample_data_db: str) -> dict:
+def sqlite_sample_db_config(path_to_sample_data_db: Path) -> dict:
     """Get configuration dictionary for target-csv."""
     return {"path_to_db": str(path_to_sample_data_db)}
 

--- a/tests/samples/test_tap_sqlite.py
+++ b/tests/samples/test_tap_sqlite.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import json
 import typing as t
-from pathlib import Path
-from tempfile import NamedTemporaryFile
 
 from click.testing import CliRunner
 
@@ -17,6 +15,8 @@ from singer_sdk.testing import (
 )
 
 if t.TYPE_CHECKING:
+    from pathlib import Path
+
     from singer_sdk.tap_base import SQLTap
 
 
@@ -28,15 +28,17 @@ def _discover_and_select_all(tap: SQLTap) -> None:
         catalog_entry["metadata"] = md.to_list()
 
 
-def test_tap_sqlite_cli(sqlite_sample_db_config: dict[str, t.Any]):
+def test_tap_sqlite_cli(sqlite_sample_db_config: dict[str, t.Any], tmp_path: Path):
     runner = CliRunner()
-    with NamedTemporaryFile() as tmp_file:
-        with Path(tmp_file.name).open("w") as f:
-            json.dump(sqlite_sample_db_config, f)
-        result = runner.invoke(
-            SQLiteTap.cli,
-            ["--discover", "--config", tmp_file.name],
-        )
+    filepath = tmp_path / "config.json"
+
+    with filepath.open("w") as f:
+        json.dump(sqlite_sample_db_config, f)
+
+    result = runner.invoke(
+        SQLiteTap.cli,
+        ["--discover", "--config", str(filepath)],
+    )
     assert result.exit_code == 0
 
     catalog = json.loads(result.stdout)


### PR DESCRIPTION
Fixes the broken initialization of SQL taps following https://github.com/meltano/sdk/pull/1835.

The subclass initializer doesn't introduce any new arguments, so this PR changes it to use `*args` and `**kwargs` so we don't miss any changes to the parent class' initializer.

cc @BuzzCutNorman


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1842.org.readthedocs.build/en/1842/

<!-- readthedocs-preview meltano-sdk end -->