### PR TITLE
fix: A clear error message is now emitted when flattening is enable but `flattening_max_depth` is not set

### DIFF
--- a/singer_sdk/helpers/_flattening.py
+++ b/singer_sdk/helpers/_flattening.py
@@ -11,6 +11,7 @@ from copy import deepcopy
 import inflection
 
 from singer_sdk._singerlib.json import serialize_json
+from singer_sdk.exceptions import ConfigValidationError
 
 DEFAULT_FLATTENING_SEPARATOR = "__"
 
@@ -35,7 +36,14 @@ def get_flattening_options(
         A new FlatteningOptions object or None if flattening is disabled.
     """
     if plugin_config.get("flattening_enabled", False):
-        return FlatteningOptions(max_level=int(plugin_config["flattening_max_depth"]))
+        if (max_depth := plugin_config.get("flattening_max_depth")) is not None:
+            return FlatteningOptions(max_level=int(max_depth))
+
+        msg = "Flattening is misconfigured"
+        raise ConfigValidationError(
+            msg,
+            errors=["flattening_max_depth is required when flattening is enabled"],
+        )
 
     return None
 

--- a/tests/core/test_flattening.py
+++ b/tests/core/test_flattening.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-from singer_sdk.helpers._flattening import flatten_record
+from singer_sdk.exceptions import ConfigValidationError
+from singer_sdk.helpers._flattening import flatten_record, get_flattening_options
 
 
 @pytest.mark.parametrize(
@@ -72,3 +73,15 @@ def test_flatten_record(flattened_schema, max_level, expected):
         record, max_level=max_level, flattened_schema=flattened_schema
     )
     assert expected == result
+
+
+def test_get_flattening_options_missing_max_depth():
+    with pytest.raises(
+        ConfigValidationError, match="Flattening is misconfigured"
+    ) as exc:
+        get_flattening_options({"flattening_enabled": True})
+
+    assert (
+        exc.value.errors[0]
+        == "flattening_max_depth is required when flattening is enabled"
+    )


### PR DESCRIPTION
See https://github.com/MeltanoLabs/tap-stackexchange/issues/41

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2683.org.readthedocs.build/en/2683/

<!-- readthedocs-preview meltano-sdk end -->