### PR TITLE
fix: Null type is now correctly appended as `{"type": "null"}` to `oneOf` types

### DIFF
--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -60,7 +60,7 @@ def append_type(type_dict: dict, new_type: str) -> dict:
         return result
 
     if "oneOf" in result:
-        result["oneOf"].append(new_type)
+        result["oneOf"].append({"type": new_type})
         return result
 
     if "type" in result:

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -341,7 +341,7 @@ def test_to_sql_type(jsonschema_type, expected):
         ),
         pytest.param(
             {"oneOf": [{"type": "integer"}, {"type": "number"}]},
-            {"oneOf": [{"type": "integer"}, {"type": "number"}, "null"]},
+            {"oneOf": [{"type": "integer"}, {"type": "number"}, {"type": "null"}]},
             id="oneOf",
         ),
     ],


### PR DESCRIPTION
This was causing config validation failures in `meltano-map-transform`: https://github.com/MeltanoLabs/meltano-map-transform/actions/runs/7962941688/job/21737507548?pr=221