### PR TITLE
ci: Back to `macos-latest` in test workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,12 +47,11 @@ jobs:
       fail-fast: false
       matrix:
         session: [tests]
-        os: ["ubuntu-latest", "macos-13", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         sqlalchemy: ["2"]
         include:
         - { session: tests,   python-version: "3.12", os: "ubuntu-latest", sqlalchemy: "1" }
-        - { session: tests,   python-version: "3.12", os: "macos-latest", sqlalchemy: "2" }
         - { session: doctest, python-version: "3.12", os: "ubuntu-latest", sqlalchemy: "2" }
         - { session: mypy,    python-version: "3.12",  os: "ubuntu-latest", sqlalchemy: "2" }
 
@@ -74,7 +73,6 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: x64
 
     - name: Upgrade pip
       env:
@@ -136,7 +134,6 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ env.NOXPYTHON }}
-        architecture: x64
 
     - name: Upgrade pip
       env:


### PR DESCRIPTION
Related:

* #2390 

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2398.org.readthedocs.build/en/2398/

<!-- readthedocs-preview meltano-sdk end -->