### PR TITLE
chore: Use Nox to run CodSpeed benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -12,9 +12,18 @@ on:
 jobs:
   benchmarks:
     runs-on: ubuntu-latest
+    env:
+      NOXSESSION: codspeed
     steps:
     - name: Check out the repository
       uses: actions/checkout@v4.1.1
+
+    - name: Install Poetry
+      env:
+        PIP_CONSTRAINT: .github/workflows/constraints.txt
+      run: |
+        pipx install poetry
+        poetry --version
 
     - name: Setup Python 3.11
       uses: actions/setup-python@v4.7.1
@@ -22,23 +31,19 @@ jobs:
         python-version: 3.11
         architecture: x64
 
-    - name: Install poetry
+    - name: Install Nox
+      env:
+        PIP_CONSTRAINT: .github/workflows/constraints.txt
       run: |
-        curl -fsS https://install.python-poetry.org | python - -y
+        pipx install nox
+        pipx inject nox nox-poetry
+        nox --version
 
-    - name: Configure poetry
-      run: poetry config virtualenvs.create false
-
-    - name: Install project
-      run: >
-        poetry install
-        -vvv
-        --with dev
-        --with benchmark
-        --all-extras
+    - name: Install dependencies
+      run: nox --install-only
 
     - name: Run benchmarks
       uses: CodSpeedHQ/action@v1
       with:
         token: ${{ secrets.CODSPEED_TOKEN }}
-        run: pytest tests/ --codspeed
+        run: nox --reuse-existing-virtualenvs --no-install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,8 +83,8 @@ jobs:
       env:
         PIP_CONSTRAINT: .github/workflows/constraints.txt
       run: |
-        pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-        pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
+        pipx install nox
+        pipx inject nox nox-poetry
         nox --version
 
     - name: Run Nox

--- a/noxfile.py
+++ b/noxfile.py
@@ -294,3 +294,12 @@ def version_bump(session: Session) -> None:
         "bump",
         *args,
     )
+
+
+@session(python=main_python_version)
+def codspeed(session: Session) -> None:
+    """Run codspeed benchmarks."""
+    session.install(".[s3]")
+    session.install(*test_dependencies)
+    session.install("pytest-codspeed")
+    session.run("pytest", "--codspeed")


### PR DESCRIPTION
See https://github.com/CodSpeedHQ/action/issues/81 and https://docs.codspeed.io/benchmarks/python#usage-with-nox


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--2049.org.readthedocs.build/en/2049/

<!-- readthedocs-preview meltano-sdk end -->