### PR TITLE
refactor: Replace `inflection` dependency with `pyhumps`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -866,17 +866,6 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["jaraco.test (>=5.4)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)", "zipp (>=3.17)"]
 
 [[package]]
-name = "inflection"
-version = "0.5.1"
-description = "A port of Ruby on Rails inflector to Python"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2"},
-    {file = "inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417"},
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -1410,6 +1399,17 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyhumps"
+version = "3.8.0"
+description = "🐫  Convert strings (and dictionary keys) between snake case, camel case and pascal case in Python. Inspired by Humps for Node"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pyhumps-3.8.0-py3-none-any.whl", hash = "sha256:060e1954d9069f428232a1adda165db0b9d8dfdce1d265d36df7fbff540acfd6"},
+    {file = "pyhumps-3.8.0.tar.gz", hash = "sha256:498026258f7ee1a8e447c2e28526c0bea9407f9a59c03260aee4bd6c04d681a3"},
+]
 
 [[package]]
 name = "pyjwt"
@@ -2524,4 +2524,4 @@ testing = ["pytest", "pytest-durations"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "a9608352516ffcc098a93ce4e3375b11989c328c7520cad28ab89c458c1dbc3b"
+content-hash = "3b0a6fff7b305eb1fc728987167b7d95733d92931259416cfa4671699c51418f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,11 @@ click = "~=8.0"
 fs = ">=2.4.16"
 importlib-metadata = {version = "<9.0.0", python = "<3.12"}
 importlib-resources = {version = ">=5.12.0,!=6.2.0,!=6.3.0,!=6.3.1", python = "<3.10"}
-inflection = ">=0.5.1"
 joblib = ">=1.3.0"
 jsonpath-ng = ">=1.5.3"
 jsonschema = ">=4.16.0"
 packaging = ">=23.1"
+pyhumps = ">=3.8.0"
 python-dotenv = ">=0.20"
 PyYAML = ">=6.0"
 referencing = ">=0.30.0"

--- a/singer_sdk/helpers/_flattening.py
+++ b/singer_sdk/helpers/_flattening.py
@@ -8,7 +8,7 @@ import re
 import typing as t
 from copy import deepcopy
 
-import inflection
+import humps
 
 from singer_sdk._singerlib.json import serialize_json
 
@@ -68,7 +68,7 @@ def flatten_key(key_name: str, parent_keys: list[str], separator: str = "__") ->
         reduced_key = re.sub(
             r"[a-z]",
             "",
-            inflection.camelize(inflected_key[reducer_index]),
+            humps.camelize(inflected_key[reducer_index]),
         )
         inflected_key[reducer_index] = (
             reduced_key if len(reduced_key) > 1 else inflected_key[reducer_index][:3]


### PR DESCRIPTION
* [`inflection` last version](https://pypi.org/project/inflection/) is from 2020/08/20
* [`pyhumps` last version](https://pypi.org/project/pyhumps/) is from 2022/10/21

Related:

* https://github.com/meltano/sdk/issues/2490#issuecomment-2180832069
* https://github.com/nficano/humps/issues/300


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2496.org.readthedocs.build/en/2496/

<!-- readthedocs-preview meltano-sdk end -->