### PR TITLE
feat: Stream sync context is now available to all instances methods as a `Stream.context` attribute

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/graphql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/graphql-client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 import requests  # noqa: TCH002
 from singer_sdk.streams import {{ cookiecutter.stream_type }}Stream
@@ -11,6 +11,9 @@ from singer_sdk.streams import {{ cookiecutter.stream_type }}Stream
 
 from {{ cookiecutter.library_name }}.auth import {{ cookiecutter.source_name }}Authenticator
 {%- endif %}
+
+if TYPE_CHECKING:
+    from singer_sdk.helpers.types import Context
 
 
 class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream):
@@ -67,7 +70,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     def post_process(
         self,
         row: dict,
-        context: dict | None = None,  # noqa: ARG002
+        context: Context | None = None,  # noqa: ARG002
     ) -> dict | None:
         """As needed, append or transform raw data to match expected structure.
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/other-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/other-client.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 from singer_sdk.streams import Stream
+
+if TYPE_CHECKING:
+    from singer_sdk.helpers.types import Context
 
 
 class {{ cookiecutter.source_name }}Stream(Stream):
@@ -12,7 +15,7 @@ class {{ cookiecutter.source_name }}Stream(Stream):
 
     def get_records(
         self,
-        context: dict | None,  # noqa: ARG002
+        context: Context | None,  # noqa: ARG002
     ) -> Iterable[dict]:
         """Return a generator of record-type dictionary objects.
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
@@ -6,7 +6,7 @@ import sys
 {%- if cookiecutter.auth_method in ("OAuth2", "JWT") %}
 from functools import cached_property
 {%- endif %}
-from typing import Any, Callable, Iterable
+from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 import requests
 {% if cookiecutter.auth_method  == "API Key" -%}
@@ -45,6 +45,10 @@ if sys.version_info >= (3, 9):
     import importlib.resources as importlib_resources
 else:
     import importlib_resources
+
+if TYPE_CHECKING:
+    from singer_sdk.helpers.types import Context
+
 
 _Auth = Callable[[requests.PreparedRequest], requests.PreparedRequest]
 
@@ -157,7 +161,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
 
     def get_url_params(
         self,
-        context: dict | None,  # noqa: ARG002
+        context: Context | None,  # noqa: ARG002
         next_page_token: Any | None,  # noqa: ANN401
     ) -> dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization.
@@ -179,7 +183,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
 
     def prepare_request_payload(
         self,
-        context: dict | None,  # noqa: ARG002
+        context: Context | None,  # noqa: ARG002
         next_page_token: Any | None,  # noqa: ARG002, ANN401
     ) -> dict | None:
         """Prepare the data payload for the REST API request.
@@ -211,7 +215,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     def post_process(
         self,
         row: dict,
-        context: dict | None = None,  # noqa: ARG002
+        context: Context | None = None,  # noqa: ARG002
     ) -> dict | None:
         """As needed, append or transform raw data to match expected structure.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,7 @@ omit = [
     "tests/*",
     "samples/*",
     "singer_sdk/helpers/_compat.py",
+    "singer_sdk/helpers/types.py",
 ]
 
 [tool.coverage.report]

--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -11,6 +11,8 @@ from singer_sdk.helpers._typing import to_json_compatible
 if t.TYPE_CHECKING:
     import datetime
 
+    from singer_sdk.helpers import types
+
     _T = t.TypeVar("_T", datetime.datetime, str, int, float)
 
 PROGRESS_MARKERS = "progress_markers"
@@ -70,7 +72,7 @@ def get_state_partitions_list(tap_state: dict, tap_stream_id: str) -> list[dict]
 
 def _find_in_partitions_list(
     partitions: list[dict],
-    state_partition_context: dict,
+    state_partition_context: types.Context,
 ) -> dict | None:
     found = [
         partition_state
@@ -88,7 +90,7 @@ def _find_in_partitions_list(
 
 def _create_in_partitions_list(
     partitions: list[dict],
-    state_partition_context: dict,
+    state_partition_context: types.Context,
 ) -> dict:
     # Existing partition not found. Creating new state entry in partitions list...
     new_partition_state = {"context": state_partition_context}
@@ -99,7 +101,7 @@ def _create_in_partitions_list(
 def get_writeable_state_dict(
     tap_state: dict,
     tap_stream_id: str,
-    state_partition_context: dict | None = None,
+    state_partition_context: types.Context | None = None,
 ) -> dict:
     """Return the stream or partition state, creating a new one if it does not exist.
 
@@ -283,8 +285,8 @@ def log_sort_error(
     ex: Exception,
     log_fn: t.Callable,
     stream_name: str,
-    current_context: dict | None,
-    state_partition_context: dict | None,
+    current_context: types.Context | None,
+    state_partition_context: types.Context | None,
     record_count: int,
     partition_record_count: int,
 ) -> None:

--- a/singer_sdk/helpers/types.py
+++ b/singer_sdk/helpers/types.py
@@ -1,0 +1,24 @@
+"""Type aliases for use in the SDK."""
+
+from __future__ import annotations
+
+import sys
+import typing as t
+
+if sys.version_info < (3, 9):
+    from typing import Mapping  # noqa: ICN003
+else:
+    from collections.abc import Mapping
+
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias  # noqa: ICN003
+
+__all__ = [
+    "Context",
+    "Record",
+]
+
+Context: TypeAlias = Mapping
+Record: TypeAlias = t.Dict[str, t.Any]

--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -20,7 +20,9 @@ from singer_sdk.helpers._resources import get_package_files
 if t.TYPE_CHECKING:
     from types import TracebackType
 
+    from singer_sdk.helpers import types
     from singer_sdk.helpers._compat import Traversable
+
 
 DEFAULT_LOG_INTERVAL = 60.0
 METRICS_LOGGER_NAME = __name__
@@ -117,7 +119,7 @@ class Meter(metaclass=abc.ABCMeta):
         self.logger = get_metrics_logger()
 
     @property
-    def context(self) -> dict | None:
+    def context(self) -> types.Context | None:
         """Get the context for this meter.
 
         Returns:
@@ -126,7 +128,7 @@ class Meter(metaclass=abc.ABCMeta):
         return self.tags.get(Tag.CONTEXT)
 
     @context.setter
-    def context(self, value: dict | None) -> None:
+    def context(self, value: types.Context | None) -> None:
         """Set the context for this meter.
 
         Args:

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -6,7 +6,6 @@ import abc
 import copy
 import datetime
 import json
-import sys
 import typing as t
 from os import PathLike
 from pathlib import Path
@@ -50,14 +49,10 @@ from singer_sdk.helpers._typing import (
 from singer_sdk.helpers._util import utc_now
 from singer_sdk.mapper import RemoveRecordTransform, SameRecordTransform, StreamMap
 
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias  # noqa: ICN003
-
 if t.TYPE_CHECKING:
     import logging
 
+    from singer_sdk.helpers import types
     from singer_sdk.helpers._compat import Traversable
     from singer_sdk.tap_base import Tap
 
@@ -66,13 +61,15 @@ REPLICATION_FULL_TABLE = "FULL_TABLE"
 REPLICATION_INCREMENTAL = "INCREMENTAL"
 REPLICATION_LOG_BASED = "LOG_BASED"
 
-FactoryType = t.TypeVar("FactoryType", bound="Stream")
-Record: TypeAlias = t.Dict[str, t.Any]
-Context: TypeAlias = t.Dict
-
 
 class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
-    """Abstract base class for tap streams."""
+    """Abstract base class for tap streams.
+
+    :ivar context: Stream partition or context dictionary.
+
+    .. versionadded:: 0.39.0
+       The ``context`` attribute.
+    """
 
     STATE_MSG_FREQUENCY = 10000
     """Number of records between state messages."""
@@ -134,6 +131,8 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         self.logger: logging.Logger = tap.logger.getChild(self.name)
         self.metrics_logger = tap.metrics_logger
         self.tap_name: str = tap.name
+        self.context: types.Context | None = None
+
         self._config: dict = dict(tap.config)
         self._tap = tap
         self._tap_state = tap.state
@@ -234,7 +233,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
     def get_starting_replication_key_value(
         self,
-        context: Context | None,
+        context: types.Context | None,
     ) -> t.Any | None:  # noqa: ANN401
         """Get starting replication key.
 
@@ -260,7 +259,8 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         )
 
     def get_starting_timestamp(
-        self, context: Context | None
+        self,
+        context: types.Context | None,
     ) -> datetime.datetime | None:
         """Get starting replication timestamp.
 
@@ -340,7 +340,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
     def _write_replication_key_signpost(
         self,
-        context: Context | None,
+        context: types.Context | None,
         value: datetime.datetime | str | int | float,
     ) -> None:
         """Write the signpost value, if available.
@@ -381,7 +381,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
         return value
 
-    def _write_starting_replication_value(self, context: Context | None) -> None:
+    def _write_starting_replication_value(self, context: types.Context | None) -> None:
         """Write the starting replication value, if available.
 
         Args:
@@ -409,7 +409,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
     def get_replication_key_signpost(
         self,
-        context: Context | None,  # noqa: ARG002
+        context: types.Context | None,  # noqa: ARG002
     ) -> datetime.datetime | t.Any | None:  # noqa: ANN401
         """Get the replication signpost.
 
@@ -656,7 +656,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         """
         return self._tap_state
 
-    def get_context_state(self, context: Context | None) -> dict:
+    def get_context_state(self, context: types.Context | None) -> dict:
         """Return a writable state dict for the given context.
 
         Gives a partitioned context state if applicable; else returns stream state.
@@ -711,7 +711,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
     # Partitions
 
     @property
-    def partitions(self) -> list[Context] | None:
+    def partitions(self) -> list[types.Context] | None:
         """Get stream partitions.
 
         Developers may override this property to provide a default partitions list.
@@ -722,7 +722,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         Returns:
             A list of partition key dicts (if applicable), otherwise `None`.
         """
-        result: list[dict] = [
+        result: list[types.Mapping] = [
             partition_state["context"]
             for partition_state in (
                 get_state_partitions_list(self.tap_state, self.name) or []
@@ -734,9 +734,9 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
     def _increment_stream_state(
         self,
-        latest_record: Record,
+        latest_record: types.Record,
         *,
-        context: Context | None = None,
+        context: types.Context | None = None,
     ) -> None:
         """Update state of stream or partition with data from the provided record.
 
@@ -827,7 +827,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
     def _generate_record_messages(
         self,
-        record: Record,
+        record: types.Record,
     ) -> t.Generator[singer.RecordMessage, None, None]:
         """Write out a RECORD message.
 
@@ -856,7 +856,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
                     time_extracted=utc_now(),
                 )
 
-    def _write_record_message(self, record: Record) -> None:
+    def _write_record_message(self, record: types.Record) -> None:
         """Write out a RECORD message.
 
         Args:
@@ -973,7 +973,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
             state: State object to promote progress markers with.
         """
         if state is None or state == {}:
-            context: Context | None
+            context: types.Context | None
             for context in self.partitions or [{}]:
                 state = self.get_context_state(context or None)
                 reset_state_progress_markers(state)
@@ -1002,7 +1002,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
             for child_stream in self.child_streams or []:
                 child_stream.finalize_state_progress_markers()
 
-            context: Context | None
+            context: types.Context | None
             for context in self.partitions or [{}]:
                 state = self.get_context_state(context or None)
                 self._finalize_state(state)
@@ -1015,9 +1015,9 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
     def _process_record(
         self,
-        record: Record,
-        child_context: Context | None = None,
-        partition_context: Context | None = None,
+        record: types.Record,
+        child_context: types.Context | None = None,
+        partition_context: types.Context | None = None,
     ) -> None:
         """Process a record.
 
@@ -1042,7 +1042,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
     def _sync_records(  # noqa: C901
         self,
-        context: Context | None = None,
+        context: types.Context | None = None,
         *,
         write_messages: bool = True,
     ) -> t.Generator[dict, t.Any, t.Any]:
@@ -1064,8 +1064,8 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         timer = metrics.sync_timer(self.name)
 
         record_index = 0
-        context_element: Context | None
-        context_list: list[dict] | None
+        context_element: types.Context | None
+        context_list: list[types.Context] | None
         context_list = [context] if context is not None else self.partitions
         selected = self.selected
 
@@ -1080,7 +1080,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
                     current_context,
                 )
                 self._write_starting_replication_value(current_context)
-                child_context: Context | None = (
+                child_context: types.Context | None = (
                     None if current_context is None else copy.copy(current_context)
                 )
 
@@ -1141,7 +1141,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
     def _sync_batches(
         self,
         batch_config: BatchConfig,
-        context: Context | None = None,
+        context: types.Context | None = None,
     ) -> None:
         """Sync batches, emitting BATCH messages.
 
@@ -1158,7 +1158,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
     # Public methods ("final", not recommended to be overridden)
 
     @t.final
-    def sync(self, context: Context | None = None) -> None:
+    def sync(self, context: types.Context | None = None) -> None:
         """Sync this stream.
 
         This method is internal to the SDK and should not need to be overridden.
@@ -1173,6 +1173,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         if context:
             msg += f" with context: {context}"
         self.logger.info("%s...", msg)
+        self.context = MappingProxyType(context) if context else None
 
         # Use a replication signpost, if available
         signpost = self.get_replication_key_signpost(context)
@@ -1198,7 +1199,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
             )
             raise
 
-    def _sync_children(self, child_context: Context | None) -> None:
+    def _sync_children(self, child_context: types.Context | None) -> None:
         if child_context is None:
             self.logger.warning(
                 "Context for child streams of '%s' is null, "
@@ -1233,7 +1234,10 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
             if catalog_entry.replication_method:
                 self.forced_replication_method = catalog_entry.replication_method
 
-    def _get_state_partition_context(self, context: Context | None) -> dict | None:
+    def _get_state_partition_context(
+        self,
+        context: types.Context | None,
+    ) -> types.Context | None:
         """Override state handling if Stream.state_partitioning_keys is specified.
 
         Args:
@@ -1252,9 +1256,9 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
     def get_child_context(
         self,
-        record: Record,
-        context: Context | None,
-    ) -> dict | None:
+        record: types.Record,
+        context: types.Context | None,
+    ) -> types.Context | None:
         """Return a child context object from the record and optional provided context.
 
         By default, will return context if provided and otherwise the record dict.
@@ -1295,9 +1299,9 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
     def generate_child_contexts(
         self,
-        record: Record,
-        context: Context | None,
-    ) -> t.Iterable[dict | None]:
+        record: types.Record,
+        context: types.Context | None,
+    ) -> t.Iterable[types.Context | None]:
         """Generate child contexts.
 
         Args:
@@ -1314,7 +1318,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
     @abc.abstractmethod
     def get_records(
         self,
-        context: Context | None,
+        context: types.Context | None,
     ) -> t.Iterable[dict | tuple[dict, dict | None]]:
         """Abstract record generator function. Must be overridden by the child class.
 
@@ -1360,7 +1364,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
     def get_batches(
         self,
         batch_config: BatchConfig,
-        context: Context | None = None,
+        context: types.Context | None = None,
     ) -> t.Iterable[tuple[BaseBatchFileEncoding, list[str]]]:
         """Batch generator function.
 
@@ -1385,8 +1389,8 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
     def post_process(  # noqa: PLR6301
         self,
-        row: Record,
-        context: Context | None = None,  # noqa: ARG002
+        row: types.Record,
+        context: types.Context | None = None,  # noqa: ARG002
     ) -> dict | None:
         """As needed, append or transform raw data to match expected structure.
 

--- a/singer_sdk/streams/graphql.py
+++ b/singer_sdk/streams/graphql.py
@@ -9,7 +9,7 @@ from singer_sdk.helpers._classproperty import classproperty
 from singer_sdk.streams.rest import RESTStream
 
 if t.TYPE_CHECKING:
-    from singer_sdk.streams.core import Context
+    from singer_sdk.helpers.types import Context
 
 _TToken = t.TypeVar("_TToken")
 

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -32,7 +32,7 @@ if t.TYPE_CHECKING:
     from backoff.types import Details
 
     from singer_sdk._singerlib import Schema
-    from singer_sdk.streams.core import Context
+    from singer_sdk.helpers.types import Context
     from singer_sdk.tap_base import Tap
 
     if sys.version_info >= (3, 10):

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -14,7 +14,7 @@ from singer_sdk.connectors import SQLConnector
 from singer_sdk.streams.core import Stream
 
 if t.TYPE_CHECKING:
-    from singer_sdk.streams.core import Context
+    from singer_sdk.helpers.types import Context
     from singer_sdk.tap_base import Tap
 
 


### PR DESCRIPTION
Some context on the design here:

* Adding a `context` parameter to `RESTStream.get_new_paginator` is a breaking change. It could be handled by catching a `TypeError` and retrying the call without the parameter, but this feels unnecessarily complicated.
* I opted for adding a new `context` attribute to the `Stream` instance. It's only set when the sync starts and is wrapped by `MappingProxyType` to discourage mutating the context object.
* The above makes the `context` parameter accepted by some methods a bit redundant, but I'm unsure whether it's worth deprecating and eventually removing it.
* Docs: https://meltano-sdk--2529.org.readthedocs.build/en/2529/classes/singer_sdk.Stream.html#singer_sdk.Stream

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2529.org.readthedocs.build/en/2529/

<!-- readthedocs-preview meltano-sdk end -->