### PR TITLE
docs: Documented versions where `fake` and `Faker` objects were added to the stream maps context

### DIFF
--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -253,8 +253,16 @@ can be referenced directly by mapping expressions.
   masking by allowing users to call `Faker.seed()`.
 
   ```{tip}
-  The `fake` object is only available if the plugin specifies `faker` as an additional dependency (through the `singer-sdk` `faker` extra, or directly).
+  The `fake` object and `Faker` are only available if the plugin specifies `faker` as an additional dependency (through the `singer-sdk` `faker` extra, or directly).
   ```
+
+:::{versionadded} 0.35.0
+The `faker` object.
+:::
+
+:::{versionadded} 0.40.0
+The `Faker` class.
+:::
 
 #### Automatic Schema Detection
 


### PR DESCRIPTION
Take a look: https://meltano-sdk--2639.org.readthedocs.build/en/2639/stream_maps.html#built-in-variable-names.

Motivation: https://github.com/MeltanoLabs/meltano-map-transform/issues/215#issuecomment-2324100873


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2639.org.readthedocs.build/en/2639/

<!-- readthedocs-preview meltano-sdk end -->