### PR TITLE
ci: Use `include-hidden-files: true` to upload coverage artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always() && (matrix.session == 'tests')
       with:
+        include-hidden-files: true
         name: coverage-data-nox_${{ matrix.session }}-${{ matrix.os }}-py${{ matrix.python-version }}_sqlalchemy_${{ matrix.sqlalchemy }}
         path: ".coverage.*"
 


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2638.org.readthedocs.build/en/2638/

<!-- readthedocs-preview meltano-sdk end -->