### PR TITLE
chore: Use `exclude_also` in coverage config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,8 +199,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-exclude_lines = [
-    "pragma: no cover",
+exclude_also = [
     "def __repr__",
     "raise AssertionError",
     "raise NotImplementedError",


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--2079.org.readthedocs.build/en/2079/

<!-- readthedocs-preview meltano-sdk end -->