### PR TITLE
feat: `PropertiesList` can now behave as an iterable

### DIFF
--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -1018,7 +1018,11 @@ class PropertiesList(ObjectType):
         self.wrapped[property.name] = property
 
     def __iter__(self) -> t.Iterator[Property]:
-        """Iterate all properties of the property list."""
+        """Iterate all properties of the property list.
+
+        Returns:
+            Iterator of properties.
+        """
         return self.wrapped.values().__iter__()
 
 

--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -1017,6 +1017,10 @@ class PropertiesList(ObjectType):
         """
         self.wrapped[property.name] = property
 
+    def __iter__(self) -> t.Iterator[Property]:
+        """Iterate all properties of the property list."""
+        return self.wrapped.values().__iter__()
+
 
 def to_jsonschema_type(
     from_type: str | sa.types.TypeEngine | type[sa.types.TypeEngine],

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -349,3 +349,15 @@ def test_to_sql_type(jsonschema_type, expected):
 def test_append_null(type_dict: dict, expected: dict):
     result = append_type(type_dict, "null")
     assert result == expected
+
+
+def test_iterate_properties_list():
+    primitive_property = Property("primitive", BooleanType)
+    object_property = Property("object", PropertiesList(Property("value", BooleanType)))
+    list_property = Property("list", ArrayType(BooleanType))
+
+    properties_list = PropertiesList(primitive_property, object_property, list_property)
+
+    assert primitive_property in properties_list
+    assert object_property in properties_list
+    assert list_property in properties_list


### PR DESCRIPTION
In `tap-spotify`, all schema objects inherit from [a `CustomObject` class](https://github.com/Matatika/tap-spotify/blob/a816614ef79d94de8f96948df3cc81ad3e4656f6/tap_spotify/schemas/utils/custom_object.py) that offers some convenience methods, including allowing [one custom object to extend others](https://github.com/Matatika/tap-spotify/blob/master/tap_spotify/streams.py#L125) in order to produce a merged schema. The reason this class exists was because at the time there wasn't an obvious way to merge two or more property lists together, but I think its a pretty simple addition to get the functionality natively.

Given that, for example, [`Rank`](https://github.com/Matatika/tap-spotify/blob/a816614ef79d94de8f96948df3cc81ad3e4656f6/tap_spotify/schemas/utils/rank.py), [`SyncedAt`](https://github.com/Matatika/tap-spotify/blob/a816614ef79d94de8f96948df3cc81ad3e4656f6/tap_spotify/schemas/utils/synced_at.py), [`Track`](https://github.com/Matatika/tap-spotify/blob/a816614ef79d94de8f96948df3cc81ad3e4656f6/tap_spotify/schemas/track.py) and [`AudioFeatures`](https://github.com/Matatika/tap-spotify/blob/a816614ef79d94de8f96948df3cc81ad3e4656f6/tap_spotify/schemas/audio_features.py) are no longer classes extending `CustomObject` and instead are just `PropertiesList` instances

`track.py`
```py
"""Schema definitions for track objects."""

from singer_sdk import typing as th

from tap_spotify.schemas.album import AlbumObject
from tap_spotify.schemas.artist import ArtistObject
from tap_spotify.schemas.external import ExternalIdObject, ExternalUrlObject
from tap_spotify.schemas.restriction import RestrictionObject as TrackRestrictionObject


TrackObject = th.PropertiesList(
    th.Property("album", AlbumObject),
    th.Property("artists", th.ArrayType(ArtistObject)),
    th.Property("available_markets", th.ArrayType(th.StringType)),
    th.Property("disc_number", th.IntegerType),
    th.Property("duration_ms", th.IntegerType),
    th.Property("explicit", th.BooleanType),
    th.Property("external_ids", ExternalIdObject()),
    th.Property("external_urls", ExternalUrlObject),
    th.Property("href", th.StringType),
    th.Property("id", th.StringType),
    th.Property("is_local", th.BooleanType),
    th.Property("is_playable", th.BooleanType),
    # th.Property("linked_from", TrackObject),  # noqa: ERA001
    th.Property("name", th.StringType),
    th.Property("popularity", th.IntegerType),
    th.Property("preview_url", th.StringType),
    th.Property("restrictions", TrackRestrictionObject),
    th.Property("track_number", th.IntegerType),
    th.Property("type", th.StringType),
    th.Property("uri", th.StringType),
)
```

then

```py
schema = TrackObject.extend_with(Rank, SyncedAt, AudioFeaturesObject).schema
```

becomes

```py
schema = th.PropertiesList(*TrackObject, *Rank, *SyncedAt, *AudioFeaturesObject).to_dict()
```

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2345.org.readthedocs.build/en/2345/

<!-- readthedocs-preview meltano-sdk end -->