### PR TITLE
fix: converting floats to decimals before schema validation

### DIFF
--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -6,6 +6,7 @@ import copy
 import datetime
 import logging
 import typing as t
+from decimal import Decimal
 from enum import Enum
 from functools import lru_cache
 
@@ -491,3 +492,15 @@ def _conform_primitive_property(  # noqa: PLR0911
     if is_boolean_type(property_schema):
         return None if elem is None else elem != 0
     return elem
+
+def float_to_decimal(value):
+    """
+    Walk the given data structure and turn all instances of float into double.
+    """
+    if isinstance(value, float):
+        return Decimal(str(value))
+    if isinstance(value, list):
+        return [float_to_decimal(child) for child in value]
+    if isinstance(value, dict):
+        return {k: float_to_decimal(v) for k, v in value.items()}
+    return value

--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -27,6 +27,7 @@ from singer_sdk.helpers._typing import (
     DatetimeErrorTreatmentEnum,
     get_datelike_property_type,
     handle_invalid_timestamp_in_record,
+    float_to_decimal,
 )
 
 if t.TYPE_CHECKING:
@@ -321,7 +322,7 @@ class Sink(metaclass=abc.ABCMeta):
         Returns:
             TODO
         """
-        self._validator.validate(record)
+        self._validator.validate(float_to_decimal(record))
         self._parse_timestamps_in_record(
             record=record,
             schema=self.schema,


### PR DESCRIPTION
Fixes a [known challenge](https://github.com/python-jsonschema/jsonschema/issues/185) with certain validations of floating points using JSON schema, by converting floats to decimals prior to validation. 

For example, this fixes errors like: 

```
ValidationError: 92.6 is not a multiple of 0.1
```

There is a relevant discussion here: https://gitlab.com/meltano/target-csv/-/issues/3

Certain targets (for example: [gupy-io/target-s3-parquet](https://github.com/gupy-io/target-s3-parquet)) rely on this project to do schema validation, so by handling this here, developers can continue to use that pattern while also avoiding these challenges with floating point validation. 

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--2041.org.readthedocs.build/en/2041/

<!-- readthedocs-preview meltano-sdk end -->