### PR TITLE
fix: Mismatch between timezone-aware and naive datetimes in start date and bookmarks is now correctly handled

### DIFF
--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -365,6 +365,23 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         state = self.get_context_state(context)
         write_replication_key_signpost(state, value)
 
+    def _parse_datetime(self, value: str) -> datetime.datetime:  # noqa: PLR6301
+        """Parse a datetime string.
+
+        Args:
+            value: The datetime string.
+
+        Returns:
+            The parsed datetime, timezone-aware preferred.
+        """
+        result = datetime_fromisoformat(value)
+
+        # Ensure datetime is timezone-aware
+        if not result.tzinfo:
+            result = result.astimezone()
+
+        return result
+
     def compare_start_date(self, value: str, start_date_value: str) -> str:
         """Compare a bookmark value to a start date and return the most recent value.
 
@@ -384,7 +401,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
             The most recent value between the bookmark and start date.
         """
         if self.is_timestamp_replication_key:
-            return max(value, start_date_value, key=datetime_fromisoformat)
+            return max(value, start_date_value, key=self._parse_datetime)
 
         return value
 

--- a/tests/core/test_streams.py
+++ b/tests/core/test_streams.py
@@ -142,6 +142,18 @@ def test_stream_apply_catalog(stream: Stream):
             id="datetime-repl-key-old-bookmark",
         ),
         pytest.param(
+            "test",
+            None,
+            "2021-01-02T00:00:00-08:00",
+            datetime.datetime(
+                2021,
+                1,
+                2,
+                tzinfo=datetime.timezone(datetime.timedelta(hours=-8)),
+            ),
+            id="datetime-repl-key-recent-bookmark-tz-aware",
+        ),
+        pytest.param(
             "unix_ts",
             None,
             None,


### PR DESCRIPTION
Related:

- Closes https://github.com/meltano/sdk/issues/2612
- https://github.com/meltano/sdk/issues/2612

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2613.org.readthedocs.build/en/2613/

<!-- readthedocs-preview meltano-sdk end -->