### PR TITLE
fix: An error message is now logged every time schema validation fails for any record

### DIFF
--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -495,9 +495,9 @@ class Sink(metaclass=abc.ABCMeta):  # noqa: PLR0904
             try:
                 self._validator.validate(record)
             except InvalidRecord:
+                self.logger.exception("Record validation failed")
                 if self.fail_on_record_validation_exception:
                     raise
-                self.logger.exception("Record validation failed")
 
         self._parse_timestamps_in_record(
             record=record,


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2421.org.readthedocs.build/en/2421/

<!-- readthedocs-preview meltano-sdk end -->