### PR TITLE
feat: The `json` module is now avaiable to stream maps

### DIFF
--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -234,6 +234,8 @@ can be referenced directly by mapping expressions.
     `hashlib.md5(<input>.encode("utf-8")).hexdigest()`.
 - `datetime` - This is the datetime module object from the Python standard library. You can access
     datetime.datetime, datetime.timedelta, etc.
+- `json` - This is the json module object from the Python standard library.
+    Primarily used for calling json.dumps() and json.loads().
 
 #### Built-in Variable Names
 

--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -235,7 +235,7 @@ can be referenced directly by mapping expressions.
 - `datetime` - This is the datetime module object from the Python standard library. You can access
     datetime.datetime, datetime.timedelta, etc.
 - `json` - This is the json module object from the Python standard library.
-    Primarily used for calling :py:func:`json.dumps()` and :py:func:`json.loads()`.
+    Primarily used for calling [`json.dumps()`](inv:py:func:json.dumps) and [`json.loads()`](inv:py:func:json.loads).
 
 #### Built-in Variable Names
 

--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -235,7 +235,7 @@ can be referenced directly by mapping expressions.
 - `datetime` - This is the datetime module object from the Python standard library. You can access
     datetime.datetime, datetime.timedelta, etc.
 - `json` - This is the json module object from the Python standard library.
-    Primarily used for calling json.dumps() and json.loads().
+    Primarily used for calling :py:func:`json.dumps()` and :py:func:`json.loads()`.
 
 #### Built-in Variable Names
 

--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -235,7 +235,8 @@ can be referenced directly by mapping expressions.
 - `datetime` - This is the datetime module object from the Python standard library. You can access
     datetime.datetime, datetime.timedelta, etc.
 - `json` - This is the json module object from the Python standard library.
-    Primarily used for calling [`json.dumps()`](inv:py:func:json.dumps) and [`json.loads()`](inv:py:func:json.loads).
+    Primarily used for calling [`json.dumps()`](inv:python:py:function:#json.dumps)
+    and [`json.loads()`](inv:python:py:function:#json.loads).
 
 #### Built-in Variable Names
 

--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -234,8 +234,8 @@ can be referenced directly by mapping expressions.
     `hashlib.md5(<input>.encode("utf-8")).hexdigest()`.
 - `datetime` - This is the datetime module object from the Python standard library. You can access
     datetime.datetime, datetime.timedelta, etc.
-- `json` - This is the json module object from the Python standard library.
-    Primarily used for calling [`json.dumps()`](inv:python:py:function:#json.dumps)
+- [`json`](inv:python:py:module:#json) - This is the json module object from the Python standard
+    library. Primarily used for calling [`json.dumps()`](inv:python:py:function:#json.dumps)
     and [`json.loads()`](inv:python:py:function:#json.loads).
 
 #### Built-in Variable Names

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -12,6 +12,7 @@ import datetime
 import fnmatch
 import hashlib
 import importlib.util
+import json
 import logging
 import typing as t
 
@@ -306,6 +307,7 @@ class CustomStreamMap(StreamMap):
         funcs["md5"] = md5
         funcs["datetime"] = datetime
         funcs["bool"] = bool
+        funcs["json"] = json
         return funcs
 
     def _eval(


### PR DESCRIPTION
This allows using `json.loads()` and `json.dumps()` to convert fields between text and json representations.

Particularily useful moving data between MySQL and Postgres where MySQL stores json as text, and Postgres stores json as JSONB.

Usage in a stream_map:
```yaml
        stream_maps:
          sample-reports:
            recipients_email_addresses: json.loads(recipients_email_addresses)
```

Closes https://github.com/meltano/sdk/issues/1502

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2531.org.readthedocs.build/en/2531/

<!-- readthedocs-preview meltano-sdk end -->