### PR TITLE
fix(templates): Test workflow now fails for any Python matrix job failure in cookiecutter template

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
@@ -8,10 +8,10 @@ on: [push]
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       GITHUB_TOKEN: {{ '${{secrets.GITHUB_TOKEN}}' }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
@@ -8,10 +8,10 @@ on: [push]
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       GITHUB_TOKEN: {{ '${{secrets.GITHUB_TOKEN}}' }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
@@ -8,10 +8,10 @@ on: [push]
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       GITHUB_TOKEN: {{ '${{secrets.GITHUB_TOKEN}}' }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:


### PR DESCRIPTION
Follow-up from #2232 

---

The current test workflow configuration for the `pytest` job uses `continue-on-error: true`, meaning that when any matrix job (i.e. test run for a specific Python version) fails, the workflow itself still shows as passing - for example: https://github.com/Matatika/tap-spotify/actions/runs/8089702498

[`fail-fast: false`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) is what should have been implemented initially (sorry, still fairly new to GitHub Actions) - for example: https://github.com/Matatika/tap-spotify/actions/runs/8089862693

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2274.org.readthedocs.build/en/2274/

<!-- readthedocs-preview meltano-sdk end -->