### PR TITLE
fix(templates): Updated cookiecutter VSCode `launch.json` to use `debugpy`

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.vscode/launch.json
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
         {
             "name": "{{ cookiecutter.tap_id }}",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "cwd": "${workspaceFolder}",
             "program": "{{ cookiecutter.library_name }}",


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2431.org.readthedocs.build/en/2431/

<!-- readthedocs-preview meltano-sdk end -->