### PR TITLE
fix(targets): Quote column names in INSERT statement

### DIFF
--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -283,7 +283,7 @@ class SQLSink(BatchSink):
         statement = dedent(
             f"""\
             INSERT INTO {full_table_name}
-            ({", ".join(quoted_name(name) for name in property_names)})
+            ({", ".join(quoted_name(name, True) for name in property_names)})
             VALUES ({", ".join([f":{name}" for name in property_names])})
             """,  # noqa: S608
         )

--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 
 import sqlalchemy as sa
 from pendulum import now
+from sqlalchemy.sql import quoted_name
 from sqlalchemy.sql.expression import bindparam
 
 from singer_sdk.connectors import SQLConnector
@@ -282,7 +283,7 @@ class SQLSink(BatchSink):
         statement = dedent(
             f"""\
             INSERT INTO {full_table_name}
-            ({", ".join([f'"{name}"' for name in property_names])})
+            ({", ".join(quoted_name(name) for name in property_names)})
             VALUES ({", ".join([f":{name}" for name in property_names])})
             """,  # noqa: S608
         )

--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -282,7 +282,7 @@ class SQLSink(BatchSink):
         statement = dedent(
             f"""\
             INSERT INTO {full_table_name}
-            ({", ".join(property_names)})
+            ({", ".join([f'"{name}"' for name in property_names])})
             VALUES ({", ".join([f":{name}" for name in property_names])})
             """,  # noqa: S608
         )

--- a/tests/samples/test_target_sqlite.py
+++ b/tests/samples/test_target_sqlite.py
@@ -490,7 +490,7 @@ def test_record_with_missing_properties(
             dedent(
                 """\
                 INSERT INTO test_stream
-                (id, name)
+                ("id", "name")
                 VALUES (:id, :name)""",
             ),
         ),


### PR DESCRIPTION
This is an update to fix how the insert into statements are being generated. If you have a source column that uses a reserved word then invalid SQL was being generated. 

Previous:
```sql
INSERT INTO analytics.foo
(id, in)
VALUES (:id, :in)
```

Updated:
```sql
INSERT INTO analytics.foo
("id", "in")
VALUES (:id, :in)
```

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2198.org.readthedocs.build/en/2198/

<!-- readthedocs-preview meltano-sdk end -->