### PR TITLE
ci: Explicitly install `poetry-plugin-export` in CI environments that need exporting requirements

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,5 +1,6 @@
 pip==23.3.1
 poetry==1.7.1
+poetry-plugin-export==1.5.0
 pre-commit==3.5.0
 nox==2023.4.22
 nox-poetry==1.0.3

--- a/.github/workflows/cookiecutter-e2e.yml
+++ b/.github/workflows/cookiecutter-e2e.yml
@@ -38,9 +38,13 @@ jobs:
         pip --version
 
     - name: Install Poetry
+      env:
+        PIP_CONSTRAINT: .github/workflows/constraints.txt
       run: |
         pipx install poetry
+        pipx inject poetry poetry-plugin-export
         poetry --version
+        poetry self show plugins
 
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4.7.1
@@ -59,8 +63,8 @@ jobs:
       env:
         PIP_CONSTRAINT: .github/workflows/constraints.txt
       run: |
-        pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-        pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
+        pipx install nox
+        pipx inject nox nox-poetry
         nox --version
 
     - name: Run Nox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,9 @@ jobs:
         PIP_CONSTRAINT: .github/workflows/constraints.txt
       run: |
         pipx install poetry
+        pipx inject poetry poetry-plugin-export
         poetry --version
+        poetry self show plugins
 
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4.7.1
@@ -83,8 +85,8 @@ jobs:
       env:
         PIP_CONSTRAINT: .github/workflows/constraints.txt
       run: |
-        pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-        pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
+        pipx install nox
+        pipx inject nox nox-poetry
         nox --version
 
     - name: Run Nox
@@ -122,7 +124,9 @@ jobs:
         PIP_CONSTRAINT: .github/workflows/constraints.txt
       run: |
         pipx install poetry
+        pipx inject poetry poetry-plugin-export
         poetry --version
+        poetry self show plugins
 
     - name: Setup Python 3.10
       uses: actions/setup-python@v4.7.1
@@ -143,8 +147,8 @@ jobs:
       env:
         PIP_CONSTRAINT: .github/workflows/constraints.txt
       run: |
-        pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-        pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
+        pipx install nox
+        pipx inject nox nox-poetry
         nox --version
 
     - name: Run Nox
@@ -160,9 +164,13 @@ jobs:
       uses: actions/checkout@v4.1.1
 
     - name: Install Poetry
+      env:
+        PIP_CONSTRAINT: .github/workflows/constraints.txt
       run: |
-        pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
+        pipx install poetry
+        pipx inject poetry poetry-plugin-export
         poetry --version
+        poetry self show plugins
 
     - name: Set up Python
       uses: actions/setup-python@v4.7.1
@@ -185,8 +193,8 @@ jobs:
       env:
         PIP_CONSTRAINT: .github/workflows/constraints.txt
       run: |
-        pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-        pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
+        pipx install nox
+        pipx inject nox nox-poetry
         nox --version
 
     - name: Combine coverage data and display human readable report


### PR DESCRIPTION
> Therefore, **we are planning to not install `poetry-plugin-export` per default in a future version of Poetry**. To ensure that as many users as possible are informed about this upcoming change, a warning, which can be deactivated, will be shown when running `poetry export`. In order to make your automation forward-compatible, just install `poetry-plugin-export` explicitly (even though it is already installed per default for now).

https://python-poetry.org/blog/announcing-poetry-1.7.0/
