### PR TITLE
docs: Document that `get_starting_timestamp` requires setting a non-null replication_key

### DIFF
--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -252,7 +252,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
         .. note::
 
-           This method requires :meth:`~singer_sdk.Stream.replication_key` to be set
+           This method requires :attr:`~singer_sdk.Stream.replication_key` to be set
            to a non-null value, indicating the stream should be synced incrementally.
         """
         state = self.get_context_state(context)
@@ -288,7 +288,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
         .. note::
 
-           This method requires :meth:`~singer_sdk.Stream.replication_key` to be set
+           This method requires :attr:`~singer_sdk.Stream.replication_key` to be set
            to a non-null value, indicating the stream should be synced incrementally.
         """
         value = self.get_starting_replication_key_value(context)

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -249,6 +249,11 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
         Returns:
             Starting replication value.
+
+        .. warning::
+
+           This method requires :meth:`~singer_sdk.Stream.replication_key` to be set
+           to a non-null value, indicating the stream should be synced incrementally.
         """
         state = self.get_context_state(context)
 
@@ -280,6 +285,11 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
         Raises:
             ValueError: If the replication value is not a valid timestamp.
+
+        .. warning::
+
+           This method requires :meth:`~singer_sdk.Stream.replication_key` to be set
+           to a non-null value, indicating the stream should be synced incrementally.
         """
         value = self.get_starting_replication_key_value(context)
 

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -250,7 +250,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         Returns:
             Starting replication value.
 
-        .. warning::
+        .. note::
 
            This method requires :meth:`~singer_sdk.Stream.replication_key` to be set
            to a non-null value, indicating the stream should be synced incrementally.
@@ -286,7 +286,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         Raises:
             ValueError: If the replication value is not a valid timestamp.
 
-        .. warning::
+        .. note::
 
            This method requires :meth:`~singer_sdk.Stream.replication_key` to be set
            to a non-null value, indicating the stream should be synced incrementally.


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2557.org.readthedocs.build/en/2557/

<!-- readthedocs-preview meltano-sdk end -->