### PR TITLE
docs: Added an example implemetation of JSON schema validation that uses `fastjsonschema`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -42,6 +42,7 @@ test_dependencies = [
     "coverage[toml]",
     "duckdb",
     "duckdb-engine",
+    "fastjsonschema",
     "pyarrow",
     "pytest",
     "pytest-benchmark",

--- a/poetry.lock
+++ b/poetry.lock
@@ -635,6 +635,20 @@ python-dateutil = ">=2.4"
 typing-extensions = {version = ">=3.10.0.1", markers = "python_version <= \"3.8\""}
 
 [[package]]
+name = "fastjsonschema"
+version = "2.19.1"
+description = "Fastest Python implementation of JSON schema"
+optional = false
+python-versions = "*"
+files = [
+    {file = "fastjsonschema-2.19.1-py3-none-any.whl", hash = "sha256:3672b47bc94178c9f23dbb654bf47440155d4db9df5f7bc47643315f9c405cd0"},
+    {file = "fastjsonschema-2.19.1.tar.gz", hash = "sha256:e3126a94bdc4623d3de4485f8d468a12f02a67921315ddc87836d6e456dc789d"},
+]
+
+[package.extras]
+devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benchmark", "pytest-cache", "validictory"]
+
+[[package]]
 name = "filelock"
 version = "3.12.4"
 description = "A platform independent file lock."
@@ -2635,4 +2649,4 @@ testing = ["pytest", "pytest-durations"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "e9747e01321a2fd07fb58447bced9656dca2b3602f9b124a9fbd68792c47c30b"
+content-hash = "37a0fb5f11f53814739deaf7ba08ded83d345087110b1dae7c5b7956f27a3a51"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ coverage = {extras = ["toml"], version = ">=7.4"}
 duckdb = { version = ">=0.8.0", python = "<3.12" }
 duckdb-engine = { version = ">=0.9.4", python = "<3.12" }
 
+fastjsonschema = ">=2.19.1"
 mypy = ">=1.0"
 pytest-benchmark = ">=4.0.0"
 pytest-snapshot = ">=0.9.0"

--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -201,6 +201,31 @@ class Sink(metaclass=abc.ABCMeta):
 
         Returns:
             An instance of a subclass of ``BaseJSONSchemaValidator``.
+
+        Example implementation using the `fastjsonschema`_ library:
+
+        .. code-block:: python
+
+           import fastjsonschema
+
+
+           class FastJSONSchemaValidator(BaseJSONSchemaValidator):
+               def __init__(self, schema: dict[str, t.Any]) -> None:
+                   super().__init__(schema)
+                   try:
+                       self.validator = fastjsonschema.compile(self.schema)
+                   except fastjsonschema.JsonSchemaDefinitionException as e:
+                       error_message = "Schema Validation Error"
+                       raise InvalidJSONSchema(error_message) from e
+
+               def validate(self, record: dict):
+                   try:
+                       self.validator(record)
+                   except fastjsonschema.JsonSchemaValueException as e:
+                       error_message = f"Record Message Validation Error: {e.message}"
+                       raise InvalidRecord(error_message, record) from e
+
+        .. _fastjsonschema: https://pypi.org/project/fastjsonschema/
         """
         if self.validate_schema:
             return JSONSchemaValidator(


### PR DESCRIPTION
Supersedes https://github.com/meltano/sdk/pull/2066

Co-authored-by: Dan Norman <buzzcutnorman@gmail.com>


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2231.org.readthedocs.build/en/2231/

<!-- readthedocs-preview meltano-sdk end -->