### PR TITLE
fix: Moved up the supported Python versions in the Markdown output of `--about`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -124,7 +124,7 @@ def update_snapshots(session: Session) -> None:
     """Update pytest snapshots."""
     args = session.posargs or ["-m", "snapshot"]
 
-    session.install(".[faker,jwt]")
+    session.install(".[faker,jwt,parquet]")
     session.install(*test_dependencies)
     session.run("pytest", "--snapshot-update", *args)
 

--- a/singer_sdk/about.py
+++ b/singer_sdk/about.py
@@ -244,6 +244,18 @@ class MarkdownFormatter(AboutFormatter, format_name="markdown"):
         capabilities += "\n\n"
         md_list.append(capabilities)
 
+        # Process Supported Python Versions
+
+        if about_info.supported_python_versions:
+            supported_python_versions = "## Supported Python Versions\n\n"
+            supported_python_versions += "\n".join(
+                [f"* {v}" for v in about_info.supported_python_versions],
+            )
+            supported_python_versions += "\n\n"
+            md_list.append(supported_python_versions)
+
+        # Process settings
+
         setting = "## Settings\n\n"
         settings_table = (
             "| Setting | Required | Default | Description |\n"
@@ -261,17 +273,6 @@ class MarkdownFormatter(AboutFormatter, format_name="markdown"):
             )
             + "\n"
         )
-        setting += "\n"
         md_list.append(setting)
-
-        # Process Supported Python Versions
-
-        if about_info.supported_python_versions:
-            supported_python_versions = "## Supported Python Versions\n\n"
-            supported_python_versions += "\n".join(
-                [f"* {v}" for v in about_info.supported_python_versions],
-            )
-            supported_python_versions += "\n"
-            md_list.append(supported_python_versions)
 
         return "".join(md_list)

--- a/tests/core/test_about.py
+++ b/tests/core/test_about.py
@@ -36,7 +36,7 @@ def about_info() -> AboutInfo:
         description="Example tap for Singer SDK",
         version="0.1.1",
         sdk_version="1.0.0",
-        supported_python_versions=["3.6", "3.7", "3.8"],
+        supported_python_versions=["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
         capabilities=[
             TapCapabilities.CATALOG,
             TapCapabilities.DISCOVER,

--- a/tests/snapshots/about_format/json.snap.json
+++ b/tests/snapshots/about_format/json.snap.json
@@ -4,9 +4,12 @@
   "version": "0.1.1",
   "sdk_version": "1.0.0",
   "supported_python_versions": [
-    "3.6",
-    "3.7",
-    "3.8"
+    "3.8",
+    "3.9",
+    "3.10",
+    "3.11",
+    "3.12",
+    "3.13"
   ],
   "capabilities": [
     "catalog",

--- a/tests/snapshots/about_format/markdown.snap.md
+++ b/tests/snapshots/about_format/markdown.snap.md
@@ -10,6 +10,15 @@ Built with the [Meltano Singer SDK](https://sdk.meltano.com).
 * `discover`
 * `state`
 
+## Supported Python Versions
+
+* 3.8
+* 3.9
+* 3.10
+* 3.11
+* 3.12
+* 3.13
+
 ## Settings
 
 | Setting | Required | Default | Description |
@@ -20,9 +29,3 @@ Built with the [Meltano Singer SDK](https://sdk.meltano.com).
 | complex_setting.sub_setting | False    | None    | A sub-setting. |
 
 A full list of supported settings and capabilities is available by running: `tap-example --about`
-
-## Supported Python Versions
-
-* 3.6
-* 3.7
-* 3.8

--- a/tests/snapshots/about_format/text.snap.txt
+++ b/tests/snapshots/about_format/text.snap.txt
@@ -2,6 +2,6 @@ Name: tap-example
 Description: Example tap for Singer SDK
 Version: 0.1.1
 SDK Version: 1.0.0
-Supported Python Versions: ['3.6', '3.7', '3.8']
+Supported Python Versions: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 Capabilities: [catalog, discover, state]
 Settings: {'properties': {'start_date': {'type': 'string', 'format': 'date-time', 'description': 'Start date for the tap to extract data from.'}, 'api_key': {'type': 'string', 'description': 'API key for the tap to use.'}, 'complex_setting': {'type': 'object', 'description': 'A complex setting, with sub-settings.', 'properties': {'sub_setting': {'type': 'string', 'description': 'A sub-setting.'}}}}, 'required': ['api_key']}


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2526.org.readthedocs.build/en/2526/

<!-- readthedocs-preview meltano-sdk end -->