### PR TITLE
perf: Ensure `raw_schema` in stream mapper is immutable

### DIFF
--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -84,7 +84,7 @@ class StreamMap(metaclass=abc.ABCMeta):
             flattening_options: Flattening options, or None to skip flattening.
         """
         self.stream_alias = stream_alias
-        self.raw_schema = raw_schema
+        self.raw_schema = copy.deepcopy(raw_schema)
         self.raw_key_properties = key_properties
         self.transformed_schema = raw_schema
         self.transformed_key_properties = key_properties


### PR DESCRIPTION
Closes https://github.com/meltano/sdk/issues/1961

When trying to figure out how to fix https://github.com/meltano/sdk/issues/1961 I realized it was caused by the [raw_schema](https://github.com/meltano/sdk/blob/97d97de313511be4c21b842bf2ba0283d4bf5c02/singer_sdk/mapper.py#L87) in the mapper being a shared object with the [transformed_schema](https://github.com/meltano/sdk/blob/97d97de313511be4c21b842bf2ba0283d4bf5c02/singer_sdk/mapper.py#L89) which is passed to `get_sink` then `add_sink`, ultimately to the sink itself [where SDC columns are added](https://github.com/meltano/sdk/blob/97d97de313511be4c21b842bf2ba0283d4bf5c02/singer_sdk/sinks/core.py#L76). The rest of the codebase expects transformed_schema to be mutable but raw_schema to be immutable (or at least it reads that way to me). They both share the same reference to the original schema dict so assumptions break. The main case I ran into was in https://github.com/meltano/sdk/issues/1961 where target-postgres was constantly creating new sink instances for me when the schema wasnt actually changing.