### PR TITLE
feat: Support stream aliasing of `BATCH` messages via stream maps

### DIFF
--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -462,14 +462,16 @@ class Target(PluginBase, SingerReader, metaclass=abc.ABCMeta):
         Args:
             message_dict: TODO
         """
-        sink = self.get_sink(message_dict["stream"])
-
+        stream_name = message_dict["stream"]
         encoding = BaseBatchFileEncoding.from_dict(message_dict["encoding"])
-        sink.process_batch_files(
-            encoding,
-            message_dict["manifest"],
-        )
-        self._handle_max_record_age()
+
+        for stream_map in self.mapper.stream_maps[stream_name]:
+            sink = self.get_sink(stream_map.stream_alias)
+            sink.process_batch_files(
+                encoding,
+                message_dict["manifest"],
+            )
+            self._handle_max_record_age()
 
     # Sink drain methods
 

--- a/tests/core/test_mapper.py
+++ b/tests/core/test_mapper.py
@@ -657,6 +657,9 @@ class MappedStream(Stream):
             },
         }
 
+    def get_batches(self, batch_config, context):
+        yield batch_config.encoding, ["file:///tmp/stream.json.gz"]
+
 
 class MappedTap(Tap):
     """A tap with mapped streams."""
@@ -751,6 +754,19 @@ class MappedTap(Tap):
             {"flattening_enabled": False, "flattening_max_depth": 0},
             "aliased_stream.jsonl",
             id="aliased_stream",
+        ),
+        pytest.param(
+            {"mystream": {"__alias__": "aliased_stream"}},
+            {
+                "flattening_enabled": False,
+                "flattening_max_depth": 0,
+                "batch_config": {
+                    "encoding": {"format": "jsonl", "compression": "gzip"},
+                    "storage": {"root": "file:///tmp"},
+                },
+            },
+            "aliased_stream_batch.jsonl",
+            id="aliased_stream_batch",
         ),
         pytest.param(
             {},

--- a/tests/core/test_mapper.py
+++ b/tests/core/test_mapper.py
@@ -657,7 +657,7 @@ class MappedStream(Stream):
             },
         }
 
-    def get_batches(self, batch_config, context):
+    def get_batches(self, batch_config, context):  # noqa: ARG002
         yield batch_config.encoding, ["file:///tmp/stream.json.gz"]
 
 

--- a/tests/snapshots/mapped_stream/aliased_stream_batch.jsonl
+++ b/tests/snapshots/mapped_stream/aliased_stream_batch.jsonl
@@ -1,0 +1,5 @@
+{"type":"STATE","value":{}}
+{"type":"SCHEMA","stream":"aliased_stream","schema":{"properties":{"email":{"type":["string"]},"count":{"type":["integer","null"]},"user":{"properties":{"id":{"type":["integer","null"]},"sub":{"properties":{"num":{"type":["integer","null"]},"custom_obj":{"type":["string","null"]}},"type":["object","null"]},"some_numbers":{"items":{"type":["number"]},"type":["array","null"]}},"type":["object","null"]}},"type":"object","required":["email"]},"key_properties":[]}
+{"type":"BATCH","stream":"aliased_stream","encoding":{"format":"jsonl","compression":"gzip"},"manifest":["file:///tmp/stream.json.gz"]}
+{"type":"STATE","value":{}}
+{"type":"STATE","value":{"bookmarks":{"mystream":{}}}}


### PR DESCRIPTION
Adds support for `BATCH` messages with `__alias__` using stream maps - a small step towards #1117.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2667.org.readthedocs.build/en/2667/

<!-- readthedocs-preview meltano-sdk end -->