### PR TITLE
Document get_schema_names behavior

### DIFF
--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -496,6 +496,7 @@ class SQLConnector:
         result: list[dict] = []
         engine = self._engine
         inspected = sqlalchemy.inspect(engine)
+        # get_schema_names returns all databases in the DB, not just schemas
         for schema_name in self.get_schema_names(engine, inspected):
             # Iterate through each table and view
             for table_name, is_view in self.get_object_names(


### PR DESCRIPTION
Mostly pushing up to call this out, not sure of what the fix should be yet. 

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1911.org.readthedocs.build/en/1911/

<!-- readthedocs-preview meltano-sdk end -->