### PR TITLE
fix: Fix pytest plugin declaration so it can be used without requiring declaration of `pytest_plugins`

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/tests/conftest.py
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/tests/conftest.py
@@ -1,3 +1,0 @@
-"""Test Configuration."""
-
-pytest_plugins = ("singer_sdk.testing.pytest_plugin",)

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/tests/conftest.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/tests/conftest.py
@@ -1,3 +1,0 @@
-"""Test Configuration."""
-
-pytest_plugins = ("singer_sdk.testing.pytest_plugin",)

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/tests/conftest.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/tests/conftest.py
@@ -1,3 +1,0 @@
-"""Test Configuration."""
-
-pytest_plugins = ("singer_sdk.testing.pytest_plugin",)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,13 +15,6 @@ The Meltano SDK test framework consists of 4 main components:
 ## Example Usage
 
 If you created your Tap/Target using the provided cookiecutter templates, you will find the following snippets in `tests/test_core.py`.
-You will also find a `conftest.py` file containing configuration of the SDK as a `pytest` plugin.
-This is required for tests to collect correctly:
-
-```python
-# register the singer_sdk pytest plugin
-pytest_plugins = ("singer_sdk.testing.pytest_plugin",)
-```
 
 ### Testing Taps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,8 +236,8 @@ style = "pep440"
 requires = ["poetry-core==1.8.1", "poetry-dynamic-versioning==1.2.0"]
 build-backend = "poetry_dynamic_versioning.backend"
 
-[tool.poetry.scripts]
-pytest11 = { reference = "singer_sdk:testing.pytest_plugin", extras = ["testing"], type = "console" }
+[tool.poetry.plugins."pytest11"]
+singer_testing = "singer_sdk.testing.pytest_plugin"
 
 [tool.poetry.plugins."singer_sdk.batch_encoders"]
 jsonl = "singer_sdk.contrib.batch_encoder_jsonl:JSONLinesBatcher"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,6 @@ if t.TYPE_CHECKING:
 
 SYSTEMS = {"linux", "darwin", "windows"}
 
-pytest_plugins = ("singer_sdk.testing.pytest_plugin",)
-
 
 def pytest_collection_modifyitems(config: Config, items: list[pytest.Item]):
     rootdir = pathlib.Path(config.rootdir)


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2158.org.readthedocs.build/en/2158/

<!-- readthedocs-preview meltano-sdk end -->