### PR TITLE
fix(templates): Avoid failing if VSCode IDE config is not requested for target and mapper cookiecutter templates

### DIFF
--- a/cookiecutter/mapper-template/hooks/post_gen_project.py
+++ b/cookiecutter/mapper-template/hooks/post_gen_project.py
@@ -14,4 +14,4 @@ if __name__ == "__main__":
         shutil.rmtree(Path(".github"))
 
     if "{{ cookiecutter.ide }}" != "VSCode":
-        shutil.rmtree(".vscode")
+        shutil.rmtree(".vscode", ignore_errors=True)

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
@@ -8,6 +8,10 @@ repos:
   rev: v4.5.0
   hooks:
   - id: check-json
+    exclude: |
+      (?x)^(
+          .*/launch.json
+      )$
   - id: check-toml
   - id: check-yaml
   - id: end-of-file-fixer

--- a/cookiecutter/target-template/hooks/post_gen_project.py
+++ b/cookiecutter/target-template/hooks/post_gen_project.py
@@ -14,4 +14,4 @@ if __name__ == "__main__":
         shutil.rmtree(Path(".github"))
 
     if "{{ cookiecutter.ide }}" != "VSCode":
-        shutil.rmtree(".vscode")
+        shutil.rmtree(".vscode", ignore_errors=True)

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
@@ -8,6 +8,10 @@ repos:
   rev: v4.5.0
   hooks:
   - id: check-json
+    exclude: |
+        (?x)^(
+            .*/launch.json
+        )$
   - id: check-toml
   - id: check-yaml
   - id: end-of-file-fixer


### PR DESCRIPTION
Related to #2182 and #2183

These templates currently do not have a `.vscode` directory, and so when VSCode IDE config is not requested (i.e. `2 - None` option) the post generate project hook fails trying to remove a directory that doesn't exist:

```
FileNotFoundError: [Errno 2] No such file or directory: '.vscode'
ERROR: Stopping generation because post_gen_project hook script didn't exit successfully
```

This PR simply ignores that error for target and mapper templates, should it occur. I haven't added any VSCode config (e.g. `launch.json`) as it's probably not gonna be the same as the tap template (in hindsight, I might have been a bit quick to exclude `launch.json` from the `check-json` pre-commit hook).