### PR TITLE
fix(deps): Make a explicit dependency on `python-dateutil`

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -30,4 +30,4 @@ scopes:
   - mappers    # mappers only
   - templates  # cookiecutters
   - deps       # production dependencies
-  - deps-dev   # development depencencies (testing, linting, etc.)
+  - deps-dev   # development dependencies (testing, linting, etc.)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2859,5 +2859,5 @@ testing = ["pytest", "pytest-durations"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.7.1,<4"
-content-hash = "280428df7a49ec32c590d73983e15254a0e1467198f331c1d13817d1b9dfaabb"
+python-versions = ">=3.7.1"
+content-hash = "5826f57c487bb62b72324fe4a953ddcafa51a2e23c00f50eef5e2a571a75a7bc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ license = "Apache-2.0"
 "Youtube" = "https://www.youtube.com/meltano"
 
 [tool.poetry.dependencies]
-python = ">=3.7.1,<4"
-backoff = ">=2.0.0"
+python = ">=3.7.1"
+backoff = { version = ">=2.0.0", python = "<4" }
 backports-datetime-fromisoformat = { version = ">=2.0.1", python = "<3.11" }
 click = "~=8.0"
 cryptography = ">=3.4.6,<42.0.0"
@@ -53,10 +53,11 @@ jsonschema = [
     { version = ">=4.16.0,<4.18", python = "<3.8" },
     { version = ">=4.16.0", python = ">=3.8" },
 ]
-memoization = ">=0.3.2,<0.5.0"
+memoization = { version = ">=0.3.2,<0.5.0", python = "<4" }
 packaging = ">=23.1"
 pendulum = ">=2.1.0"
 PyJWT = "~=2.4"
+python-dateutil = "^2.8.2"
 python-dotenv = ">=0.20,<0.22"
 pytz = ">=2022.2.1,<2024.0.0"
 PyYAML = ">=6.0"


### PR DESCRIPTION
Currently we have a _transitive_ dependency on
[`python-dateutil`](https://github.com/dateutil/dateutil) via [`pendulum`](https://github.com/sdispater/pendulum).

We actually rely on direct calls to its API, so it's better to list it as an explicit dependency in order not to break more stuff than necessary if we ever remove the dependency on Pendulum.

<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--2076.org.readthedocs.build/en/2076/

<!-- readthedocs-preview meltano-sdk end -->