### PR TITLE
feat(mapper): expressions now have access to the Faker libary, rather than just faker instance

### DIFF
--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -337,7 +337,10 @@ class CustomStreamMap(StreamMap):
         names["config"] = self.map_config  # Allow map config access within transform
 
         if self.fake:
+            from faker import Faker  # noqa: PLC0415
+
             names["fake"] = self.fake
+            names["Faker"] = Faker
 
         if property_name and property_name in record:
             # Allow access to original property value if applicable


### PR DESCRIPTION
I made [a post in the discussions](https://github.com/meltano/sdk/discussions/2537) about my motivation for this.

Note the Faker lib provides two ways to accomplish this:
1. How it is done in this PR

```python
from faker import Faker
Faker.seed('something')
faker = Faker()
```

2. Create your faker instance using the `Faker.factory()` method. 
```python
from faker.factory import Factory
Faker = Factory.create
fake = Faker()
fake.seed(0)
```

Option 2 is actually [what the faker docs recommend](https://faker.readthedocs.io/en/master/fakerclass.html).

Unfortunately, option 2 does not allow for multiple locales. Given that, I thought it best to go with option 1, rather than breaking other people's code.



<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2577.org.readthedocs.build/en/2577/

<!-- readthedocs-preview meltano-sdk end -->