### PR TITLE
feat: Settings write-back

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,6 +152,7 @@ extlinks = {
 # -- Options for intersphinx -----------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration
 intersphinx_mapping = {
+    "blinker": ("https://blinker.readthedocs.io/en/stable/", None),
     "requests": ("https://requests.readthedocs.io/en/latest/", None),
     "python": ("https://docs.python.org/3/", None),
 }

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -8,4 +8,5 @@ The following pages contain useful information for developers building on top of
 porting
 pagination-classes
 custom-clis
+signals
 ```

--- a/docs/guides/signals.md
+++ b/docs/guides/signals.md
@@ -1,0 +1,49 @@
+# Signals
+
+This guide will show you how to use the built-in [Blinker](inv:blinker:std:doc#index) signals in the Singer SDK.
+
+## Settings write-back
+
+The SDK provides a signal that allows you to write back settings to the configuration file. This is useful if you want to update the configuration file with new settings that were set during the run, like a `refresh_token`.
+
+```python
+import requests
+from singer_sdk.authenticators import OAuthAuthenticator
+from singer_sdk.plugin_base import PluginBase
+
+
+class RefreshTokenAuthenticator(OAuthAuthenticator):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.refresh_token = self.config["refresh_token"]
+
+    @property
+    def oauth_request_body(self):
+        return {
+            "client_id": self.config["client_id"],
+            "client_secret": self.config["client_secret"],
+            "grant_type": "refresh_token",
+            "refresh_token": self.refresh_token,
+            "user_type": "Location",
+        }
+
+    def update_access_token(self):
+        token_response = requests.post(
+            self.auth_endpoint,
+            headers=self._oauth_headers,
+            data=auth_request_payload,
+            timeout=60,
+        )
+        token_response.raise_for_status()
+        token_json = token_response.json()
+
+        self.access_token = token_json["access_token"]
+        self.refresh_token = token_json["refresh_token"]
+        PluginBase.config_updated.send(self, refresh_token=self.refresh_token)
+```
+
+In the example above, the `RefreshTokenAuthenticator` class is a subclass of `OAuthAuthenticator` that calls `PluginBase.config_updated.send` to send a signal to update the `refresh_token` in tap's configuration.
+
+```{note}
+Only when a single file is passed via the `--config` command line option, the SDK will write back the settings to the same file.
+```

--- a/poetry.lock
+++ b/poetry.lock
@@ -159,6 +159,17 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
+name = "blinker"
+version = "1.7.0"
+description = "Fast, simple object-to-object and broadcast signaling"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "blinker-1.7.0-py3-none-any.whl", hash = "sha256:c3f865d4d54db7abc53758a01601cf343fe55b84c1de4e3fa910e420b438d5b9"},
+    {file = "blinker-1.7.0.tar.gz", hash = "sha256:e6820ff6fa4e4d1d8e2747c2283749c3f547e4fee112b98555cdcdae32996182"},
+]
+
+[[package]]
 name = "boto3"
 version = "1.34.100"
 description = "The AWS SDK for Python"
@@ -2667,4 +2678,4 @@ testing = ["pytest", "pytest-durations"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "6ce3b4821061e0e086e451a5d652882a18f669bb5685ad8029188f54b17243fd"
+content-hash = "65ede351f294da59f85e9f1138c91b09dabce7ce11d89af3502996d599e8c746"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ license = "Apache-2.0"
 python = ">=3.8"
 backoff = { version = ">=2.0.0", python = "<4" }
 backports-datetime-fromisoformat = { version = ">=2.0.1", python = "<3.11" }
+blinker = ">=1.7.0"
 click = "~=8.0"
 cryptography = ">=3.4.6"
 fs = ">=2.4.16"

--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -7,7 +7,6 @@ import math
 import typing as t
 import warnings
 from datetime import timedelta
-from types import MappingProxyType
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 import requests
@@ -16,6 +15,7 @@ from singer_sdk.helpers._util import utc_now
 
 if t.TYPE_CHECKING:
     import logging
+    from types import MappingProxyType
 
     from pendulum import DateTime
 
@@ -90,19 +90,19 @@ class APIAuthenticatorBase:
             stream: A stream for a RESTful endpoint.
         """
         self.tap_name: str = stream.tap_name
-        self._config: dict[str, t.Any] = dict(stream.config)
+        self._config = stream.config
         self._auth_headers: dict[str, t.Any] = {}
         self._auth_params: dict[str, t.Any] = {}
         self.logger: logging.Logger = stream.logger
 
     @property
-    def config(self) -> t.Mapping[str, t.Any]:
+    def config(self) -> MappingProxyType:
         """Get stream or tap config.
 
         Returns:
             A frozen (read-only) config dictionary map.
         """
-        return MappingProxyType(self._config)
+        return self._config
 
     @property
     def auth_headers(self) -> dict:

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -10,7 +10,6 @@ import sys
 import typing as t
 from os import PathLike
 from pathlib import Path
-from types import MappingProxyType
 
 import pendulum
 
@@ -58,6 +57,7 @@ else:
 
 if t.TYPE_CHECKING:
     import logging
+    from types import MappingProxyType
 
     from singer_sdk.helpers._compat import Traversable
     from singer_sdk.tap_base import Tap
@@ -135,7 +135,6 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         self.logger: logging.Logger = tap.logger.getChild(self.name)
         self.metrics_logger = tap.metrics_logger
         self.tap_name: str = tap.name
-        self._config: dict = dict(tap.config)
         self._tap = tap
         self._tap_state = tap.state
         self._tap_input_catalog: singer.Catalog | None = None
@@ -602,13 +601,13 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         return singer.Catalog([(self.tap_stream_id, self._singer_catalog_entry)])
 
     @property
-    def config(self) -> t.Mapping[str, t.Any]:
+    def config(self) -> MappingProxyType[str, t.Any]:
         """Get stream configuration.
 
         Returns:
             A frozen (read-only) config dictionary map.
         """
-        return MappingProxyType(self._config)
+        return self._tap.config
 
     @property
     def tap_stream_id(self) -> str:

--- a/tests/core/test_plugin_base.py
+++ b/tests/core/test_plugin_base.py
@@ -57,3 +57,11 @@ def test_mapper_not_initialized():
 def test_supported_python_versions():
     """Test that supported python versions are correctly parsed."""
     assert PluginBase._get_supported_python_versions(SDK_PACKAGE_NAME)
+
+
+def test_config_updated_signal():
+    plugin = PluginTest(config={"prop1": "hello"})
+    assert plugin.config == {"prop1": "hello"}
+
+    PluginBase.config_updated.send(prop2="abc")
+    assert plugin.config == {"prop1": "hello", "prop2": "abc"}


### PR DESCRIPTION
## Why signals?

A config update may b e triggered in a number of moments during a sync (error handling, authentication, etc.). [Blinker's](https://github.com/pallets-eco/blinker) signals would let us decouple emitting a signal at one of those moments, from processing the event in some other place.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2346.org.readthedocs.build/en/2346/

<!-- readthedocs-preview meltano-sdk end -->