### PR TITLE
test: Replace freezegun with time-machine

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -44,9 +44,9 @@ test_dependencies = [
     "pytest",
     "pytest-snapshot",
     "pytest-durations",
-    "freezegun",
     "pyarrow",
     "requests-mock",
+    "time-machine",
     # Cookiecutter tests
     "black",
     "cookiecutter",

--- a/poetry.lock
+++ b/poetry.lock
@@ -680,20 +680,6 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
-name = "freezegun"
-version = "1.2.2"
-description = "Let your Python tests travel through time"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "freezegun-1.2.2-py3-none-any.whl", hash = "sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f"},
-    {file = "freezegun-1.2.2.tar.gz", hash = "sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446"},
-]
-
-[package.dependencies]
-python-dateutil = ">=2.7"
-
-[[package]]
 name = "fs"
 version = "2.4.16"
 description = "Python's filesystem abstraction layer"
@@ -2379,6 +2365,72 @@ files = [
 ]
 
 [[package]]
+name = "time-machine"
+version = "2.10.0"
+description = "Travel through time in your tests."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "time_machine-2.10.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2d5e93c14b935d802a310c1d4694a9fe894b48a733ebd641c9a570d6f9e1f667"},
+    {file = "time_machine-2.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4c0dda6b132c0180941944ede357109016d161d840384c2fb1096a3a2ef619f4"},
+    {file = "time_machine-2.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:900517e4a4121bf88527343d6aea2b5c99df134815bb8271ef589ec792502a71"},
+    {file = "time_machine-2.10.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:860279c7f9413bc763b3d1aee622937c4538472e2e58ad668546b49a797cb9fb"},
+    {file = "time_machine-2.10.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f451be286d50ec9b685198c7f76cea46538b8c57ec816f60edf5eb68d71c4f4"},
+    {file = "time_machine-2.10.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b1b07f5da833b2d8ea170cdf15a322c6fa2c6f7e9097a1bea435adc597cdcb5d"},
+    {file = "time_machine-2.10.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6b3a529ecc819488783e371df5ad315e790b9558c6945a236b13d7cb9ab73b9a"},
+    {file = "time_machine-2.10.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:51e36491bd4a43f8a937ca7c0d1a2287b8998f41306f47ebed250a02f93d2fe4"},
+    {file = "time_machine-2.10.0-cp310-cp310-win32.whl", hash = "sha256:1e9973091ad3272c719dafae35a5bb08fa5433c2902224d0f745657f9e3ac327"},
+    {file = "time_machine-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:ab82ea5a59faa1faa7397465f2edd94789a13f543daa02d16244906339100080"},
+    {file = "time_machine-2.10.0-cp310-cp310-win_arm64.whl", hash = "sha256:55bc6d666966fa2e6283d7433ebe875be37684a847eaa802075433c1ab3a377a"},
+    {file = "time_machine-2.10.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:99fc366cb4fa26d81f12fa36a929db0da89d99909e28231c045e0f1277e0db84"},
+    {file = "time_machine-2.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5969f325c20bdcb7f8917a6ac2ef328ec41cc2e256320a99dfe38b4080eeae71"},
+    {file = "time_machine-2.10.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:a1a5e283ab47b28205f33fa3c5a2df3fd9f07f09add63dbe76637c3633893a23"},
+    {file = "time_machine-2.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4083ec185ab9ece3e5a7ca7a7589114a555f04bcff31b29d4eb47a37e87d97fe"},
+    {file = "time_machine-2.10.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cbe45f88399b8af299136435a2363764d5fa6d16a936e4505081b6ea32ff3e18"},
+    {file = "time_machine-2.10.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d149a3fae8a06a3593361496ec036a27906fed478ade23ffc01dd402acd0b37"},
+    {file = "time_machine-2.10.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:2e05306f63df3c7760170af6e77e1b37405b7c7c4a97cc9fdf0105f1094b1b1c"},
+    {file = "time_machine-2.10.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:3d6d7b7680e34dbe60da34d75d6d5f31b6206c7149c0de8a7b0f0311d0ef7e3a"},
+    {file = "time_machine-2.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:91b8b06e09e1dfd53dafe272d41b60690d6f8806d7194c62982b003a088dc423"},
+    {file = "time_machine-2.10.0-cp311-cp311-win32.whl", hash = "sha256:6241a1742657622ebdcd66cf6045c92e0ec6ca6365c55434cc7fea945008192c"},
+    {file = "time_machine-2.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:48cce6dcb7118ba4a58537c6de4d1dd6e7ad6ea15d0257d6e0003b45c4a839c2"},
+    {file = "time_machine-2.10.0-cp311-cp311-win_arm64.whl", hash = "sha256:8cb6285095efa0833fd0301e159748a06e950c7744dc3d38e92e7607e2232d5a"},
+    {file = "time_machine-2.10.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8829ca7ed939419c2a23c360101edc51e3b57f40708d304b6aed16214d8b2a1f"},
+    {file = "time_machine-2.10.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b5b60bc00ad2efa5fefee117e5611a28b26f563f1a64df118d1d2f2590a679a"},
+    {file = "time_machine-2.10.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b1491fb647568134d38b06e844783d3069f5811405e9a3906eff88d55403e327"},
+    {file = "time_machine-2.10.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e78f2759a63fcc7660d283e22054c7cfa7468fad1ad86d0846819b6ea958d63f"},
+    {file = "time_machine-2.10.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:30881f263332245a665a49d0e30fda135597c4e18f2efa9c6759c224419c36a5"},
+    {file = "time_machine-2.10.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:e93750309093275340e0e95bb270801ec9cbf2ee8702d71031f4ccd8cc91dd7f"},
+    {file = "time_machine-2.10.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:a906bb338a6be978b83f09f09d8b24737239330f280c890ecbf1c13828e1838c"},
+    {file = "time_machine-2.10.0-cp37-cp37m-win32.whl", hash = "sha256:10c8b170920d3f83dad2268ae8d5e1d8bb431a85198e32d778e6f3a1f93b172d"},
+    {file = "time_machine-2.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:5efc4cc914d93138944c488fdebd6e4290273e3ac795d5c7a744af29eb04ce0f"},
+    {file = "time_machine-2.10.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:1787887168e36f57d5ca1abf1b9d065a55eb67067df2fa23aaa4382da36f7098"},
+    {file = "time_machine-2.10.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:26a8cc1f8e9f4f69ea3f50b9b9e3a699e80e44ac9359a867208be6adac30fc60"},
+    {file = "time_machine-2.10.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07e2c6c299c5509c72cc221a19f4bf680c87c793727a3127a29e18ddad3db13"},
+    {file = "time_machine-2.10.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f3e5f263a623148a448756a332aad45e65a59876fcb2511f7f61213e6d3ec3e"},
+    {file = "time_machine-2.10.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2b3abcb48d7ca7ed95e5d99220317b7ce31378636bb020cabfa62f9099e7dad"},
+    {file = "time_machine-2.10.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:545a813b7407c33dee388aa380449e79f57f02613ea149c6e907fc9ca3d53e64"},
+    {file = "time_machine-2.10.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:458b52673ec83d10da279d989d7a6ad1e60c93e4ba986210d72e6c78e17102f4"},
+    {file = "time_machine-2.10.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:acb2ca50d779d39eab1d0fab48697359e4ffc1aedfa58b79cd3a86ee13253834"},
+    {file = "time_machine-2.10.0-cp38-cp38-win32.whl", hash = "sha256:648fec54917a7e67acca38ed8e736b206e8a9688730e13e1cf7a74bcce89dec7"},
+    {file = "time_machine-2.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:3ed92d2a6e2c2b7a0c8161ecca5d012041b7ba147cbdfb2b7f62f45c02615111"},
+    {file = "time_machine-2.10.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6d2588581d3071d556f96954d084b7b99701e54120bb29dfadaab04791ef6ae4"},
+    {file = "time_machine-2.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:185f7a4228e993ddae610e24fb3c7e7891130ebb6a40f42d58ea3be0bfafe1b1"},
+    {file = "time_machine-2.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8225eb813ea9488de99e61569fc1b2d148d236473a84c6758cc436ffef4c043"},
+    {file = "time_machine-2.10.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7f03ac22440b00abd1027bfb7dd793dfeffb72dda26f336f4d561835e0ce6117"},
+    {file = "time_machine-2.10.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4252f4daef831556e6685853d7a61b02910d0465528c549f179ea4e36aaeb14c"},
+    {file = "time_machine-2.10.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:58c65bf4775fca62e1678cb234f1ca90254e811d978971c819d2cd24e1b7f136"},
+    {file = "time_machine-2.10.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:8527ac8fca7b92556c3c4c0f08e0bea995202db4be5b7d95b9b2ccbcb63649f2"},
+    {file = "time_machine-2.10.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4684308d749fdb0c22af173b081206d2a5a85d2154a683a7f4a60c4b667f7a65"},
+    {file = "time_machine-2.10.0-cp39-cp39-win32.whl", hash = "sha256:2adc24cf25b7e8d08aea2b109cc42c5db76817b07ee709fae5c66afa4ec7bc6e"},
+    {file = "time_machine-2.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:36f5be6f3042734fca043bedafbfbb6ad4809352e40b3283cb46b151a823674c"},
+    {file = "time_machine-2.10.0-cp39-cp39-win_arm64.whl", hash = "sha256:c1775a949dd830579d1af5a271ec53d920dc01657035ad305f55c5a1ac9b9f1e"},
+    {file = "time_machine-2.10.0.tar.gz", hash = "sha256:64fd89678cf589fc5554c311417128b2782222dd65f703bf248ef41541761da0"},
+]
+
+[package.dependencies]
+python-dateutil = "*"
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -2813,4 +2865,4 @@ testing = ["pytest", "pytest-durations"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.1,<4"
-content-hash = "abc9f3dec23f90e9d52baa621b6d25fe3051b193799b707048bee1186e0dd727"
+content-hash = "7dda84407ad4237de30a7a840872e9c3979680b6ef4128ebc5d959d1805b635c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,6 @@ cookiecutter = ">=2.1.1"
 coverage = {extras = ["toml"], version = ">=7.2"}
 duckdb = ">=0.8.0"
 duckdb-engine = ">=0.9.2"
-freezegun = ">=1.2.2"
 mypy = ">=1.0"
 numpy = [
     { version = "<1.22", python = "<3.8" },
@@ -112,6 +111,7 @@ numpy = [
 pyarrow = ">=11,<13"
 pytest-snapshot = ">=0.9.0"
 requests-mock = ">=1.10.0"
+time-machine = ">=2.10.0"
 types-jsonschema = ">=4.17.0.6"
 types-python-dateutil = ">=2.8.19"
 types-pytz = ">=2022.7.1.2"

--- a/tests/core/sinks/test_sdc_metadata.py
+++ b/tests/core/sinks/test_sdc_metadata.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-from freezegun import freeze_time
+import datetime
+
+import time_machine
 
 from tests.conftest import BatchSinkMock, TargetMock
 
 
 def test_sdc_metadata():
-    with freeze_time("2023-01-01T00:00:00+00:00"):
+    with time_machine.travel(
+        datetime.datetime(2023, 1, 1, tzinfo=datetime.timezone.utc),
+        tick=False,
+    ):
         target = TargetMock()
 
     sink = BatchSinkMock(
@@ -25,7 +30,10 @@ def test_sdc_metadata():
     }
     record = record_message["record"]
 
-    with freeze_time("2023-01-01T00:05:00+00:00"):
+    with time_machine.travel(
+        datetime.datetime(2023, 1, 1, 0, 5, tzinfo=datetime.timezone.utc),
+        tick=False,
+    ):
         sink._add_sdc_metadata_to_record(record, record_message, {})
 
     assert record == {

--- a/tests/core/test_mapper.py
+++ b/tests/core/test_mapper.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import datetime
 import io
 import json
 import logging
@@ -11,7 +12,7 @@ from contextlib import redirect_stdout
 from decimal import Decimal
 
 import pytest
-from freezegun import freeze_time
+import time_machine
 
 from singer_sdk._singerlib import Catalog
 from singer_sdk.exceptions import MapExpressionError
@@ -470,7 +471,10 @@ def _clear_schema_cache() -> None:
     get_selected_schema.cache_clear()
 
 
-@freeze_time("2022-01-01T00:00:00Z")
+@time_machine.travel(
+    datetime.datetime(2022, 1, 1, tzinfo=datetime.timezone.utc),
+    tick=False,
+)
 @pytest.mark.snapshot()
 @pytest.mark.usefixtures("_clear_schema_cache")
 @pytest.mark.parametrize(

--- a/tests/samples/test_tap_sqlite.py
+++ b/tests/samples/test_tap_sqlite.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import datetime
 import json
 import typing as t
 
 import pytest
+import time_machine
 from click.testing import CliRunner
-from freezegun import freeze_time
 
 from samples.sample_tap_sqlite import SQLiteTap
 from samples.sample_target_csv.csv_target import SampleTargetCSV
@@ -122,7 +123,10 @@ def test_sync_sqlite_to_csv(sqlite_sample_tap: SQLTap, tmp_path: Path):
 
 
 @pytest.fixture
-@freeze_time("2022-01-01T00:00:00Z")
+@time_machine.travel(
+    datetime.datetime(2022, 1, 1, tzinfo=datetime.timezone.utc),
+    tick=False,
+)
 def sqlite_sample_tap_state_messages(sqlite_sample_tap: SQLTap) -> list[dict]:
     stdout, _ = tap_sync_test(sqlite_sample_tap)
     state_messages = []

--- a/tests/samples/test_target_csv.py
+++ b/tests/samples/test_target_csv.py
@@ -1,6 +1,7 @@
 """Test tap-to-target sync."""
 from __future__ import annotations
 
+import datetime
 import json
 import shutil
 import typing as t
@@ -8,8 +9,8 @@ import uuid
 from pathlib import Path
 
 import pytest
+import time_machine
 from click.testing import CliRunner
-from freezegun import freeze_time
 
 from samples.sample_mapper.mapper import StreamTransform
 from samples.sample_tap_countries.countries_tap import SampleTapCountries
@@ -77,12 +78,33 @@ def test_target_batching():
 
     buf, _ = tap_sync_test(tap)
 
-    mocked_starttime = "2012-01-01 12:00:00"
-    mocked_jumptotime2 = "2012-01-01 12:31:00"
-    mocked_jumptotime3 = "2012-01-01 13:02:00"
+    mocked_starttime = datetime.datetime(
+        2012,
+        1,
+        1,
+        12,
+        0,
+        tzinfo=datetime.timezone.utc,
+    )
+    mocked_jumptotime2 = datetime.datetime(
+        2012,
+        1,
+        1,
+        12,
+        31,
+        tzinfo=datetime.timezone.utc,
+    )
+    mocked_jumptotime3 = datetime.datetime(
+        2012,
+        1,
+        1,
+        13,
+        2,
+        tzinfo=datetime.timezone.utc,
+    )
     countries_record_count = 257
 
-    with freeze_time(mocked_starttime):
+    with time_machine.travel(mocked_starttime, tick=False):
         target = TargetMock(config={})
         target.max_parallelism = 1  # Limit unit test to 1 process
         assert target.num_records_processed == 0
@@ -96,7 +118,7 @@ def test_target_batching():
         assert len(target.records_written) == 0  # Drain not yet called
         assert len(target.state_messages_written) == 0  # Drain not yet called
 
-    with freeze_time(mocked_jumptotime2):
+    with time_machine.travel(mocked_jumptotime2, tick=False):
         buf.seek(0)
         target_sync_test(target, buf, finalize=False)
 
@@ -105,7 +127,7 @@ def test_target_batching():
         assert len(target.records_written) == countries_record_count + 1
         assert len(target.state_messages_written) == 1
 
-    with freeze_time(mocked_jumptotime3):
+    with time_machine.travel(mocked_jumptotime3, tick=False):
         buf.seek(0)
         target_sync_test(target, buf, finalize=False)
 


### PR DESCRIPTION
| | [freezegun](https://pypi.org/project/freezegun/) | [time-machine](https://pypi.org/project/time-machine/) |
|-|-|-|
| Last released | Aug 12, 2022 | Sep 19, 2023 |
| Officially supported Python | 3.6 - 3.9 | 3.8 - 3.12 |


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--1997.org.readthedocs.build/en/1997/

<!-- readthedocs-preview meltano-sdk end -->
