### PR TITLE
ci: Use uv in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
-        cache: 'pip'
-        cache-dependency-path: 'poetry.lock'
 
     - name: Upgrade pip
       env:
@@ -88,7 +86,7 @@ jobs:
       env:
         PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/constraints.txt
       run: |
-        pipx install nox
+        pipx install 'nox[uv]'
         pipx inject nox nox-poetry
         nox --version
 
@@ -138,8 +136,6 @@ jobs:
       with:
         python-version: ${{ env.NOXPYTHON }}
         architecture: x64
-        cache: 'pip'
-        cache-dependency-path: 'poetry.lock'
 
     - name: Upgrade pip
       env:
@@ -152,7 +148,7 @@ jobs:
       env:
         PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/constraints.txt
       run: |
-        pipx install nox
+        pipx install 'nox[uv]'
         pipx inject nox nox-poetry
         nox --version
 
@@ -181,8 +177,6 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-        cache: 'pip'
-        cache-dependency-path: 'poetry.lock'
 
     - name: Upgrade pip
       env:
@@ -200,7 +194,7 @@ jobs:
       env:
         PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/constraints.txt
       run: |
-        pipx install nox
+        pipx install 'nox[uv]'
         pipx inject nox nox-poetry
         nox --version
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,6 +21,7 @@ except ImportError:
     raise SystemExit(dedent(message)) from None
 
 nox.needs_version = ">=2024.4.15"
+nox.options.default_venv_backend = "uv|virtualenv"
 
 RUFF_OVERRIDES = """\
 extend = "./pyproject.toml"


### PR DESCRIPTION
Would be nice to have:

* https://github.com/astral-sh/uv/issues/2231
* https://github.com/actions/setup-python/pull/818

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2377.org.readthedocs.build/en/2377/

<!-- readthedocs-preview meltano-sdk end -->