### PR TITLE
fix: The `state_partition_context` dictionary is now correctly interpolated in the error message when duplicate partitions/contexts are detected in the input state

### DIFF
--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -80,7 +80,7 @@ def _find_in_partitions_list(
     if len(found) > 1:
         msg = (
             "State file contains duplicate entries for partition: "
-            f"{{state_partition_context}}.\nMatching state values were: {found!s}"
+            f"{state_partition_context}.\nMatching state values were: {found!s}"
         )
         raise ValueError(msg)
     return found[0] if found else None


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2281.org.readthedocs.build/en/2281/

<!-- readthedocs-preview meltano-sdk end -->