### PR TITLE
feat: Developers can now more easily override the mapping from SQL column type to JSON schema

### DIFF
--- a/docs/classes/singer_sdk.connectors.sql.SQLToJSONSchema.rst
+++ b/docs/classes/singer_sdk.connectors.sql.SQLToJSONSchema.rst
@@ -1,0 +1,8 @@
+﻿singer_sdk.connectors.sql.SQLToJSONSchema
+=========================================
+
+.. currentmodule:: singer_sdk.connectors.sql
+
+.. autoclass:: SQLToJSONSchema
+    :members:
+    :special-members: __init__, __call__

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -158,6 +158,10 @@ extlinks = {
         "https://json-schema.org/understanding-json-schema/reference/%s",
         "%s",
     ),
+    "column_type": (
+        "https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.%s",
+        "%s",
+    ),
 }
 
 # -- Options for intersphinx -----------------------------------------------------------

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,4 +9,5 @@ porting
 pagination-classes
 custom-clis
 config-schema
+sql-tap
 ```

--- a/docs/guides/sql-tap.md
+++ b/docs/guides/sql-tap.md
@@ -1,0 +1,59 @@
+# Building SQL taps
+
+## Default type mapping
+
+The Singer SDK automatically handles the most common SQLAlchemy column types, using [`functools.singledispatchmethod`](inv:python:py:class:#functools.singledispatchmethod) to process each type:
+
+```{eval-rst}
+.. autoclass:: singer_sdk.connectors.sql.SQLToJSONSchemaMap
+    :members:
+```
+
+## Custom type mapping
+
+If the class above doesn't cover all the types supported by the SQLAlchemy dialect in your tap, you can subclass it and override or extend with a new method for the type you need to support:
+
+```python
+import functools
+
+from sqlalchemy import Numeric
+from singer_sdk import typing as th
+from singer_sdk.connectors import SQLConnector
+from singer_sdk.connectors.sql import SQLToJSONSchemaMap
+
+from my_sqlalchemy_dialect import VectorType
+
+
+class CustomSQLToJSONSchemaMap(SQLToJSONSchemaMap):
+    @SQLToJSONSchemaMap.to_jsonschema.register
+    def custom_number_to_jsonschema(self, column_type: Numeric) -> dict:
+        """Override the default mapping for NUMERIC columns.
+
+        For example, a scale of 4 translates to a multipleOf 0.0001.
+        """
+        return {"type": ["number"], "multipleOf": 10**-column_type.scale}
+
+    @SQLToJSONSchemaMap.to_jsonschema.register(VectorType)
+    def vector_to_json_schema(self, column_type):
+        """Custom vector to JSON schema."""
+        return th.ArrayType(items=th.NumberType())
+```
+
+````{tip}
+You can also use a type annotation to specify the type of the column when registering a new method:
+
+```python
+@SQLToJSONSchemaMap.to_jsonschema.register
+def vector_to_json_schema(self, column_type: VectorType):
+    return th.ArrayType(items=th.NumberType())
+```
+````
+
+Then, you need to use your custom type mapping in your connector:
+
+```python
+class MyConnector(SQLConnector):
+    @functools.cached_property
+    def type_mapping(self):
+        return CustomSQLToJSONSchemaMap()
+```

--- a/docs/guides/sql-tap.md
+++ b/docs/guides/sql-tap.md
@@ -26,7 +26,7 @@ from my_sqlalchemy_dialect import VectorType
 
 class CustomSQLToJSONSchema(SQLToJSONSchema):
     @SQLToJSONSchema.to_jsonschema.register
-    def custom_number_to_jsonschema(self, column_type: Numeric) -> dict:
+    def custom_number_to_jsonschema(self, column_type: Numeric):
         """Override the default mapping for NUMERIC columns.
 
         For example, a scale of 4 translates to a multipleOf 0.0001.

--- a/docs/guides/sql-tap.md
+++ b/docs/guides/sql-tap.md
@@ -5,7 +5,7 @@
 The Singer SDK automatically handles the most common SQLAlchemy column types, using [`functools.singledispatchmethod`](inv:python:py:class:#functools.singledispatchmethod) to process each type:
 
 ```{eval-rst}
-.. autoclass:: singer_sdk.connectors.sql.SQLToJSONSchemaMap
+.. autoclass:: singer_sdk.connectors.sql.SQLToJSONSchema
     :members:
 ```
 
@@ -19,13 +19,13 @@ import functools
 from sqlalchemy import Numeric
 from singer_sdk import typing as th
 from singer_sdk.connectors import SQLConnector
-from singer_sdk.connectors.sql import SQLToJSONSchemaMap
+from singer_sdk.connectors.sql import SQLToJSONSchema
 
 from my_sqlalchemy_dialect import VectorType
 
 
-class CustomSQLToJSONSchemaMap(SQLToJSONSchemaMap):
-    @SQLToJSONSchemaMap.to_jsonschema.register
+class CustomSQLToJSONSchema(SQLToJSONSchema):
+    @SQLToJSONSchema.to_jsonschema.register
     def custom_number_to_jsonschema(self, column_type: Numeric) -> dict:
         """Override the default mapping for NUMERIC columns.
 
@@ -33,7 +33,7 @@ class CustomSQLToJSONSchemaMap(SQLToJSONSchemaMap):
         """
         return {"type": ["number"], "multipleOf": 10**-column_type.scale}
 
-    @SQLToJSONSchemaMap.to_jsonschema.register(VectorType)
+    @SQLToJSONSchema.to_jsonschema.register(VectorType)
     def vector_to_json_schema(self, column_type):
         """Custom vector to JSON schema."""
         return th.ArrayType(items=th.NumberType())
@@ -43,7 +43,7 @@ class CustomSQLToJSONSchemaMap(SQLToJSONSchemaMap):
 You can also use a type annotation to specify the type of the column when registering a new method:
 
 ```python
-@SQLToJSONSchemaMap.to_jsonschema.register
+@SQLToJSONSchema.to_jsonschema.register
 def vector_to_json_schema(self, column_type: VectorType):
     return th.ArrayType(items=th.NumberType())
 ```
@@ -55,5 +55,5 @@ Then, you need to use your custom type mapping in your connector:
 class MyConnector(SQLConnector):
     @functools.cached_property
     def type_mapping(self):
-        return CustomSQLToJSONSchemaMap()
+        return CustomSQLToJSONSchema()
 ```

--- a/docs/guides/sql-tap.md
+++ b/docs/guides/sql-tap.md
@@ -2,12 +2,7 @@
 
 ## Default type mapping
 
-The Singer SDK automatically handles the most common SQLAlchemy column types, using [`functools.singledispatchmethod`](inv:python:py:class:#functools.singledispatchmethod) to process each type:
-
-```{eval-rst}
-.. autoclass:: singer_sdk.connectors.sql.SQLToJSONSchema
-    :members:
-```
+The Singer SDK automatically handles the most common SQLAlchemy column types, using [`functools.singledispatchmethod`](inv:python:py:class:#functools.singledispatchmethod) to process each type. See the [`SQLToJSONSchema`](connectors.sql.SQLToJSONSchema) reference documentation for details.
 
 ## Custom type mapping
 

--- a/docs/guides/sql-tap.md
+++ b/docs/guides/sql-tap.md
@@ -31,7 +31,7 @@ class CustomSQLToJSONSchema(SQLToJSONSchema):
     @SQLToJSONSchema.to_jsonschema.register(VectorType)
     def vector_to_json_schema(self, column_type):
         """Custom vector to JSON schema."""
-        return th.ArrayType(items=th.NumberType())
+        return th.ArrayType(th.NumberType()).to_dict()
 ```
 
 ````{tip}
@@ -40,7 +40,7 @@ You can also use a type annotation to specify the type of the column when regist
 ```python
 @SQLToJSONSchema.to_jsonschema.register
 def vector_to_json_schema(self, column_type: VectorType):
-    return th.ArrayType(items=th.NumberType())
+    return th.ArrayType(th.NumberType()).to_dict()
 ```
 ````
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -143,3 +143,12 @@ Batch
 
     batch.BaseBatcher
     batch.JSONLinesBatcher
+
+Other
+-----
+
+.. autosummary::
+    :toctree: classes
+    :template: class.rst
+
+    connectors.sql.SQLToJSONSchema

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import logging
 import typing as t
 import warnings
@@ -103,6 +104,83 @@ class FullyQualifiedName(UserString):
         return part
 
 
+class SQLToJSONSchemaMap:
+    """SQLAlchemy to JSON Schema type mapping helper.
+
+    This class provides a mapping from SQLAlchemy types to JSON Schema types.
+    """
+
+    @functools.singledispatchmethod
+    def to_jsonschema(self, column_type: sa.types.TypeEngine) -> dict:  # noqa: ARG002, D102, PLR6301
+        return th.StringType.type_dict  # type: ignore[no-any-return]
+
+    @to_jsonschema.register
+    def datetime_to_jsonschema(self, column_type: sa.types.DateTime) -> dict:  # noqa: ARG002, PLR6301
+        """Return a JSON Schema representation of a generic datetime type.
+
+        Args:
+            column_type (:column_type:`DateTime`): The column type.
+        """
+        return th.DateTimeType.type_dict  # type: ignore[no-any-return]
+
+    @to_jsonschema.register
+    def date_to_jsonschema(self, column_type: sa.types.Date) -> dict:  # noqa: ARG002, PLR6301
+        """Return a JSON Schema representation of a date type.
+
+        Args:
+            column_type (:column_type:`Date`): The column type.
+        """
+        return th.DateType.type_dict  # type: ignore[no-any-return]
+
+    @to_jsonschema.register
+    def time_to_jsonschema(self, column_type: sa.types.Time) -> dict:  # noqa: ARG002, PLR6301
+        """Return a JSON Schema representation of a time type.
+
+        Args:
+            column_type (:column_type:`Time`): The column type.
+        """
+        return th.TimeType.type_dict  # type: ignore[no-any-return]
+
+    @to_jsonschema.register
+    def integer_to_jsonschema(self, column_type: sa.types.Integer) -> dict:  # noqa: ARG002, PLR6301
+        """Return a JSON Schema representation of a an integer type.
+
+        Args:
+            column_type (:column_type:`Integer`): The column type.
+        """
+        return th.IntegerType.type_dict  # type: ignore[no-any-return]
+
+    @to_jsonschema.register
+    def float_to_jsonschema(self, column_type: sa.types.Numeric) -> dict:  # noqa: ARG002, PLR6301
+        """Return a JSON Schema representation of a generic number type.
+
+        Args:
+            column_type (:column_type:`Numeric`): The column type.
+        """
+        return th.NumberType.type_dict  # type: ignore[no-any-return]
+
+    @to_jsonschema.register
+    def string_to_jsonschema(self, column_type: sa.types.String) -> dict:  # noqa: ARG002, PLR6301
+        """Return a JSON Schema representation of a generic string type.
+
+        Args:
+            column_type (:column_type:`String`): The column type.
+        """
+        # TODO: Enable support for maxLength.
+        # if sa_type.length:
+        #     return StringType(max_length=sa_type.length).type_dict  # noqa: ERA001
+        return th.StringType.type_dict  # type: ignore[no-any-return]
+
+    @to_jsonschema.register
+    def boolean_to_jsonschema(self, column_type: sa.types.Boolean) -> dict:  # noqa: ARG002, PLR6301
+        """Return a JSON Schema representation of a boolean type.
+
+        Args:
+            column_type (:column_type:`Boolean`): The column type.
+        """
+        return th.BooleanType.type_dict  # type: ignore[no-any-return]
+
+
 class SQLConnector:  # noqa: PLR0904
     """Base class for SQLAlchemy-based connectors.
 
@@ -155,6 +233,17 @@ class SQLConnector:  # noqa: PLR0904
             Plugin logger.
         """
         return logging.getLogger("sqlconnector")
+
+    @functools.cached_property
+    def type_mapping(self) -> SQLToJSONSchemaMap:
+        """Return the type mapper object.
+
+        Override this method to provide a custom mapping for your SQL dialect.
+
+        Returns:
+            The type mapper object.
+        """
+        return SQLToJSONSchemaMap()
 
     @contextmanager
     def _connect(self) -> t.Iterator[sa.engine.Connection]:
@@ -260,8 +349,8 @@ class SQLConnector:  # noqa: PLR0904
 
         return t.cast(str, config["sqlalchemy_url"])
 
-    @staticmethod
     def to_jsonschema_type(
+        self,
         sql_type: (
             str  # noqa: ANN401
             | sa.types.TypeEngine
@@ -287,10 +376,25 @@ class SQLConnector:  # noqa: PLR0904
         Returns:
             The JSON Schema representation of the provided type.
         """
-        if isinstance(sql_type, (str, sa.types.TypeEngine)):
+        if isinstance(sql_type, sa.types.TypeEngine):
+            return self.type_mapping.to_jsonschema(sql_type)
+
+        if isinstance(sql_type, str):  # pragma: no cover
+            warnings.warn(
+                "Passing string types to `to_jsonschema_type` is deprecated. "
+                "Please pass a SQLAlchemy type object instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return th.to_jsonschema_type(sql_type)
 
-        if isinstance(sql_type, type):
+        if isinstance(sql_type, type):  # pragma: no cover
+            warnings.warn(
+                "Passing type classes to `to_jsonschema_type` is deprecated. "
+                "Please pass a SQLAlchemy type object instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             if issubclass(sql_type, sa.types.TypeEngine):
                 return th.to_jsonschema_type(sql_type)
 

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -104,7 +104,7 @@ class FullyQualifiedName(UserString):
         return part
 
 
-class SQLToJSONSchemaMap:
+class SQLToJSONSchema:
     """SQLAlchemy to JSON Schema type mapping helper.
 
     This class provides a mapping from SQLAlchemy types to JSON Schema types.
@@ -235,7 +235,7 @@ class SQLConnector:  # noqa: PLR0904
         return logging.getLogger("sqlconnector")
 
     @functools.cached_property
-    def type_mapping(self) -> SQLToJSONSchemaMap:
+    def type_mapping(self) -> SQLToJSONSchema:
         """Return the type mapper object.
 
         Override this method to provide a custom mapping for your SQL dialect.
@@ -243,7 +243,7 @@ class SQLConnector:  # noqa: PLR0904
         Returns:
             The type mapper object.
         """
-        return SQLToJSONSchemaMap()
+        return SQLToJSONSchema()
 
     @contextmanager
     def _connect(self) -> t.Iterator[sa.engine.Connection]:

--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -1092,7 +1092,7 @@ class PropertiesList(ObjectType):
 
 
 @deprecated(
-    "Use `SQLToJSONSchemaMap` instead.",
+    "Use `SQLToJSONSchema` instead.",
     category=DeprecationWarning,
 )
 def to_jsonschema_type(

--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -53,6 +53,7 @@ Note:
 from __future__ import annotations
 
 import json
+import sys
 import typing as t
 
 import sqlalchemy as sa
@@ -65,9 +66,13 @@ from singer_sdk.helpers._typing import (
     get_datelike_property_type,
 )
 
-if t.TYPE_CHECKING:
-    import sys
+if sys.version_info < (3, 13):
+    from typing_extensions import deprecated
+else:
+    from typing import deprecated  # noqa: ICN003 # pragma: no cover
 
+
+if t.TYPE_CHECKING:
     from jsonschema.protocols import Validator
 
     if sys.version_info >= (3, 10):
@@ -1086,6 +1091,10 @@ class PropertiesList(ObjectType):
         return self.wrapped.values().__iter__()
 
 
+@deprecated(
+    "Use `SQLToJSONSchemaMap` instead.",
+    category=DeprecationWarning,
+)
 def to_jsonschema_type(
     from_type: str | sa.types.TypeEngine | type[sa.types.TypeEngine],
 ) -> dict:
@@ -1119,9 +1128,9 @@ def to_jsonschema_type(
         "bool": BooleanType.type_dict,
         "variant": StringType.type_dict,
     }
-    if isinstance(from_type, str):
+    if isinstance(from_type, str):  # pragma: no cover
         type_name = from_type
-    elif isinstance(from_type, sa.types.TypeEngine):
+    elif isinstance(from_type, sa.types.TypeEngine):  # pragma: no cover
         type_name = type(from_type).__name__
     elif isinstance(from_type, type) and issubclass(
         from_type,

--- a/tests/core/test_connector_sql.py
+++ b/tests/core/test_connector_sql.py
@@ -11,7 +11,7 @@ from sqlalchemy.engine.default import DefaultDialect
 
 from samples.sample_duckdb import DuckDBConnector
 from singer_sdk.connectors import SQLConnector
-from singer_sdk.connectors.sql import FullyQualifiedName, SQLToJSONSchemaMap
+from singer_sdk.connectors.sql import FullyQualifiedName, SQLToJSONSchema
 from singer_sdk.exceptions import ConfigValidationError
 
 if t.TYPE_CHECKING:
@@ -446,13 +446,13 @@ def test_sql_to_json_schema_map(
     sql_type: sa.types.TypeEngine,
     expected_jsonschema_type: dict,
 ):
-    m = SQLToJSONSchemaMap()
+    m = SQLToJSONSchema()
     assert m.to_jsonschema(sql_type) == expected_jsonschema_type
 
 
 def test_custom_type():
-    class MyMap(SQLToJSONSchemaMap):
-        @SQLToJSONSchemaMap.to_jsonschema.register
+    class MyMap(SQLToJSONSchema):
+        @SQLToJSONSchema.to_jsonschema.register
         def custom_number_to_jsonschema(self, column_type: sa.types.NUMERIC) -> dict:
             """Custom number to JSON schema.
 
@@ -460,7 +460,7 @@ def test_custom_type():
             """
             return {"type": ["number"], "multipleOf": 10**-column_type.scale}
 
-        @SQLToJSONSchemaMap.to_jsonschema.register(MyType)
+        @SQLToJSONSchema.to_jsonschema.register(MyType)
         def my_type_to_jsonschema(self, column_type) -> dict:  # noqa: ARG002
             return {"type": ["string"], "contentEncoding": "base64"}
 

--- a/tests/core/test_sql_typing.py
+++ b/tests/core/test_sql_typing.py
@@ -70,5 +70,7 @@ def test_convert_sql_type_to_jsonschema_type(
     sql_type: sa.types.TypeEngine,
     is_of_jsonschema_type: dict,
 ):
-    result = th.to_jsonschema_type(sql_type)
+    with pytest.warns(DeprecationWarning):
+        result = th.to_jsonschema_type(sql_type)
+
     assert result == is_of_jsonschema_type


### PR DESCRIPTION
Related:

- https://github.com/meltano/sdk/issues/1831
- https://github.com/TicketSwap/target-redshift/issues/105
- https://github.com/MeltanoLabs/tap-postgres/issues/477
- https://github.com/meltano/sdk/issues/1812
- https://github.com/MeltanoLabs/tap-postgres/pull/485
- https://github.com/thkwag/target-mysql/blob/c84fe01850b0470d39e4d0c56fd884e2019174c4/target_mysql/sinks.py#L195-L196

New docs links:

- Custom type mapping guide: https://meltano-sdk--2618.org.readthedocs.build/en/2618/guides/sql-tap.html#custom-type-mapping
- Default type mapping reference docs: https://meltano-sdk--2618.org.readthedocs.build/en/2618/classes/singer_sdk.connectors.sql.SQLToJSONSchema.html#singer_sdk.connectors.sql.SQLToJSONSchema

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2618.org.readthedocs.build/en/2618/

<!-- readthedocs-preview meltano-sdk end -->