### PR TITLE
fix: Use mapped stream aliases when handling `ACTIVATE_VERSION` messages in the base target class

### DIFF
--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -451,8 +451,10 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
             message_dict: TODO
         """
         stream_name = message_dict["stream"]
-        sink = self.get_sink(stream_name)
-        sink.activate_version(message_dict["version"])
+
+        for stream_map in self.mapper.stream_maps[stream_name]:
+            sink = self.get_sink(stream_map.stream_alias)
+            sink.activate_version(message_dict["version"])
 
     def _process_batch_message(self, message_dict: dict) -> None:
         """Handle the optional BATCH message extension.


### PR DESCRIPTION
Closes https://github.com/meltano/sdk/issues/1055


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2554.org.readthedocs.build/en/2554/

<!-- readthedocs-preview meltano-sdk end -->