### PR TITLE
fix: Avoid registering mappers for unselected streams

### DIFF
--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -682,6 +682,10 @@ class PluginMapper:
             catalog: TODO
         """
         for catalog_entry in catalog.streams:
+            mask = catalog_entry.metadata.resolve_selection()
+            if not mask[()]:
+                # Skip unselected streams
+                continue
             self.register_raw_stream_schema(
                 catalog_entry.stream or catalog_entry.tap_stream_id,
                 get_selected_schema(


### PR DESCRIPTION
Closes #1942

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1944.org.readthedocs.build/en/1944/

<!-- readthedocs-preview meltano-sdk end -->