### PR TITLE
refactor: Use future `warnings.deprecated` decorator

### DIFF
--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -5,14 +5,19 @@ from __future__ import annotations
 import base64
 import datetime
 import math
+import sys
 import typing as t
-import warnings
 from types import MappingProxyType
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
 import requests
 
 from singer_sdk.helpers._util import utc_now
+
+if sys.version_info < (3, 13):
+    from typing_extensions import deprecated
+else:
+    from warnings import deprecated
 
 if t.TYPE_CHECKING:
     import logging
@@ -277,6 +282,10 @@ class BearerTokenAuthenticator(APIAuthenticatorBase):
         return cls(stream=stream, token=token)
 
 
+@deprecated(
+    "BasicAuthenticator is deprecated. Use requests.auth.HTTPBasicAuth instead.",
+    category=DeprecationWarning,
+)
 class BasicAuthenticator(APIAuthenticatorBase):
     """Implements basic authentication for REST Streams.
 
@@ -302,12 +311,6 @@ class BasicAuthenticator(APIAuthenticatorBase):
             password: API password.
         """
         super().__init__(stream=stream)
-        warnings.warn(
-            "BasicAuthenticator is deprecated. Use "
-            "requests.auth.HTTPBasicAuth instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
         credentials = f"{username}:{password}".encode()
         auth_token = base64.b64encode(credentials).decode("ascii")

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 import typing as t
 import warnings
 from collections import UserString
@@ -17,6 +18,11 @@ from singer_sdk._singerlib import CatalogEntry, MetadataMapping, Schema
 from singer_sdk.exceptions import ConfigValidationError
 from singer_sdk.helpers._util import dump_json, load_json
 from singer_sdk.helpers.capabilities import TargetLoadMethods
+
+if sys.version_info < (3, 13):
+    from typing_extensions import deprecated
+else:
+    from warnings import deprecated
 
 if t.TYPE_CHECKING:
     from sqlalchemy.engine import Engine
@@ -161,6 +167,14 @@ class SQLConnector:  # noqa: PLR0904
         with self._engine.connect().execution_options(stream_results=True) as conn:
             yield conn
 
+    @deprecated(
+        "`SQLConnector.create_sqlalchemy_connection` is deprecated. "
+        "If you need to execute something that isn't available "
+        "on the connector currently, make a child class and "
+        "add your required method on that connector.",
+        category=DeprecationWarning,
+        stacklevel=1,
+    )
     def create_sqlalchemy_connection(self) -> sa.engine.Connection:
         """(DEPRECATED) Return a new SQLAlchemy connection using the provided config.
 
@@ -180,16 +194,14 @@ class SQLConnector:  # noqa: PLR0904
         Returns:
             A newly created SQLAlchemy engine object.
         """
-        warnings.warn(
-            "`SQLConnector.create_sqlalchemy_connection` is deprecated. "
-            "If you need to execute something that isn't available "
-            "on the connector currently, make a child class and "
-            "add your required method on that connector.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return self._engine.connect().execution_options(stream_results=True)
 
+    @deprecated(
+        "`SQLConnector.create_sqlalchemy_engine` is deprecated. Override "
+        "`_engine` or `sqlalchemy_url` instead.",
+        category=DeprecationWarning,
+        stacklevel=1,
+    )
     def create_sqlalchemy_engine(self) -> Engine:
         """(DEPRECATED) Return a new SQLAlchemy engine using the provided config.
 
@@ -199,12 +211,6 @@ class SQLConnector:  # noqa: PLR0904
         Returns:
             A newly created SQLAlchemy engine object.
         """
-        warnings.warn(
-            "`SQLConnector.create_sqlalchemy_engine` is deprecated. Override"
-            "`_engine` or sqlalchemy_url` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return self._engine
 
     @property

--- a/tests/core/test_connector_sql.py
+++ b/tests/core/test_connector_sql.py
@@ -156,7 +156,7 @@ class TestConnectorSQL:  # noqa: PLR0904
         engine2 = connector._cached_engine
         assert engine1 is engine2
 
-    def test_deprecated_functions_warn(self, connector):
+    def test_deprecated_functions_warn(self, connector: SQLConnector):
         with pytest.deprecated_call():
             connector.create_sqlalchemy_engine()
         with pytest.deprecated_call():


### PR DESCRIPTION
- https://peps.python.org/pep-0702/
- https://docs.python.org/3.13/library/warnings.html#warnings.deprecated
- https://typing-extensions.readthedocs.io/en/latest/#typing_extensions.deprecated

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2647.org.readthedocs.build/en/2647/

<!-- readthedocs-preview meltano-sdk end -->