### PR TITLE
fix: Fixed typos in `--about` plain text output

### DIFF
--- a/singer_sdk/about.py
+++ b/singer_sdk/about.py
@@ -128,12 +128,12 @@ class TextFormatter(AboutFormatter, format_name="text"):
         )
 
         if about_info.supported_python_versions:
-            output += "\nSupport Python Versions:\n"
+            output += "\nSupported Python Versions:\n"
             output += "\n".join(
                 [f"  - {v}" for v in about_info.supported_python_versions]
             )
 
-        output += "\nSupport Python Versions:\n"
+        output += "\nCapabilities:\n"
         output += "\n".join([f"  - {c}" for c in about_info.capabilities])
 
         output += "\nSettings:\n"

--- a/tests/snapshots/about_format/text.snap.txt
+++ b/tests/snapshots/about_format/text.snap.txt
@@ -2,14 +2,14 @@ Name: tap-example
 Description: Example tap for Singer SDK
 Version: 0.1.1
 SDK Version: 1.0.0
-Support Python Versions:
+Supported Python Versions:
   - 3.8
   - 3.9
   - 3.10
   - 3.11
   - 3.12
   - 3.13
-Support Python Versions:
+Capabilities:
   - catalog
   - discover
   - state


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2592.org.readthedocs.build/en/2592/

<!-- readthedocs-preview meltano-sdk end -->