### PR TITLE
chore: Bump `poetry-core` build backend to 1.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,7 @@ enable = true
 style = "pep440"
 
 [build-system]
-requires = ["poetry-core==1.8.1", "poetry-dynamic-versioning==1.2.0"]
+requires = ["poetry-core==1.9.0", "poetry-dynamic-versioning==1.2.0"]
 build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry.plugins."pytest11"]


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2391.org.readthedocs.build/en/2391/

<!-- readthedocs-preview meltano-sdk end -->