### PR TITLE
fix(templates): Ensure `.vscode` directory is included when requested in cookiecutters and avoid failing if it does not exist

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,10 @@ repos:
   rev: v4.5.0
   hooks:
   - id: check-json
+    exclude: |
+        (?x)^(
+            .*/launch.json
+        )$
   - id: check-toml
     exclude: |
         (?x)^(

--- a/cookiecutter/.gitignore
+++ b/cookiecutter/.gitignore
@@ -1,0 +1,2 @@
+# Include template VSCode directory
+!*/*/.vscode/

--- a/cookiecutter/tap-template/hooks/post_gen_project.py
+++ b/cookiecutter/tap-template/hooks/post_gen_project.py
@@ -28,4 +28,4 @@ if __name__ == "__main__":
         shutil.rmtree(".github")
 
     if "{{ cookiecutter.ide }}" != "VSCode":
-        shutil.rmtree(".vscode")
+        shutil.rmtree(".vscode", ignore_errors=True)

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
@@ -8,6 +8,10 @@ repos:
   rev: v4.5.0
   hooks:
   - id: check-json
+    exclude: |
+      (?x)^(
+        \.vscode/.*\.json
+      )$
   - id: check-toml
   - id: check-yaml
   - id: end-of-file-fixer
@@ -20,7 +24,7 @@ repos:
   - id: check-github-workflows
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.11
+  rev: v0.1.14
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.vscode/launch.json
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "{{ cookiecutter.tap_id }}",
+            "type": "python",
+            "request": "launch",
+            "cwd": "${workspaceFolder}",
+            "program": "{{ cookiecutter.library_name }}",
+            "justMyCode": false,
+            "args": [
+                "--config",
+                ".secrets/config.json",
+            ],
+        },
+    ]
+}


### PR DESCRIPTION
Closes https://github.com/meltano/sdk/issues/2182


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2183.org.readthedocs.build/en/2183/

<!-- readthedocs-preview meltano-sdk end -->