### PR TITLE
fix: retry all 5xx status codes

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -149,7 +149,7 @@ class RESTStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):
     def validate_response(self, response: requests.Response) -> None:
         """Validate HTTP response.
 
-        Checks for error status codes and wether they are fatal or retriable.
+        Checks for error status codes and whether they are fatal or retriable.
 
         In case an error is deemed transient and can be safely retried, then this
         method should raise an :class:`singer_sdk.exceptions.RetriableAPIError`.

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -181,7 +181,6 @@ class RESTStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):
             response.status_code in self.extra_retry_statuses
             or HTTPStatus.INTERNAL_SERVER_ERROR
             <= response.status_code
-            <= max(HTTPStatus)
         ):
             msg = self.response_error_message(response)
             raise RetriableAPIError(msg, response)

--- a/tests/core/rest/test_backoff.py
+++ b/tests/core/rest/test_backoff.py
@@ -75,6 +75,14 @@ def custom_validation_stream(rest_tap):
             ),
         ),
         (
+            521,  # Cloudflare custom status code higher than max(HTTPStatus)
+            "Web Server Is Down",
+            pytest.raises(
+                RetriableAPIError,
+                match=r"521 Server Error: Web Server Is Down for path: /dummy",
+            ),
+        ),
+        (
             429,
             "Too Many Requests",
             pytest.raises(
@@ -84,7 +92,7 @@ def custom_validation_stream(rest_tap):
         ),
         (200, "OK", nullcontext()),
     ],
-    ids=["client-error", "server-error", "rate-limited", "ok"],
+    ids=["client-error", "server-error", "server-error", "rate-limited", "ok"],
 )
 def test_status_code_api(basic_rest_stream, status_code, reason, expectation):
     fake_response = requests.Response()


### PR DESCRIPTION
The documentation for the `validate_response` function states that 5xx error codes should raise a `RetriableAPIError`. 

However, because `max(HTTPStatus)` evaluates to 511, the current implementation does not raise the expected error for valid custom error codes such as Cloudflare's "521 Web Server Is Down".

This PR removes the cap on `RetriableAPIError` status codes so that valid custom error codes will raise the expected error.