### PR TITLE
fix: All HTTP timeout exceptions are now retried in REST and GraphQL streams

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -253,7 +253,7 @@ class RESTStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: PL
             (
                 ConnectionResetError,
                 RetriableAPIError,
-                requests.exceptions.ReadTimeout,
+                requests.exceptions.Timeout,
                 requests.exceptions.ConnectionError,
                 requests.exceptions.ChunkedEncodingError,
                 requests.exceptions.ContentDecodingError,


### PR DESCRIPTION
Closes #2643 

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2697.org.readthedocs.build/en/2697/

<!-- readthedocs-preview meltano-sdk end -->