### PR TITLE
feat(templates): Add email field and use human-readable questions in templates

### DIFF
--- a/cookiecutter/mapper-template/cookiecutter.json
+++ b/cookiecutter/mapper-template/cookiecutter.json
@@ -1,9 +1,19 @@
 {
   "name": "MyMapperName",
   "admin_name": "FirstName LastName",
+  "admin_email": "firstname.lastname@example.com",
   "mapper_id": "mapper-{{ cookiecutter.name.lower() }}",
   "library_name": "{{ cookiecutter.mapper_id.replace('-', '_') }}",
   "variant": "None (Skip)",
   "include_ci_files": ["GitHub", "None (Skip)"],
-  "license": ["Apache-2.0"]
+  "license": ["Apache-2.0"],
+  "__prompts__": {
+    "name": "The name of the mapper, in CamelCase",
+    "admin_name": "Provide your [bold yellow]full name[/]",
+    "admin_email": "Provide your [bold yellow]email[/]",
+    "mapper_id": "The ID of the tap, in kebab-case",
+    "library_name": "The name of the library, in snake_case. This is how the library will be imported in Python.",
+    "include_ci_files": "Whether to include CI files for a common CI services",
+    "license": "The license for the project"
+  }
 }

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -7,7 +7,7 @@ name = "{{cookiecutter.mapper_id}}"
 version = "0.0.1"
 description = "`{{cookiecutter.mapper_id}}` is a Singer mapper {{cookiecutter.name}}, built with the Meltano Singer SDK."
 readme = "README.md"
-authors = ["{{ cookiecutter.admin_name }}"]
+authors = ["{{ cookiecutter.admin_name }} <{{ cookiecutter.admin_email }}>"]
 keywords = [
     "ELT",
     "Mapper",

--- a/cookiecutter/tap-template/cookiecutter.json
+++ b/cookiecutter/tap-template/cookiecutter.json
@@ -1,6 +1,7 @@
 {
   "source_name": "MySourceName",
   "admin_name": "FirstName LastName",
+  "admin_email": "firstname.lastname@example.com",
   "tap_id": "tap-{{ cookiecutter.source_name.lower() }}",
   "library_name": "{{ cookiecutter.tap_id.replace('-', '_') }}",
   "variant": "None (Skip)",
@@ -14,5 +15,16 @@
     "Custom or N/A"
   ],
   "include_ci_files": ["GitHub", "None (Skip)"],
-  "license": ["Apache-2.0"]
+  "license": ["Apache-2.0"],
+  "__prompts__": {
+    "source_name": "The name of the source, in CamelCase",
+    "admin_name": "Provide your [bold yellow]full name[/]",
+    "admin_email": "Provide your [bold yellow]email[/]",
+    "tap_id": "The ID of the tap, in kebab-case",
+    "library_name": "The name of the library, in snake_case. This is how the library will be imported in Python.",
+    "stream_type": "The type of stream the source provides",
+    "auth_method": "The [bold red]authentication[/] method used by the source, for REST and GraphQL sources",
+    "include_ci_files": "Whether to include CI files for a common CI services",
+    "license": "The license for the project"
+  }
 }

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -7,7 +7,7 @@ name = "{{cookiecutter.tap_id}}"
 version = "0.0.1"
 description = "`{{cookiecutter.tap_id}}` is a Singer tap for {{cookiecutter.source_name}}, built with the Meltano Singer SDK."
 readme = "README.md"
-authors = ["{{ cookiecutter.admin_name }}"]
+authors = ["{{ cookiecutter.admin_name }} <{{ cookiecutter.admin_email }}>"]
 keywords = [
     "ELT",
     "{{cookiecutter.source_name}}",

--- a/cookiecutter/target-template/cookiecutter.json
+++ b/cookiecutter/target-template/cookiecutter.json
@@ -1,10 +1,21 @@
 {
   "destination_name": "MyDestinationName",
   "admin_name": "FirstName LastName",
+  "admin_email": "firstname.lastname@example.com",
   "target_id": "target-{{ cookiecutter.destination_name.lower() }}",
   "library_name": "{{ cookiecutter.target_id.replace('-', '_') }}",
   "variant": "None (Skip)",
   "serialization_method": ["Per record", "Per batch", "SQL"],
   "include_ci_files": ["GitHub", "None (Skip)"],
-  "license": ["Apache-2.0"]
+  "license": ["Apache-2.0"],
+  "__prompts__": {
+    "name": "The name of the mapper, in CamelCase",
+    "admin_name": "Provide your [bold yellow]full name[/]",
+    "admin_email": "Provide your [bold yellow]email[/]",
+    "mapper_id": "The ID of the tap, in kebab-case",
+    "library_name": "The name of the library, in snake_case. This is how the library will be imported in Python.",
+    "serialization_method": "The serialization method to use for loading data",
+    "include_ci_files": "Whether to include CI files for a common CI services",
+    "license": "The license for the project"
+  }
 }

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -7,7 +7,7 @@ name = "{{cookiecutter.target_id}}"
 version = "0.0.1"
 description = "`{{cookiecutter.target_id}}` is a Singer target for {{cookiecutter.destination_name}}, built with the Meltano Singer SDK."
 readme = "README.md"
-authors = ["{{ cookiecutter.admin_name }}"]
+authors = ["{{ cookiecutter.admin_name }} <{{ cookiecutter.admin_email }}>"]
 keywords = [
     "ELT",
     "{{cookiecutter.destination_name}}",

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -76,6 +76,24 @@ generated `README.md` file to complete your new tap or target. You can also refe
 [Meltano Tutorial](https://docs.meltano.com/tutorials/custom-extractor) for a more
 detailed guide.
 
+````{admonition} Avoid repeating yourself
+  If you find yourself repeating the same inputs to the cookiecutter, you can create a
+  `cookiecutterrc` file in your home directory to set default values for the prompts.
+
+  For example, if you want to set the default value for your name and email, and the
+  default stream type and authentication method, you can add the following to your
+  `~/.cookiecutterrc` file:
+
+  ```yaml
+  # ~/.cookiecutterrc
+  default_context:
+    admin_name: Johnny B. Goode
+    admin_email: jbg@example.com
+    stream_type: REST
+    auth_method: Bearer Token
+  ```
+````
+
 ### Using an existing library
 
 In some cases, there may already be a library that connects to the API and all you need the SDK for

--- a/e2e-tests/cookiecutters/mapper-base.json
+++ b/e2e-tests/cookiecutters/mapper-base.json
@@ -2,6 +2,7 @@
     "cookiecutter": {
       "name": "MyMapperName",
       "admin_name": "Automatic Tester",
+      "admin_email": "auto.tester@example.com",
       "mapper_id": "mapper-base",
       "library_name": "mapper_base",
       "variant": "None (Skip)",

--- a/e2e-tests/cookiecutters/tap-graphql-jwt.json
+++ b/e2e-tests/cookiecutters/tap-graphql-jwt.json
@@ -2,6 +2,7 @@
     "cookiecutter": {
       "source_name": "GraphQLJWTTemplateTest",
       "admin_name": "Automatic Tester",
+      "admin_email": "auto.tester@example.com",
       "tap_id": "tap-graphql-jwt",
       "library_name": "tap_graphql_jwt",
       "variant": "None (Skip)",

--- a/e2e-tests/cookiecutters/tap-other-custom.json
+++ b/e2e-tests/cookiecutters/tap-other-custom.json
@@ -2,6 +2,7 @@
     "cookiecutter": {
       "source_name": "AutomaticTestTap",
       "admin_name": "Automatic Tester",
+      "admin_email": "auto.tester@example.com",
       "tap_id": "tap-other-custom",
       "library_name": "tap_other_custom",
       "variant": "None (Skip)",

--- a/e2e-tests/cookiecutters/tap-rest-api_key-github.json
+++ b/e2e-tests/cookiecutters/tap-rest-api_key-github.json
@@ -2,6 +2,7 @@
     "cookiecutter": {
       "source_name": "AutomaticTestTap",
       "admin_name": "Automatic Tester",
+      "admin_email": "auto.tester@example.com",
       "tap_id": "tap-rest-api_key-github",
       "library_name": "tap_rest_api_key_github",
       "variant": "None (Skip)",

--- a/e2e-tests/cookiecutters/tap-rest-basic_auth.json
+++ b/e2e-tests/cookiecutters/tap-rest-basic_auth.json
@@ -2,6 +2,7 @@
     "cookiecutter": {
       "source_name": "AutomaticTestTap",
       "admin_name": "Automatic Tester",
+      "admin_email": "auto.tester@example.com",
       "tap_id": "tap-rest-basic_auth",
       "library_name": "tap_rest_basic_auth",
       "variant": "None (Skip)",

--- a/e2e-tests/cookiecutters/tap-rest-bearer_token.json
+++ b/e2e-tests/cookiecutters/tap-rest-bearer_token.json
@@ -2,6 +2,7 @@
     "cookiecutter": {
       "source_name": "AutomaticTestTap",
       "admin_name": "Automatic Tester",
+      "admin_email": "auto.tester@example.com",
       "tap_id": "tap-rest-bearer_token",
       "library_name": "tap_rest_bearer_token",
       "variant": "None (Skip)",

--- a/e2e-tests/cookiecutters/tap-rest-custom.json
+++ b/e2e-tests/cookiecutters/tap-rest-custom.json
@@ -2,6 +2,7 @@
     "cookiecutter": {
       "source_name": "AutomaticTestTap",
       "admin_name": "Automatic Tester",
+      "admin_email": "auto.tester@example.com",
       "tap_id": "tap-rest-custom",
       "library_name": "tap_rest_custom",
       "variant": "None (Skip)",

--- a/e2e-tests/cookiecutters/tap-rest-jwt.json
+++ b/e2e-tests/cookiecutters/tap-rest-jwt.json
@@ -2,6 +2,7 @@
     "cookiecutter": {
       "source_name": "AutomaticTestTap",
       "admin_name": "Automatic Tester",
+      "admin_email": "auto.tester@example.com",
       "tap_id": "tap-rest-jwt",
       "library_name": "tap_rest_jwt",
       "variant": "None (Skip)",

--- a/e2e-tests/cookiecutters/tap-rest-oauth2.json
+++ b/e2e-tests/cookiecutters/tap-rest-oauth2.json
@@ -2,6 +2,7 @@
     "cookiecutter": {
       "source_name": "AutomaticTestTap",
       "admin_name": "Automatic Tester",
+      "admin_email": "auto.tester@example.com",
       "tap_id": "tap-rest-oauth2",
       "library_name": "tap_rest_oauth2",
       "variant": "None (Skip)",

--- a/e2e-tests/cookiecutters/tap-sql-custom.json
+++ b/e2e-tests/cookiecutters/tap-sql-custom.json
@@ -2,6 +2,7 @@
     "cookiecutter": {
       "source_name": "AutomaticTestTap",
       "admin_name": "Automatic Tester",
+      "admin_email": "auto.tester@example.com",
       "tap_id": "tap-sql-custom",
       "library_name": "tap_sql_custom",
       "variant": "None (Skip)",

--- a/e2e-tests/cookiecutters/target-per_record.json
+++ b/e2e-tests/cookiecutters/target-per_record.json
@@ -2,6 +2,7 @@
     "cookiecutter": {
       "destination_name": "MyDestinationName",
       "admin_name": "FirstName LastName",
+      "admin_email": "firstname.lastname@example.com",
       "target_id": "target-per_record",
       "library_name": "target_per_record",
       "variant": "None (Skip)",

--- a/e2e-tests/cookiecutters/target-sql.json
+++ b/e2e-tests/cookiecutters/target-sql.json
@@ -2,6 +2,7 @@
     "cookiecutter": {
       "destination_name": "MyDestinationName",
       "admin_name": "FirstName LastName",
+      "admin_email": "firstname.lastname@example.com",
       "target_id": "target-sql",
       "library_name": "target_sql",
       "variant": "None (Skip)",


### PR DESCRIPTION
Minor improvements spotted after using the tap template to test https://github.com/meltano/sdk/pull/1894:

- Added an `admin_email` field that's used in the `authors` filed in project metadata
- Added a note on using `~/.cookiecutterrc` to customize default values: https://meltano-sdk--1905.org.readthedocs.build/en/1905/dev_guide.html#building-a-new-tap-or-target
- Added human-readable prompts and make use of Rich markup:

  <img width="593" alt="Screenshot 2023-08-10 at 17 20 51" src="https://github.com/meltano/sdk/assets/16805946/7105b561-1b4e-4925-a3fe-afe3382741fc">



<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1905.org.readthedocs.build/en/1905/

<!-- readthedocs-preview meltano-sdk end -->