### PR TITLE
ci: Use Python 3.12 to compute benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
         architecture: x64
 
     - name: Install poetry


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2134.org.readthedocs.build/en/2134/

<!-- readthedocs-preview meltano-sdk end -->