### PR TITLE
Add viztracer command for testing targets

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -264,6 +264,7 @@ Then simply run your package's CLI as normal, preceded by the `viztracer` comman
 
 ```console
 $ poetry run viztracer my-tap
+$ poetry run viztracer -- my-target --config=config.json --input=messages.json
 ```
 
 That command will produce a `result.json` file which you can explore with the `vizviewer` tool.


### PR DESCRIPTION
When it comes to testing targets it took me a long while to work out I could use the `--input` switch to pass a file of records to the target rather than trying to work out how to run `viztracer` on a command containing a pipe 🤯. If the added line can be proven to work by a reviewer and it's OK to be added to the documentation then it would have saved me heaps of time yesterday 😄