### PR TITLE
docs: Prepare for RTD addons migration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 #
 from __future__ import annotations
 
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -60,10 +61,19 @@ templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Options for HTML output -----------------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
+
+# Define the canonical URL for sdk.meltano.com
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+html_context = {}
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
+
 html_logo = "_static/img/logo.svg"
 html_theme = "furo"
 html_theme_options = {


### PR DESCRIPTION
I went ahead and enabled addons in
https://app.readthedocs.org/dashboard/meltano-sdk/addons/edit/ and
updated `docs/conf.py` following guidance from the blog post.

References:

* https://about.readthedocs.com/blog/2024/07/addons-by-default/
* https://docs.readthedocs.io/en/stable/pull-requests.html#features
* https://docs.readthedocs.io/en/stable/addons.html#enabling-read-the-docs-addons


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2536.org.readthedocs.build/en/2536/

<!-- readthedocs-preview meltano-sdk end -->