### PR TITLE
refactor: Default to UTC when parsing dates without a known timezone

### DIFF
--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -378,7 +378,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
         # Ensure datetime is timezone-aware
         if not result.tzinfo:
-            result = result.astimezone()
+            result = result.replace(tzinfo=datetime.timezone.utc)
 
         return result
 


### PR DESCRIPTION
Follow-on of https://github.com/meltano/sdk/pull/2613.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2619.org.readthedocs.build/en/2619/

<!-- readthedocs-preview meltano-sdk end -->