### PR TITLE
docs: Fix stale `pip_url` example that uses shell script workaround for editable installation

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -161,7 +161,7 @@ plugins:
   extractors:
   - name: my-tap
     namespace: my_tap
-    executable: ./my-tap.sh
+    executable: -e .
     capabilities:
     - state
     - catalog


### PR DESCRIPTION
Closes #321

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1852.org.readthedocs.build/en/1852/

<!-- readthedocs-preview meltano-sdk end -->