### PR TITLE
fix(taps): Hard and soft deletes for handling `ACTIVATE_VERSION` messages now use the same `WHERE` clause 

### DIFF
--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -1212,6 +1212,6 @@ class SQLConnector:
             conn.execute(
                 sa.text(
                     f"DELETE FROM {full_table_name} "  # noqa: S608
-                    f"WHERE {version_column_name} <= {current_version}",
+                    f"WHERE {version_column_name} < {current_version}",
                 ),
             )


### PR DESCRIPTION
Soft delete is deleting only versions smaller than the latest version .
Hard delete is deleting smaller and equal.
Making both strategies delete only smaller versions.

fixes https://github.com/meltano/sdk/issues/2227

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2242.org.readthedocs.build/en/2242/

<!-- readthedocs-preview meltano-sdk end -->