### PR TITLE
fix(target): DDL for adding a column now uses a SQLAlchemy-compiled clause to apply proper quoting

### DIFF
--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -974,8 +974,8 @@ class SQLConnector:  # noqa: PLR0904
 
         return column.type
 
-    @staticmethod
     def get_column_add_ddl(
+        self,
         table_name: str,
         column_name: str,
         column_type: sa.types.TypeEngine,
@@ -998,11 +998,12 @@ class SQLConnector:  # noqa: PLR0904
                 column_type,
             ),
         )
+        compiled = create_column_clause.compile(self._engine)
         return sa.DDL(
             "ALTER TABLE %(table_name)s ADD COLUMN %(create_column_clause)s",
-            {
+            {  # type: ignore[arg-type]
                 "table_name": table_name,
-                "create_column_clause": create_column_clause,
+                "create_column_clause": compiled,
             },
         )
 


### PR DESCRIPTION
# Description

call the `compile` method, specifying the sqlalchemy engine, this ensures that sqlalchemy is able to specify database specific object quoting.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2582.org.readthedocs.build/en/2582/

<!-- readthedocs-preview meltano-sdk end -->