### PR TITLE
chore: Fix the `warnings.deprecated` import in Python 3.13

### DIFF
--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -69,7 +69,7 @@ from singer_sdk.helpers._typing import (
 if sys.version_info < (3, 13):
     from typing_extensions import deprecated
 else:
-    from typing import deprecated  # noqa: ICN003 # pragma: no cover
+    from warnings import deprecated  # pragma: no cover
 
 
 if t.TYPE_CHECKING:


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2676.org.readthedocs.build/en/2676/

<!-- readthedocs-preview meltano-sdk end -->