### PR TITLE
fix(targets): Added a condition to the `No schema for record field` warning

### DIFF
--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -544,7 +544,8 @@ class Sink(metaclass=abc.ABCMeta):
         """
         for key, value in record.items():
             if key not in schema["properties"]:
-                self.logger.warning("No schema for record field '%s'", key)
+                if value is not None:
+                    self.logger.warning("No schema for record field '%s'", key)
                 continue
             datelike_type = get_datelike_property_type(schema["properties"][key])
             if datelike_type:


### PR DESCRIPTION
If schema flattening is enabled but a value for a key in the record which is flattened is None, this warning is returned because the record can not be flattened and then the key is not in the schema. This can be avoided by checking if the value is None. If it is None the record field actually does not exist so we do not need a warning.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2348.org.readthedocs.build/en/2348/

<!-- readthedocs-preview meltano-sdk end -->