### PR TITLE
chore(deps): Unpin `commitizen` to use latest patch in version bump

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -61,9 +61,6 @@ jobs:
         github_token: ${{ secrets.MELTYBOT_GITHUB_AUTH_TOKEN }}
         extra_requirements: 'git+https://github.com/meltano/commitizen-version-bump@main'
         changelog_increment_filename: _changelog_fragment.md
-        # TODO: Remove this constraint once the issue is fixed
-        # https://github.com/commitizen-tools/commitizen/issues/1024
-        commitizen_version: "3.18.0"
 
     - name: Add job summary
       run: |


### PR DESCRIPTION
It was patched in https://github.com/commitizen-tools/commitizen/pull/1026

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2317.org.readthedocs.build/en/2317/

<!-- readthedocs-preview meltano-sdk end -->