### PR TITLE
packaging: Remove upper constraint on `faker` extra

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -642,13 +642,13 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "faker"
-version = "28.0.0"
+version = "28.1.0"
 description = "Faker is a Python package that generates fake data for you."
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "Faker-28.0.0-py3-none-any.whl", hash = "sha256:6a3a08be54c37e05f7943d7ba5211d252c1de737687a46ad6f29209d8d5db11f"},
-    {file = "faker-28.0.0.tar.gz", hash = "sha256:0d3c0399204aaf8205cc1750db443474ca0436f177126b2c27b798e8336cc74f"},
+    {file = "Faker-28.1.0-py3-none-any.whl", hash = "sha256:b17d69312ef6485a720e21bffa997668c88876a5298b278e903ba706243c9c6b"},
+    {file = "faker-28.1.0.tar.gz", hash = "sha256:bc460a0e6020966410d0b276043879abca0fac51890f3324bc254bb0a383ee3a"},
 ]
 
 [package.dependencies]
@@ -2592,4 +2592,4 @@ testing = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "cdb61b3c2edc05495046425e778c37240b7035bbed822153ec4d5c38c8e54d57"
+content-hash = "34a80dcb1e59005ff2d6e534b2fed2cf683cf8c0b4a54ce5af6e779cf07090d0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ pyarrow = { version = ">=13", optional = true }
 pytest = {version=">=7.2.1", optional = true}
 
 # installed as optional 'faker' extra
-faker = {version = ">=22.5,<29.0", optional = true}
+faker = {version = ">=22.5", optional = true}
 
 # Crypto extras
 cryptography = { version = ">=3.4.6", optional = true }


### PR DESCRIPTION
Less maintenance burden on our end. If `faker` makes a breaking change upstream, we would just catch it CI and make a patch release.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2640.org.readthedocs.build/en/2640/

<!-- readthedocs-preview meltano-sdk end -->