### PR TITLE
refactor: Deprecated `Faker` class in stream maps

### DIFF
--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -249,11 +249,9 @@ can be referenced directly by mapping expressions.
 - `fake` - a [`Faker`](inv:faker:std:doc#index) instance, configurable via `faker_config`
   (see previous example) - see the built-in [standard providers](inv:faker:std:doc#providers)
   for available methods
-- `Faker` - the [`Faker`](inv:faker:std:doc#fakerclass) class. This was made available to enable consistent data
-  masking by allowing users to call `Faker.seed()`.
 
   ```{tip}
-  The `fake` object and `Faker` are only available if the plugin specifies `faker` as an additional dependency (through the `singer-sdk` `faker` extra, or directly).
+  The `fake` object is only available if the plugin specifies `faker` as an additional dependency (through the `singer-sdk` `faker` extra, or directly).
   ```
 
 :::{versionadded} 0.35.0
@@ -262,6 +260,10 @@ The `faker` object.
 
 :::{versionadded} 0.40.0
 The `Faker` class.
+:::
+
+:::{versionchanged} TODO
+The `Faker` class was deprecated in favor of instance methods on the `fake` object.
 :::
 
 #### Automatic Schema Detection
@@ -475,9 +477,9 @@ To generate consistent masked values, you must provide the **same seed each time
 stream_maps:
   customers:
     # will always generate the same value for the same seed
-    first_name: Faker.seed(_['first_name']) or fake.first_name()
+    first_name: fake.seed_instance(_['first_name']) or fake.first_name()
 faker_config:
-  # IMPORTANT: `fake` and `Faker` names are only available if faker_config is defined.
+  # IMPORTANT: `fake` is only available if the `faker` extra is installed
   locale: en_US
 ```
 

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -519,7 +519,7 @@ class CustomStreamMap(StreamMap):
                 )
                 if "Faker" in prop_def:
                     warnings.warn(
-                        "Class 'Faker' is deprecated in stream maps. Use instance methods, like 'fake.seed_instance'",  # noqa: E501
+                        "Class 'Faker' is deprecated in stream maps. Use instance methods, like 'fake.seed_instance.'",  # noqa: E501
                         DeprecationWarning,
                         stacklevel=2,
                     )

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -14,7 +14,9 @@ import hashlib
 import importlib.util
 import json
 import logging
+import sys
 import typing as t
+import warnings
 
 import simpleeval  # type: ignore[import-untyped]
 
@@ -515,6 +517,12 @@ class CustomStreamMap(StreamMap):
                         self._eval_type(prop_def, default=default_type),
                     ).to_dict(),
                 )
+                if "Faker" in prop_def:
+                    warnings.warn(
+                        "Class 'Faker' is deprecated in stream maps. Use instance methods, like 'fake.seed_instance'",  # noqa: E501
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
                 try:
                     parsed_def: ast.Expr = ast.parse(prop_def).body[0]  # type: ignore[assignment]
                     stream_map_parsed.append((prop_key, prop_def, parsed_def))

--- a/tests/core/test_mapper.py
+++ b/tests/core/test_mapper.py
@@ -853,6 +853,43 @@ class MappedTap(Tap):
             "fake_credit_card_number.jsonl",
             id="fake_credit_card_number",
         ),
+        pytest.param(
+            {
+                "mystream": {
+                    "email": "Faker.seed(email) or fake.email()",
+                    "__else__": None,
+                },
+            },
+            {
+                "flattening_enabled": False,
+                "flattening_max_depth": 0,
+                "faker_config": {
+                    "locale": "en_US",
+                },
+            },
+            "fake_email_seed_class.jsonl",
+            id="fake_email_seed_class",
+            marks=pytest.mark.filterwarnings(
+                "default:Class 'Faker' is deprecated:DeprecationWarning"
+            ),
+        ),
+        pytest.param(
+            {
+                "mystream": {
+                    "email": "fake.seed_instance(email) or fake.email()",
+                    "__else__": None,
+                },
+            },
+            {
+                "flattening_enabled": False,
+                "flattening_max_depth": 0,
+                "faker_config": {
+                    "locale": "en_US",
+                },
+            },
+            "fake_email_seed_instance.jsonl",
+            id="fake_email_seed_instance",
+        ),
     ],
 )
 def test_mapped_stream(

--- a/tests/snapshots/mapped_stream/fake_email_seed_class.jsonl
+++ b/tests/snapshots/mapped_stream/fake_email_seed_class.jsonl
@@ -1,0 +1,6 @@
+{"type":"STATE","value":{}}
+{"type":"SCHEMA","stream":"mystream","schema":{"type":"object","properties":{"email":{"type":["string","null"]}}},"key_properties":[]}
+{"type":"RECORD","stream":"mystream","record":{"email":"zwells@example.org"},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"mystream","record":{"email":"josephcunningham@example.com"},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"mystream","record":{"email":"lydia62@example.net"},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"STATE","value":{"bookmarks":{"mystream":{}}}}

--- a/tests/snapshots/mapped_stream/fake_email_seed_instance.jsonl
+++ b/tests/snapshots/mapped_stream/fake_email_seed_instance.jsonl
@@ -1,0 +1,6 @@
+{"type":"STATE","value":{}}
+{"type":"SCHEMA","stream":"mystream","schema":{"type":"object","properties":{"email":{"type":["string","null"]}}},"key_properties":[]}
+{"type":"RECORD","stream":"mystream","record":{"email":"zwells@example.org"},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"mystream","record":{"email":"josephcunningham@example.com"},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"mystream","record":{"email":"lydia62@example.net"},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"STATE","value":{"bookmarks":{"mystream":{}}}}


### PR DESCRIPTION
Related:

- Closes #2669
- https://github.com/meltano/sdk/pull/2598#issuecomment-2351878064

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2670.org.readthedocs.build/en/2670/

<!-- readthedocs-preview meltano-sdk end -->