### PR TITLE
fix: Handle replication key not found in stream schema

### DIFF
--- a/singer_sdk/exceptions.py
+++ b/singer_sdk/exceptions.py
@@ -17,6 +17,10 @@ class FatalAPIError(Exception):
     """Exception raised when a failed request should not be considered retriable."""
 
 
+class InvalidReplicationKeyException(Exception):
+    """Exception to raise if the replication key is not in the stream properties."""
+
+
 class InvalidStreamSortException(Exception):
     """Exception to raise if sorting errors are found while syncing the records."""
 

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -214,7 +214,8 @@ class Stream(metaclass=abc.ABCMeta):
             True if the stream uses a timestamp-based replication key.
 
         Raises:
-            InvalidReplicationKeyException: If the schema does not contain the replication key.
+            InvalidReplicationKeyException: If the schema does not contain the 
+            replication key.
         """
         if not self.replication_key:
             return False

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -212,7 +212,7 @@ class Stream(metaclass=abc.ABCMeta):
 
         Returns:
             True if the stream uses a timestamp-based replication key.
-        
+
         Raises:
             InvalidReplicationKeyException: If the schema does not contain the replication key.
         """

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -19,9 +19,9 @@ from singer_sdk.batch import JSONLinesBatcher
 from singer_sdk.exceptions import (
     AbortedSyncFailedException,
     AbortedSyncPausedException,
+    InvalidReplicationKeyException,
     InvalidStreamSortException,
     MaxRecordsLimitException,
-    InvalidReplicationKeyException,
 )
 from singer_sdk.helpers._batch import (
     BaseBatchFileEncoding,

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -215,7 +215,7 @@ class Stream(metaclass=abc.ABCMeta):
 
         Raises:
             InvalidReplicationKeyException: If the schema does not contain the
-            replication key.
+                replication key.
         """
         if not self.replication_key:
             return False

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -221,9 +221,7 @@ class Stream(metaclass=abc.ABCMeta):
             return False
         type_dict = self.schema.get("properties", {}).get(self.replication_key)
         if type_dict is None:
-            msg = (
-                f"Field '{self.replication_key}' is not in schema for stream '{self.name}'"
-            )
+            msg = f"Field '{self.replication_key}' is not in schema for stream '{self.name}'"
             raise InvalidReplicationKeyException(msg)
         return is_datetime_type(type_dict)
 

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -222,7 +222,7 @@ class Stream(metaclass=abc.ABCMeta):
         type_dict = self.schema.get("properties", {}).get(self.replication_key)
         if type_dict is None:
             msg = (
-                f"{self.replication_key} is not in schema for stream name: {self.name}"
+                f"Field '{self.replication_key}' is not in schema for stream '{self.name}'"
             )
             raise InvalidReplicationKeyException(msg)
         return is_datetime_type(type_dict)

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -214,7 +214,7 @@ class Stream(metaclass=abc.ABCMeta):
             True if the stream uses a timestamp-based replication key.
 
         Raises:
-            InvalidReplicationKeyException: If the schema does not contain the 
+            InvalidReplicationKeyException: If the schema does not contain the
             replication key.
         """
         if not self.replication_key:

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -221,7 +221,7 @@ class Stream(metaclass=abc.ABCMeta):
             return False
         type_dict = self.schema.get("properties", {}).get(self.replication_key)
         if type_dict is None:
-            msg = f"Field '{self.replication_key}' is not in schema for stream '{self.name}'"
+            msg = f"Field '{self.replication_key}' is not in schema for stream '{self.name}'"  # noqa: E501
             raise InvalidReplicationKeyException(msg)
         return is_datetime_type(type_dict)
 

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -212,6 +212,9 @@ class Stream(metaclass=abc.ABCMeta):
 
         Returns:
             True if the stream uses a timestamp-based replication key.
+        
+        Raises:
+            InvalidReplicationKeyException: If the schema does not contain the replication key.
         """
         if not self.replication_key:
             return False

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -21,6 +21,7 @@ from singer_sdk.exceptions import (
     AbortedSyncPausedException,
     InvalidStreamSortException,
     MaxRecordsLimitException,
+    InvalidReplicationKeyException,
 )
 from singer_sdk.helpers._batch import (
     BaseBatchFileEncoding,
@@ -215,6 +216,11 @@ class Stream(metaclass=abc.ABCMeta):
         if not self.replication_key:
             return False
         type_dict = self.schema.get("properties", {}).get(self.replication_key)
+        if type_dict is None:
+            msg = (
+                f"{self.replication_key} is not in schema for stream name: {self.name}"
+            )
+            raise InvalidReplicationKeyException(msg)
         return is_datetime_type(type_dict)
 
     def get_starting_replication_key_value(

--- a/tests/core/test_streams.py
+++ b/tests/core/test_streams.py
@@ -289,7 +289,7 @@ def test_stream_invalid_replication_key(tap: SimpleTestTap):
     with pytest.raises(
         InvalidReplicationKeyException,
         match=(
-            f"{stream.replication_key} is not in schema for stream name: {stream.name}"
+            f"Field '{stream.replication_key}' is not in schema for stream '{stream.name}'"
         ),
     ):
         _check = stream.is_timestamp_replication_key

--- a/tests/core/test_streams.py
+++ b/tests/core/test_streams.py
@@ -288,9 +288,11 @@ def test_stream_invalid_replication_key(tap: SimpleTestTap):
 
     with pytest.raises(
         InvalidReplicationKeyException,
-        match=f"{stream.replication_key} is not in schema for stream name: {stream.name}",
+        match=(
+            f"{stream.replication_key} is not in schema for stream name: {stream.name}"
+        ),
     ):
-        stream.is_timestamp_replication_key
+        exception_check = stream.is_timestamp_replication_key
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_streams.py
+++ b/tests/core/test_streams.py
@@ -292,7 +292,7 @@ def test_stream_invalid_replication_key(tap: SimpleTestTap):
             f"{stream.replication_key} is not in schema for stream name: {stream.name}"
         ),
     ):
-        pass
+        _check = stream.is_timestamp_replication_key
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_streams.py
+++ b/tests/core/test_streams.py
@@ -277,15 +277,16 @@ def test_stream_starting_timestamp(
 
 def test_stream_invalid_replication_key(tap: SimpleTestTap):
     """Validate an exception is raised if replication_key not in schema."""
+
     class InvalidReplicationKeyStream(SimpleTestStream):
         replication_key = "INVALID"
 
     stream = InvalidReplicationKeyStream(tap)
 
-    with pytest.raises( 
-                        InvalidReplicationKeyException, 
-                        match=f"{stream.replication_key} is not in schema for stream name: {stream.name}"
-                       ):
+    with pytest.raises(
+        InvalidReplicationKeyException,
+        match=f"{stream.replication_key} is not in schema for stream name: {stream.name}",
+    ):
         stream.is_timestamp_replication_key
 
 

--- a/tests/core/test_streams.py
+++ b/tests/core/test_streams.py
@@ -10,6 +10,9 @@ import pytest
 import requests
 
 from singer_sdk._singerlib import Catalog, MetadataMapping
+from singer_sdk.exceptions import (
+    InvalidReplicationKeyException,
+)
 from singer_sdk.helpers._classproperty import classproperty
 from singer_sdk.helpers.jsonpath import _compile_jsonpath, extract_jsonpath
 from singer_sdk.pagination import first

--- a/tests/core/test_streams.py
+++ b/tests/core/test_streams.py
@@ -275,6 +275,20 @@ def test_stream_starting_timestamp(
     assert get_starting_value(None) == expected_starting_value
 
 
+def test_stream_invalid_replication_key(tap: SimpleTestTap):
+    """Validate an exception is raised if replication_key not in schema."""
+    class InvalidReplicationKeyStream(SimpleTestStream):
+        replication_key = "INVALID"
+
+    stream = InvalidReplicationKeyStream(tap)
+
+    with pytest.raises( 
+                        InvalidReplicationKeyException, 
+                        match=f"{stream.replication_key} is not in schema for stream name: {stream.name}"
+                       ):
+        stream.is_timestamp_replication_key
+
+
 @pytest.mark.parametrize(
     "path,content,result",
     [

--- a/tests/core/test_streams.py
+++ b/tests/core/test_streams.py
@@ -292,7 +292,7 @@ def test_stream_invalid_replication_key(tap: SimpleTestTap):
             f"{stream.replication_key} is not in schema for stream name: {stream.name}"
         ),
     ):
-        exception_check = stream.is_timestamp_replication_key
+        pass
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_streams.py
+++ b/tests/core/test_streams.py
@@ -289,7 +289,8 @@ def test_stream_invalid_replication_key(tap: SimpleTestTap):
     with pytest.raises(
         InvalidReplicationKeyException,
         match=(
-            f"Field '{stream.replication_key}' is not in schema for stream '{stream.name}'"
+            f"Field '{stream.replication_key}' is not in schema for stream "
+            f"'{stream.name}'"
         ),
     ):
         _check = stream.is_timestamp_replication_key


### PR DESCRIPTION
Closes: #1332

Changes:

- Add new `InvalidReplicationKeyException` to `singer_sdk.exceptions`
- Update `streams.core`. A `get()` is used to obtain the `replication_key` from `self.schema`, if the key is not present in the schema, the variable `type_dict` would equal `None`. A check has been added, if the value of the `type_dict` is `None` then the new exception is raised
- The resulting error message is of the format:

```log
"incorrect_replication_key" is not in schema for stream name: my_stream"
```

- Add a test to `tests/core/test_streams.py` which checks that a `SimpleTestStream` with `replication_key` overridden to `"INVALID"` raises the correct `InvalidReplicationKeyException` exception. 

