### PR TITLE
chore: Use `nox.project.load_toml` to get test dependencies

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -3,5 +3,5 @@ poetry==1.8.2
 poetry-plugin-export==1.7.1
 poetry-dynamic-versioning==1.2.0
 pre-commit==3.7.0
-nox==2024.3.2
+nox==2024.4.15
 nox-poetry==1.0.3

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,6 +20,8 @@ except ImportError:
     {sys.executable} -m pip install nox-poetry"""
     raise SystemExit(dedent(message)) from None
 
+nox.needs_version = ">=2024.4.15"
+
 RUFF_OVERRIDES = """\
 extend = "./pyproject.toml"
 extend-ignore = ["TD002", "TD003", "FIX002"]
@@ -38,21 +40,9 @@ nox.options.sessions = (
     "doctest",
     "test_cookiecutter",
 )
-test_dependencies = [
-    "coverage[toml]",
-    "duckdb",
-    "duckdb-engine",
-    "fastjsonschema",
-    "pyarrow",
-    "pytest",
-    "pytest-benchmark",
-    "pytest-durations",
-    "pytest-snapshot",
-    "pytz",
-    "requests-mock",
-    "rfc3339-validator",
-    "time-machine",
-]
+
+poetry_config = nox.project.load_toml("pyproject.toml")["tool"]["poetry"]
+test_dependencies = poetry_config["group"]["dev"]["dependencies"].keys()
 
 
 @session(python=main_python_version)


### PR DESCRIPTION
* https://github.com/wntrblm/nox/releases/tag/2024.04.15
* https://nox.thea.codes/en/stable/tutorial.html#loading-dependencies-from-pyproject-toml-or-scripts
* https://nox.thea.codes/en/stable/config.html#nox-version-requirements