### PR TITLE
chore: Use `singer_sdk.helpers._util.utc_now` in ACTIVATE_VERSION handling

### DIFF
--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -9,13 +9,13 @@ from copy import copy
 from textwrap import dedent
 
 import sqlalchemy as sa
-from pendulum import now
 from sqlalchemy.sql import quoted_name
 from sqlalchemy.sql.expression import bindparam
 
 from singer_sdk.connectors import SQLConnector
 from singer_sdk.exceptions import ConformedNameClashException
 from singer_sdk.helpers._conformers import replace_leading_digit
+from singer_sdk.helpers._util import utc_now
 from singer_sdk.sinks.batch import BatchSink
 
 if t.TYPE_CHECKING:
@@ -371,7 +371,7 @@ class SQLSink(BatchSink):
         if not self.connector.table_exists(self.full_table_name):
             return
 
-        deleted_at = now()
+        deleted_at = utc_now()
 
         if not self.connector.column_exists(
             full_table_name=self.full_table_name,

--- a/tests/core/test_record_typing.py
+++ b/tests/core/test_record_typing.py
@@ -6,9 +6,9 @@ import logging
 import typing as t
 from datetime import datetime
 
-import pendulum
 import pytest
 
+from singer_sdk.helpers._compat import datetime_fromisoformat as parse
 from singer_sdk.helpers._typing import (
     TypeConformanceLevel,
     conform_record_data_types,
@@ -21,19 +21,19 @@ from singer_sdk.helpers._typing import (
     "record,schema,expected_row,ignore_props_message",
     [
         (
-            {"updatedAt": pendulum.parse("2021-08-25T20:05:28+00:00")},
+            {"updatedAt": parse("2021-08-25T20:05:28+00:00")},
             {"properties": {"updatedAt": True}},
             {"updatedAt": "2021-08-25T20:05:28+00:00"},
             None,
         ),
         (
-            {"updatedAt": pendulum.parse("2021-08-25T20:05:28Z")},
+            {"updatedAt": parse("2021-08-25T20:05:28Z")},
             {"properties": {"updatedAt": True}},
             {"updatedAt": "2021-08-25T20:05:28+00:00"},
             None,
         ),
         (
-            {"updatedAt": pendulum.parse("2021-08-25T20:05:28")},
+            {"updatedAt": parse("2021-08-25T20:05:28")},
             {"properties": {"updatedAt": True}},
             {"updatedAt": "2021-08-25T20:05:28+00:00"},
             None,
@@ -84,8 +84,8 @@ def test_conform_record_data_types(
 @pytest.mark.parametrize(
     "datetime_val,expected",
     [
-        (pendulum.parse("2021-08-25T20:05:28+00:00"), "2021-08-25T20:05:28+00:00"),
-        (pendulum.parse("2021-08-25T20:05:28+07:00"), "2021-08-25T20:05:28+07:00"),
+        (parse("2021-08-25T20:05:28+00:00"), "2021-08-25T20:05:28+00:00"),
+        (parse("2021-08-25T20:05:28+07:00"), "2021-08-25T20:05:28+07:00"),
         (
             datetime.strptime(  # noqa: DTZ007
                 "2021-08-25T20:05:28",

--- a/tests/core/test_streams.py
+++ b/tests/core/test_streams.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import logging
 import typing as t
 
@@ -14,6 +15,7 @@ from singer_sdk.exceptions import (
     InvalidReplicationKeyException,
 )
 from singer_sdk.helpers._classproperty import classproperty
+from singer_sdk.helpers._compat import datetime_fromisoformat as parse
 from singer_sdk.helpers.jsonpath import _compile_jsonpath, extract_jsonpath
 from singer_sdk.pagination import first
 from singer_sdk.streams.core import REPLICATION_FULL_TABLE, REPLICATION_INCREMENTAL
@@ -116,14 +118,14 @@ def test_stream_apply_catalog(stream: Stream):
             "test",
             None,
             None,
-            pendulum.parse(CONFIG_START_DATE),
+            parse(CONFIG_START_DATE).replace(tzinfo=datetime.timezone.utc),
             id="datetime-repl-key-no-state",
         ),
         pytest.param(
             "test",
             None,
             "2021-02-01",
-            pendulum.datetime(2021, 2, 1),
+            datetime.datetime(2021, 2, 1, tzinfo=datetime.timezone.utc),
             id="datetime-repl-key-recent-bookmark",
         ),
         pytest.param(
@@ -137,7 +139,7 @@ def test_stream_apply_catalog(stream: Stream):
             "test",
             None,
             "2020-01-01",
-            pendulum.parse(CONFIG_START_DATE),
+            parse(CONFIG_START_DATE).replace(tzinfo=datetime.timezone.utc),
             id="datetime-repl-key-old-bookmark",
         ),
         pytest.param(


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2454.org.readthedocs.build/en/2454/

<!-- readthedocs-preview meltano-sdk end -->