### PR TITLE
docs: Using an empty list for `__key_properties__` to disable a stream primary keys is now recommended as an alternative to `null`

### DIFF
--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -401,7 +401,7 @@ stream_maps:
 
 Notes:
 
-- To sync the stream as if it did not contain a primary key, simply set `__key_properties__` to `null`.
+- To sync the stream as if it did not contain a primary key, simply set `__key_properties__` to `null` or an empty list.
 - Key properties _must_ be present in the transformed stream result. Otherwise, an error will be raised.
 
 ### Add a property with a string literal value


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2435.org.readthedocs.build/en/2435/

<!-- readthedocs-preview meltano-sdk end -->