### PR TITLE
fix: Restore test runner class-level attributes

### DIFF
--- a/singer_sdk/testing/runners.py
+++ b/singer_sdk/testing/runners.py
@@ -21,6 +21,12 @@ if t.TYPE_CHECKING:
 class SingerTestRunner(metaclass=abc.ABCMeta):
     """Base Singer Test Runner."""
 
+    raw_messages: list[dict] = []  # noqa: RUF012
+    schema_messages: list[dict] = []  # noqa: RUF012
+    record_messages: list[dict] = []  # noqa: RUF012
+    state_messages: list[dict] = []  # noqa: RUF012
+    records: defaultdict = defaultdict(list)  # noqa: RUF012
+
     def __init__(
         self,
         singer_class: type[Tap] | type[Target],
@@ -41,12 +47,6 @@ class SingerTestRunner(metaclass=abc.ABCMeta):
         self.config = config or {}
         self.default_kwargs = kwargs
         self.suite_config = suite_config or SuiteConfig()
-
-        self.raw_messages: list[dict] = []
-        self.schema_messages: list[dict] = []
-        self.record_messages: list[dict] = []
-        self.state_messages: list[dict] = []
-        self.records: defaultdict = defaultdict(list)
 
     @staticmethod
     def _clean_sync_output(raw_records: str) -> list[dict]:


### PR DESCRIPTION
Introduced by https://github.com/meltano/sdk/pull/1832

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2334.org.readthedocs.build/en/2334/

<!-- readthedocs-preview meltano-sdk end -->