### PR TITLE
packaging(templates): Remove unused backport `importlib_resources` dependency in tap template

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -29,7 +29,6 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.9"
-importlib-resources = { version = "==6.4.*", python = "<3.9" }
 singer-sdk = { version="~=0.40.0", extras = [
     {%- if cookiecutter.auth_method == "JWT" -%}"jwt", {% endif -%}
     {%- if cookiecutter.faker_extra -%}"faker",{%- endif -%}


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2694.org.readthedocs.build/en/2694/

<!-- readthedocs-preview meltano-sdk end -->