### PR TITLE
fix(targets): Quote column names in INSERT statement

### DIFF
--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -283,7 +283,7 @@ class SQLSink(BatchSink):
         statement = dedent(
             f"""\
             INSERT INTO {full_table_name}
-            ({", ".join(quoted_name(name) for name in property_names)})
+            ({", ".join(quoted_name(name, True) for name in property_names)})
             VALUES ({", ".join([f":{name}" for name in property_names])})
             """,  # noqa: S608
         )

--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -280,10 +280,14 @@ class SQLSink(BatchSink):
             An insert statement.
         """
         property_names = list(self.conform_schema(schema)["properties"].keys())
+        column_identifiers = [
+            self.connector.quote(quoted_name(name, quote=True))
+            for name in property_names
+        ]
         statement = dedent(
             f"""\
             INSERT INTO {full_table_name}
-            ({", ".join(quoted_name(name, True) for name in property_names)})
+            ({", ".join(column_identifiers)})
             VALUES ({", ".join([f":{name}" for name in property_names])})
             """,  # noqa: S608
         )

--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 
 import sqlalchemy as sa
 from pendulum import now
+from sqlalchemy.sql import quoted_name
 from sqlalchemy.sql.expression import bindparam
 
 from singer_sdk.connectors import SQLConnector
@@ -282,7 +283,7 @@ class SQLSink(BatchSink):
         statement = dedent(
             f"""\
             INSERT INTO {full_table_name}
-            ({", ".join([f'"{name}"' for name in property_names])})
+            ({", ".join(quoted_name(name) for name in property_names)})
             VALUES ({", ".join([f":{name}" for name in property_names])})
             """,  # noqa: S608
         )

--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -282,7 +282,7 @@ class SQLSink(BatchSink):
         statement = dedent(
             f"""\
             INSERT INTO {full_table_name}
-            ({", ".join(property_names)})
+            ({", ".join([f'"{name}"' for name in property_names])})
             VALUES ({", ".join([f":{name}" for name in property_names])})
             """,  # noqa: S608
         )

--- a/tests/samples/test_target_sqlite.py
+++ b/tests/samples/test_target_sqlite.py
@@ -484,14 +484,15 @@ def test_record_with_missing_properties(
                 "properties": {
                     "id": {"type": "integer"},
                     "name": {"type": "string"},
+                    "table": {"type": "string"},
                 },
             },
             [],
             dedent(
                 """\
                 INSERT INTO test_stream
-                ("id", "name")
-                VALUES (:id, :name)""",
+                (id, name, "table")
+                VALUES (:id, :name, :table)""",
             ),
         ),
     ],

--- a/tests/samples/test_target_sqlite.py
+++ b/tests/samples/test_target_sqlite.py
@@ -490,7 +490,7 @@ def test_record_with_missing_properties(
             dedent(
                 """\
                 INSERT INTO test_stream
-                (id, name)
+                ("id", "name")
                 VALUES (:id, :name)""",
             ),
         ),


### PR DESCRIPTION
- Update sql.py
- Mattwill09 patch 1 (#1)
- Update singer_sdk/sinks/sql.py
- Use IdentifierPreparer


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2200.org.readthedocs.build/en/2200/

<!-- readthedocs-preview meltano-sdk end -->