### PR TITLE
docs: Documented `BATCH` as a default plugin capability

### DIFF
--- a/docs/capabilities.rst
+++ b/docs/capabilities.rst
@@ -12,6 +12,7 @@ Built-in base capabilities
 The following capabilities are supported by default.
 
 .. autoattribute:: PluginCapabilities.ABOUT
+.. autoattribute:: PluginCapabilities.BATCH
 .. autoattribute:: PluginCapabilities.STREAM_MAPS
 
 ========================
@@ -21,7 +22,6 @@ Custom base capabilities
 The following capabilities have to be implemented in the plugin.
 
 .. autoattribute:: PluginCapabilities.ACTIVATE_VERSION
-.. autoattribute:: PluginCapabilities.BATCH
 
 Tap Capabilities
 ----------------


### PR DESCRIPTION
> Is it enough that a tap is built with the SDK for it to support batched files (i.e. `batch` capability)? [These docs](https://sdk.meltano.com/en/latest/capabilities.html#singer_sdk.helpers.capabilities.PluginCapabilities.BATCH) seem to suggest it requires an implementation, but the SDK reports it as a supported capability with `--about`...

https://meltano.slack.com/archives/C068YBV6KEK/p1710531278261849

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2326.org.readthedocs.build/en/2326/

<!-- readthedocs-preview meltano-sdk end -->