### PR TITLE
fix: Output JSONPath expression with match count message

### DIFF
--- a/singer_sdk/helpers/jsonpath.py
+++ b/singer_sdk/helpers/jsonpath.py
@@ -33,7 +33,7 @@ def extract_jsonpath(
     match: jsonpath_ng.DatumInContext
     matches = compiled_jsonpath.find(input)
 
-    logger.info("JSONPath matches: %d", len(matches))
+    logger.info("JSONPath %s match count: %d", expression, len(matches))
 
     for match in matches:
         yield match.value


### PR DESCRIPTION
Adding the expression to the jsonpath logging message can be helpful in determining whether the message refers to a "next page" jsonpath parsing call, or a "records" parsing call

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2118.org.readthedocs.build/en/2118/

<!-- readthedocs-preview meltano-sdk end -->