### PR TITLE
chore: Faster benchmarks

### DIFF
--- a/tests/core/sinks/test_validation.py
+++ b/tests/core/sinks/test_validation.py
@@ -75,7 +75,7 @@ def bench_record():
 
 def test_bench_parse_timestamps_in_record(benchmark, bench_sink, bench_record):
     """Run benchmark for Sink method _parse_timestamps_in_record."""
-    number_of_runs = 10000
+    number_of_runs = 1000
 
     sink: BatchSinkMock = bench_sink
 
@@ -90,7 +90,7 @@ def test_bench_parse_timestamps_in_record(benchmark, bench_sink, bench_record):
 
 def test_bench_validate_and_parse(benchmark, bench_sink, bench_record):
     """Run benchmark for Sink method _validate_and_parse."""
-    number_of_runs = 10000
+    number_of_runs = 1000
 
     sink: BatchSinkMock = bench_sink
 


### PR DESCRIPTION
Benchmark run time drops from ~9 to ~2 minutes.

cc @buzzcutnorman


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--2064.org.readthedocs.build/en/2064/

<!-- readthedocs-preview meltano-sdk end -->