### PR TITLE
fix(templates): Test workflow job now fails for unsupported Python versions in cookiecutter templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on: [push]
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    continue-on-error: true
     env:
       GITHUB_TOKEN: {{ '${{secrets.GITHUB_TOKEN}}' }}
     strategy:

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         pip install poetry
     - name: Install dependencies
       run: |
+        poetry env use {{ '${{ matrix.python-version }}' }}
         poetry install
     - name: Test with pytest
       run: |

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on: [push]
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    continue-on-error: true
     env:
       GITHUB_TOKEN: {{ '${{secrets.GITHUB_TOKEN}}' }}
     strategy:

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         pip install poetry
     - name: Install dependencies
       run: |
+        poetry env use {{ '${{ matrix.python-version }}' }}
         poetry install
     - name: Test with pytest
       run: |

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on: [push]
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    continue-on-error: true
     env:
       GITHUB_TOKEN: {{ '${{secrets.GITHUB_TOKEN}}' }}
     strategy:

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         pip install poetry
     - name: Install dependencies
       run: |
+        poetry env use {{ '${{ matrix.python-version }}' }}
         poetry install
     - name: Test with pytest
       run: |


### PR DESCRIPTION
Closes #2223

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2232.org.readthedocs.build/en/2232/

<!-- readthedocs-preview meltano-sdk end -->