### PR TITLE
refactor(taps): Use `CursorResult.mappings()` in SQL streams

### DIFF
--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -213,7 +213,7 @@ class SQLStream(Stream, metaclass=abc.ABCMeta):
             query = query.limit(self.ABORT_AT_RECORD_COUNT + 1)
 
         with self.connector._connect() as conn:
-            for record in conn.execute(query).mappings().all():
+            for record in conn.execute(query).mappings():
                 # TODO: Standardize record mapping type
                 # https://github.com/meltano/sdk/issues/2096
                 transformed_record = self.post_process(dict(record))

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -215,7 +215,8 @@ class SQLStream(Stream, metaclass=abc.ABCMeta):
         with self.connector._connect() as conn:
             for record in conn.execute(query).mappings().all():
                 # TODO: Standardize record mapping type
-                transformed_record = self.post_process(record)  # type: ignore[arg-type]
+                # https://github.com/meltano/sdk/issues/2096
+                transformed_record = self.post_process(dict(record))
                 if transformed_record is None:
                     # Record filtered out during post_process()
                     continue

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -213,8 +213,9 @@ class SQLStream(Stream, metaclass=abc.ABCMeta):
             query = query.limit(self.ABORT_AT_RECORD_COUNT + 1)
 
         with self.connector._connect() as conn:
-            for record in conn.execute(query):
-                transformed_record = self.post_process(dict(record._mapping))
+            for record in conn.execute(query).mappings().all():
+                # TODO: Standardize record mapping type
+                transformed_record = self.post_process(record)  # type: ignore[arg-type]
                 if transformed_record is None:
                     # Record filtered out during post_process()
                     continue


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
:books: Documentation preview :books:: https://meltano-sdk--2095.org.readthedocs.build/en/2095/

<!-- readthedocs-preview meltano-sdk end -->