### PR TITLE
ci: Use Python 3.11 as the default Python version in CI jobs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -36,6 +36,7 @@ body:
         - "3.8"
         - "3.9"
         - "3.10"
+        - "3.11"
         - "NA"
     validations:
       required: true

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Check out the repository
       uses: actions/checkout@v4.1.1
 
-    - name: Setup Python 3.11
+    - name: Setup Python
       uses: actions/setup-python@v4.7.1
       with:
         python-version: 3.11

--- a/.github/workflows/cookiecutter-e2e.yml
+++ b/.github/workflows/cookiecutter-e2e.yml
@@ -3,10 +3,16 @@ name: E2E Cookiecutters
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths: ["cookiecutter/**", "e2e-tests/cookiecutters/**"]
+    paths:
+    - "cookiecutter/**"
+    - "e2e-tests/cookiecutters/**"
+    - ".github/workflows/cookiecutter-e2e.yml"
   push:
     branches: [main]
-    paths: ["cookiecutter/**", "e2e-tests/cookiecutters/**"]
+    paths:
+    - "cookiecutter/**"
+    - "e2e-tests/cookiecutters/**"
+    - ".github/workflows/cookiecutter-e2e.yml"
   workflow_dispatch:
 
 concurrency:
@@ -18,13 +24,13 @@ env:
 
 jobs:
   lint:
-    name: Cookiecutter E2E ${{ matrix.python-version }} ${{ matrix.python-version }} / ${{ matrix.os }}
+    name: Cookiecutter E2E Python ${{ matrix.python-version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
         include:
-          - { python-version: "3.10",  os: "ubuntu-latest" }
+          - { python-version: "3.11",  os: "ubuntu-latest" }
 
     steps:
     - name: Check out the repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4.7.1
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Upgrade pip
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,8 @@ jobs:
         sqlalchemy: ["2.*"]
         include:
         - { session: tests,   python-version: "3.11", os: "ubuntu-latest", sqlalchemy: "1.*" }
-        - { session: doctest, python-version: "3.10", os: "ubuntu-latest", sqlalchemy: "2.*" }
-        - { session: mypy,    python-version: "3.8",  os: "ubuntu-latest", sqlalchemy: "2.*" }
+        - { session: doctest, python-version: "3.11", os: "ubuntu-latest", sqlalchemy: "2.*" }
+        - { session: mypy,    python-version: "3.11",  os: "ubuntu-latest", sqlalchemy: "2.*" }
 
     steps:
     - name: Check out the repository
@@ -107,6 +107,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.head.repo.fork }}
     env:
+      NOXPYTHON: "3.11"
+      NOXSESSION: tests
       SAMPLE_TAP_GITLAB_AUTH_TOKEN: ${{ secrets.SAMPLE_TAP_GITLAB_AUTH_TOKEN }}
       SAMPLE_TAP_GITLAB_GROUP_IDS: ${{ secrets.SAMPLE_TAP_GITLAB_GROUP_IDS }}
       SAMPLE_TAP_GITLAB_PROJECT_IDS: ${{ secrets.SAMPLE_TAP_GITLAB_PROJECT_IDS }}
@@ -128,10 +130,10 @@ jobs:
         poetry --version
         poetry self show plugins
 
-    - name: Setup Python 3.10
+    - name: Setup Python
       uses: actions/setup-python@v4.7.1
       with:
-        python-version: '3.10'
+        python-version: ${{ env.NOXPYTHON }}
         architecture: x64
         cache: 'pip'
         cache-dependency-path: 'poetry.lock'
@@ -153,7 +155,7 @@ jobs:
 
     - name: Run Nox
       run: |
-        nox -s tests -p 3.10 -- -m "external"
+        nox -- -m "external"
 
   coverage:
     name: Coverage
@@ -175,7 +177,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4.7.1
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: 'pip'
         cache-dependency-path: 'poetry.lock'
 

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4.7.1
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         architecture: x64
 
     - name: Bump version

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,7 @@ COOKIECUTTER_REPLAY_FILES = list(Path("./e2e-tests/cookiecutters").glob("*.json"
 
 package = "singer_sdk"
 python_versions = ["3.11", "3.10", "3.9", "3.8", "3.7"]
-main_python_version = "3.10"
+main_python_version = "3.11"
 locations = "singer_sdk", "tests", "noxfile.py", "docs/conf.py"
 nox.options.sessions = (
     "mypy",


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--2062.org.readthedocs.build/en/2062/

<!-- readthedocs-preview meltano-sdk end -->