### PR TITLE
fix(templates): Include empty `schemas` directory in REST tap cookiecutter

### DIFF
--- a/cookiecutter/tap-template/hooks/post_gen_project.py
+++ b/cookiecutter/tap-template/hooks/post_gen_project.py
@@ -15,6 +15,9 @@ if __name__ == "__main__":
     for client_py in PACKAGE_PATH.rglob("*-client.py"):
         client_py.unlink()
 
+    if "{{ cookiecutter.stream_type }}" != "REST":
+        shutil.rmtree(PACKAGE_PATH.joinpath("schemas"), ignore_errors=True)
+
     if "{{ cookiecutter.auth_method }}" not in ("OAuth2", "JWT"):
         PACKAGE_PATH.joinpath("auth.py").unlink()
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/schemas/__init__.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""JSON schema files for the REST API."""


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2195.org.readthedocs.build/en/2195/

<!-- readthedocs-preview meltano-sdk end -->