### PR TITLE
refactor: Use `functools.lru_cache` instead of the stale `memoization` library (#1981)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1060,16 +1060,6 @@ files = [
 ]
 
 [[package]]
-name = "memoization"
-version = "0.4.0"
-description = "A powerful caching library for Python, with TTL support and multiple algorithm options. (https://github.com/lonelyenvoy/python-memoization)"
-optional = false
-python-versions = ">=3, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
-files = [
-    {file = "memoization-0.4.0.tar.gz", hash = "sha256:fde5e7cd060ef45b135e0310cfec17b2029dc472ccb5bbbbb42a503d4538a135"},
-]
-
-[[package]]
 name = "mypy"
 version = "1.8.0"
 description = "Optional static typing for Python"
@@ -2620,4 +2610,4 @@ testing = ["pytest", "pytest-durations"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "3308a0e70f8f097b0a678989aa8d25133ff05e8d9ea37232d739a9664b05f361"
+content-hash = "d4e6a793a168c7440918376ba46cf015de7cd633d0f957dfc244db89f81b85d8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ inflection = ">=0.5.1"
 joblib = ">=1.0.1"
 jsonpath-ng = ">=1.5.3"
 jsonschema = ">=4.16.0"
-memoization = { version = ">=0.3.2,<0.5.0", python = "<4" }
 packaging = ">=23.1"
 pendulum = ">=2.1.0,<4"
 PyJWT = "~=2.4"

--- a/singer_sdk/helpers/_catalog.py
+++ b/singer_sdk/helpers/_catalog.py
@@ -5,17 +5,17 @@ from __future__ import annotations
 import typing as t
 from copy import deepcopy
 
-from memoization import cached
-
 from singer_sdk.helpers._typing import is_object_type
 
 if t.TYPE_CHECKING:
     from singer_sdk._singerlib import Catalog, SelectionMask
 
-_MAX_LRU_CACHE = 500
 
-
-@cached(max_size=_MAX_LRU_CACHE)
+# TODO: this was previously cached using the `memoization` library. However, the
+# `functools.lru_cache` decorator does not support non-hashable arguments.
+# It is possible that this function is not a bottleneck, but if it is, we should
+# consider implementing a custom LRU cache decorator that supports non-hashable
+# arguments.
 def get_selected_schema(
     stream_name: str,
     schema: dict,

--- a/singer_sdk/helpers/jsonpath.py
+++ b/singer_sdk/helpers/jsonpath.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import logging
 import typing as t
+from functools import lru_cache
 
-import memoization
 from jsonpath_ng.ext import parse
 
 if t.TYPE_CHECKING:
@@ -39,7 +39,7 @@ def extract_jsonpath(
         yield match.value
 
 
-@memoization.cached
+@lru_cache
 def _compile_jsonpath(expression: str) -> jsonpath_ng.JSONPath:
     """Parse a JSONPath expression and cache the result.
 

--- a/tests/core/rest/conftest.py
+++ b/tests/core/rest/conftest.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import typing as t
+from functools import cached_property
 
 import pytest
-from memoization.memoization import cached
 from requests.auth import HTTPProxyAuth
 
 from singer_sdk.authenticators import APIAuthenticatorBase, SingletonMeta
@@ -49,8 +49,7 @@ class NaiveAuthenticator(APIAuthenticatorBase):
 class CachedAuthStream(SimpleRESTStream):
     """A stream with Naive authentication."""
 
-    @property
-    @cached
+    @cached_property
     def authenticator(self) -> NaiveAuthenticator:
         """Stream authenticator."""
         return NaiveAuthenticator(stream=self)

--- a/tests/core/test_mapper.py
+++ b/tests/core/test_mapper.py
@@ -16,7 +16,6 @@ import time_machine
 
 from singer_sdk._singerlib import Catalog
 from singer_sdk.exceptions import MapExpressionError
-from singer_sdk.helpers._catalog import get_selected_schema
 from singer_sdk.mapper import PluginMapper, RemoveRecordTransform, md5
 from singer_sdk.streams.core import Stream
 from singer_sdk.tap_base import Tap
@@ -563,19 +562,11 @@ class MappedTap(Tap):
         return [MappedStream(self)]
 
 
-@pytest.fixture
-def _clear_schema_cache() -> None:
-    """Schemas are cached, so the cache needs to be cleared between test invocations."""
-    yield
-    get_selected_schema.cache_clear()
-
-
 @time_machine.travel(
     datetime.datetime(2022, 1, 1, tzinfo=datetime.timezone.utc),
     tick=False,
 )
 @pytest.mark.snapshot()
-@pytest.mark.usefixtures("_clear_schema_cache")
 @pytest.mark.parametrize(
     "stream_maps,flatten,flatten_max_depth,snapshot_name",
     [


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2189.org.readthedocs.build/en/2189/

<!-- readthedocs-preview meltano-sdk end -->