### PR TITLE
fix: Fix pytest plugin declaration so it can be used without requiring using `pytest_plugins`

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/tests/conftest.py
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/tests/conftest.py
@@ -1,3 +1,0 @@
-"""Test Configuration."""
-
-pytest_plugins = ("singer_sdk.testing.pytest_plugin",)

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/tests/conftest.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/tests/conftest.py
@@ -1,3 +1,0 @@
-"""Test Configuration."""
-
-pytest_plugins = ("singer_sdk.testing.pytest_plugin",)

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/tests/conftest.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/tests/conftest.py
@@ -1,3 +1,0 @@
-"""Test Configuration."""
-
-pytest_plugins = ("singer_sdk.testing.pytest_plugin",)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,8 +208,8 @@ module = [
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.poetry.scripts]
-pytest11 = { reference = "singer_sdk:testing.pytest_plugin", extras = ["testing"], type = "console" }
+[tool.poetry.plugins."pytest11"]
+singer_testing = "singer_sdk.testing.pytest_plugin"
 
 [tool.ruff]
 exclude = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,8 +24,6 @@ if t.TYPE_CHECKING:
 
 SYSTEMS = {"linux", "darwin", "windows"}
 
-pytest_plugins = ("singer_sdk.testing.pytest_plugin",)
-
 
 def pytest_collection_modifyitems(config: Config, items: list[pytest.Item]):
     rootdir = pathlib.Path(config.rootdir)


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1940.org.readthedocs.build/en/1940/

<!-- readthedocs-preview meltano-sdk end -->