### PR TITLE
docs: Call out minimum recommended `cookiecutter` version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,7 +117,12 @@ html_css_files = [
     "css/custom.css",
 ]
 
+# -- Options for MyST --------------------------------------------------------
+# https://myst-parser.readthedocs.io/en/latest/configuration.html
 myst_heading_anchors = 3
+myst_enable_extensions = {
+    "colon_fence",
+}
 
 redirects = {
     "porting.html": "guides/porting.html",

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -55,6 +55,10 @@ pipx install poetry
 pipx install tox
 ```
 
+:::{tip}
+The minimum recommended version of cookiecutter is `2.2.0` (released 2023-07-06).
+:::
+
 Now you can initialize your new project with the Cookiecutter template for taps:
 
 ```bash


### PR DESCRIPTION
See https://github.com/meltano/sdk/issues/2182#issuecomment-1912321145


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2186.org.readthedocs.build/en/2186/

<!-- readthedocs-preview meltano-sdk end -->