### PR TITLE
refactor: Use `datetime.fromisoformat` in other places

### DIFF
--- a/samples/sample_tap_google_analytics/ga_tap_stream.py
+++ b/samples/sample_tap_google_analytics/ga_tap_stream.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
+import datetime
 import typing as t
 from pathlib import Path
-
-import pendulum
 
 from singer_sdk.authenticators import OAuthJWTAuthenticator
 from singer_sdk.streams import RESTStream
@@ -59,7 +58,7 @@ class SampleGoogleAnalyticsStream(RESTStream):
             request_def["dateRanges"] = [
                 {
                     "startDate": self.config.get("start_date"),
-                    "endDate": pendulum.now(tz="UTC"),
+                    "endDate": datetime.datetime.now(datetime.timezone.utc),
                 },
             ]
         return {"reportRequests": [request_def]}

--- a/singer_sdk/_singerlib/messages.py
+++ b/singer_sdk/_singerlib/messages.py
@@ -9,7 +9,11 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 
 import simplejson as json
-from dateutil.parser import parse
+
+if sys.version_info < (3, 11):
+    from backports.datetime_fromisoformat import MonkeyPatch
+
+    MonkeyPatch.patch_fromisoformat()
 
 
 class SingerMessageType(str, enum.Enum):
@@ -112,7 +116,9 @@ class RecordMessage(Message):
             stream=data["stream"],
             record=data["record"],
             version=data.get("version"),
-            time_extracted=parse(time_extracted) if time_extracted else None,
+            time_extracted=datetime.fromisoformat(time_extracted)
+            if time_extracted
+            else None,
         )
 
     def to_dict(self) -> dict[str, t.Any]:

--- a/singer_sdk/_singerlib/utils.py
+++ b/singer_sdk/_singerlib/utils.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import sys
 from datetime import datetime, timedelta
 
-import dateutil.parser
 import pytz
+
+if sys.version_info < (3, 11):
+    from backports.datetime_fromisoformat import MonkeyPatch
+
+    MonkeyPatch.patch_fromisoformat()
 
 DATETIME_FMT = "%04Y-%m-%dT%H:%M:%S.%fZ"
 DATETIME_FMT_SAFE = "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -26,7 +31,7 @@ def strptime_to_utc(dtimestr: str) -> datetime:
     Returns:
         A UTC datetime.datetime object
     """
-    d_object: datetime = dateutil.parser.parse(dtimestr)
+    d_object: datetime = datetime.fromisoformat(dtimestr)
     if d_object.tzinfo is None:
         return d_object.replace(tzinfo=pytz.UTC)
 

--- a/singer_sdk/testing/tap_tests.py
+++ b/singer_sdk/testing/tap_tests.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import typing as t
 import warnings
 
-from dateutil import parser
 from jsonschema import Draft7Validator
 
 import singer_sdk.helpers._typing as th
 from singer_sdk import Tap
+from singer_sdk.helpers._compat import datetime_fromisoformat
 
 from .templates import AttributeTestTemplate, StreamTestTemplate, TapTestTemplate
 
@@ -194,8 +194,8 @@ class AttributeIsDateTimeTest(AttributeTestTemplate):
         try:
             for v in self.non_null_attribute_values:
                 error_message = f"Unable to parse value ('{v}') with datetime parser."
-                assert parser.parse(v), error_message
-        except parser.ParserError as e:
+                assert datetime_fromisoformat(v), error_message
+        except ValueError as e:
             raise AssertionError(error_message) from e
 
     @classmethod


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--2092.org.readthedocs.build/en/2092/

<!-- readthedocs-preview meltano-sdk end -->