### PR TITLE
feat(mappers): Stream name can now be accessed in `__alias__` context of stream maps

### DIFF
--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -675,7 +675,7 @@ stream_maps:
 ````
 
 :::{versionadded} TODO
-Support for __alias__ expression evaluation.
+Support for `__alias__` expression evaluation.
 :::
 
 ### Understanding Filters' Affects on Parent-Child Streams

--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -266,6 +266,14 @@ The `Faker` class.
 The `Faker` class was deprecated in favor of instance methods on the `fake` object.
 :::
 
+#### Built-in Alias Variable Names
+
+- `__stream_name__` - the existing stream name
+
+:::{versionadded} TODO
+The `__stream_name__` variable.
+:::
+
 #### Automatic Schema Detection
 
 For performance reasons, type detection is performed at runtime using text analysis
@@ -638,6 +646,36 @@ stream_maps:
 
 :::{versionadded} 0.37.0
 Support for stream glob expressions.
+:::
+
+### Aliasing two or more streams
+
+The `__alias__` operation has built-in variable `__stream_name__`, representing the original stream.
+
+You can combine this with glob expressions to rename more than one stream:
+
+````{tab} meltano.yml
+```yaml
+stream_maps:
+  "*":
+    __alias__: "__stream_name__ + '_v2'"
+```
+````
+
+````{tab} JSON
+```json
+{
+    "stream_maps": {
+        "*": {
+            "__alias__": "__stream_name__ + '_v2'"
+        }
+    }
+}
+```
+````
+
+:::{versionadded} TODO
+Support for __alias__ expression evaluation.
 :::
 
 ### Understanding Filters' Affects on Parent-Child Streams

--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -650,7 +650,7 @@ Support for stream glob expressions.
 
 ### Aliasing two or more streams
 
-The `__alias__` operation has built-in variable `__stream_name__`, representing the original stream.
+The `__alias__` operation evaluates simple python expressions.
 
 You can combine this with glob expressions to rename more than one stream:
 

--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -268,6 +268,7 @@ The `Faker` class was deprecated in favor of instance methods on the `fake` obje
 
 #### Built-in Alias Variable Names
 
+The following variables are available in the context of the `__alias__` expression:
 - `__stream_name__` - the existing stream name
 
 :::{versionadded} TODO

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -866,6 +866,6 @@ class PluginMapper:
             msg = f"Failed to evaluate simpleeval expressions {expr}."
             raise MapExpressionError(msg) from ex
 
-        logging.debug("Eval result: %s = %s", expr, result)
+        logging.debug("Stream eval result: %s = %s", expr, result)
 
         return result

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -850,16 +850,18 @@ class PluginMapper:
         # Allow stream name access within alias transform
         names = {"__stream_name__": stream_name}
 
+        result: str
+
         try:
             expr_evaluator = simpleeval.EvalWithCompoundTypes(names=names)
-            result: str = expr_evaluator.eval(expr)
+            result = expr_evaluator.eval(expr)
         except simpleeval.NameNotDefined:
             logging.debug(
                 "Failed to evaluate simpleeval expression %(expr) - "
                 "falling back to original expression",
                 extra={"expr": expr},
             )
-            result: str = expr
+            result = expr
         except (simpleeval.InvalidExpression, SyntaxError) as ex:
             msg = f"Failed to evaluate simpleeval expressions {expr}."
             raise MapExpressionError(msg) from ex

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -779,6 +779,7 @@ class PluginMapper:
                 elif MAPPER_ALIAS_OPTION in stream_def:
                     # <source>: __alias__: <alias>
                     stream_alias = stream_def.pop(MAPPER_ALIAS_OPTION)
+                    stream_alias = PluginMapper._eval_stream(stream_alias, stream_name)
 
             if stream_name == source_stream:
                 # Exact match
@@ -831,3 +832,38 @@ class PluginMapper:
             else:
                 # Additional mappers for aliasing and multi-projection:
                 self.stream_maps[source_stream].append(mapper)
+
+    @staticmethod
+    def _eval_stream(expr: str, stream_name: str) -> str:
+        """Solve an alias expression.
+
+        Args:
+            expr: String expression to evaluate.
+            stream_name: Name of stream to transform.
+
+        Returns:
+            Evaluated expression.
+
+        Raises:
+            MapExpressionError: If the mapping expression failed to evaluate.
+        """
+        # Allow stream name access within alias transform
+        names = {"__stream_name__": stream_name}
+
+        try:
+            expr_evaluator = simpleeval.EvalWithCompoundTypes(names=names)
+            result: str = expr_evaluator.eval(expr)
+        except simpleeval.NameNotDefined:
+            logging.debug(
+                "Failed to evaluate simpleeval expression %(expr) - "
+                "falling back to original expression",
+                extra={"expr": expr},
+            )
+            result: str = expr
+        except (simpleeval.InvalidExpression, SyntaxError) as ex:
+            msg = f"Failed to evaluate simpleeval expressions {expr}."
+            raise MapExpressionError(msg) from ex
+
+        logging.debug("Eval result: %s = %s", expr, result)
+
+        return result

--- a/tests/core/test_mapper.py
+++ b/tests/core/test_mapper.py
@@ -769,6 +769,30 @@ class MappedTap(Tap):
             id="aliased_stream_batch",
         ),
         pytest.param(
+            {"mystream": {"__alias__": "aliased.stream"}},
+            {"flattening_enabled": False, "flattening_max_depth": 0},
+            "aliased_stream_not_expr.jsonl",
+            id="aliased_stream_not_expr",
+        ),
+        pytest.param(
+            {"mystream": {"__alias__": "'__stream_name__'"}},
+            {"flattening_enabled": False, "flattening_max_depth": 0},
+            "aliased_stream_quoted.jsonl",
+            id="aliased_stream_quoted",
+        ),
+        pytest.param(
+            {"mystream": {"__alias__": "'aliased_' + __stream_name__"}},
+            {"flattening_enabled": False, "flattening_max_depth": 0},
+            "builtin_variable_stream_name_alias.jsonl",
+            id="builtin_variable_stream_name_alias",
+        ),
+        pytest.param(
+            {"mystream": {"__alias__": "__stream_name__.upper()"}},
+            {"flattening_enabled": False, "flattening_max_depth": 0},
+            "builtin_variable_stream_name_alias_expr.jsonl",
+            id="builtin_variable_stream_name_alias_expr",
+        ),
+        pytest.param(
             {},
             {"flattening_enabled": True, "flattening_max_depth": 0},
             "flatten_depth_0.jsonl",

--- a/tests/snapshots/mapped_stream/aliased_stream_not_expr.jsonl
+++ b/tests/snapshots/mapped_stream/aliased_stream_not_expr.jsonl
@@ -1,0 +1,6 @@
+{"type":"STATE","value":{}}
+{"type":"SCHEMA","stream":"aliased.stream","schema":{"properties":{"email":{"type":["string"]},"count":{"type":["integer","null"]},"user":{"properties":{"id":{"type":["integer","null"]},"sub":{"properties":{"num":{"type":["integer","null"]},"custom_obj":{"type":["string","null"]}},"type":["object","null"]},"some_numbers":{"items":{"type":["number"]},"type":["array","null"]}},"type":["object","null"]}},"type":"object","required":["email"]},"key_properties":[]}
+{"type":"RECORD","stream":"aliased.stream","record":{"email":"alice@example.com","count":21,"user":{"id":1,"sub":{"num":1,"custom_obj":"obj-hello"},"some_numbers":[3.14,2.718]}},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"aliased.stream","record":{"email":"bob@example.com","count":13,"user":{"id":2,"sub":{"num":2,"custom_obj":"obj-world"},"some_numbers":[10.32,1.618]}},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"aliased.stream","record":{"email":"charlie@example.com","count":19,"user":{"id":3,"sub":{"num":3,"custom_obj":"obj-hello"},"some_numbers":[1.414,1.732]}},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"STATE","value":{"bookmarks":{"mystream":{}}}}

--- a/tests/snapshots/mapped_stream/aliased_stream_quoted.jsonl
+++ b/tests/snapshots/mapped_stream/aliased_stream_quoted.jsonl
@@ -1,0 +1,6 @@
+{"type":"STATE","value":{}}
+{"type":"SCHEMA","stream":"__stream_name__","schema":{"properties":{"email":{"type":["string"]},"count":{"type":["integer","null"]},"user":{"properties":{"id":{"type":["integer","null"]},"sub":{"properties":{"num":{"type":["integer","null"]},"custom_obj":{"type":["string","null"]}},"type":["object","null"]},"some_numbers":{"items":{"type":["number"]},"type":["array","null"]}},"type":["object","null"]}},"type":"object","required":["email"]},"key_properties":[]}
+{"type":"RECORD","stream":"__stream_name__","record":{"email":"alice@example.com","count":21,"user":{"id":1,"sub":{"num":1,"custom_obj":"obj-hello"},"some_numbers":[3.14,2.718]}},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"__stream_name__","record":{"email":"bob@example.com","count":13,"user":{"id":2,"sub":{"num":2,"custom_obj":"obj-world"},"some_numbers":[10.32,1.618]}},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"__stream_name__","record":{"email":"charlie@example.com","count":19,"user":{"id":3,"sub":{"num":3,"custom_obj":"obj-hello"},"some_numbers":[1.414,1.732]}},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"STATE","value":{"bookmarks":{"mystream":{}}}}

--- a/tests/snapshots/mapped_stream/builtin_variable_stream_name_alias.jsonl
+++ b/tests/snapshots/mapped_stream/builtin_variable_stream_name_alias.jsonl
@@ -1,0 +1,6 @@
+{"type":"STATE","value":{}}
+{"type":"SCHEMA","stream":"aliased_mystream","schema":{"properties":{"email":{"type":["string"]},"count":{"type":["integer","null"]},"user":{"properties":{"id":{"type":["integer","null"]},"sub":{"properties":{"num":{"type":["integer","null"]},"custom_obj":{"type":["string","null"]}},"type":["object","null"]},"some_numbers":{"items":{"type":["number"]},"type":["array","null"]}},"type":["object","null"]}},"type":"object","required":["email"]},"key_properties":[]}
+{"type":"RECORD","stream":"aliased_mystream","record":{"email":"alice@example.com","count":21,"user":{"id":1,"sub":{"num":1,"custom_obj":"obj-hello"},"some_numbers":[3.14,2.718]}},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"aliased_mystream","record":{"email":"bob@example.com","count":13,"user":{"id":2,"sub":{"num":2,"custom_obj":"obj-world"},"some_numbers":[10.32,1.618]}},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"aliased_mystream","record":{"email":"charlie@example.com","count":19,"user":{"id":3,"sub":{"num":3,"custom_obj":"obj-hello"},"some_numbers":[1.414,1.732]}},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"STATE","value":{"bookmarks":{"mystream":{}}}}

--- a/tests/snapshots/mapped_stream/builtin_variable_stream_name_alias_expr.jsonl
+++ b/tests/snapshots/mapped_stream/builtin_variable_stream_name_alias_expr.jsonl
@@ -1,0 +1,6 @@
+{"type":"STATE","value":{}}
+{"type":"SCHEMA","stream":"MYSTREAM","schema":{"properties":{"email":{"type":["string"]},"count":{"type":["integer","null"]},"user":{"properties":{"id":{"type":["integer","null"]},"sub":{"properties":{"num":{"type":["integer","null"]},"custom_obj":{"type":["string","null"]}},"type":["object","null"]},"some_numbers":{"items":{"type":["number"]},"type":["array","null"]}},"type":["object","null"]}},"type":"object","required":["email"]},"key_properties":[]}
+{"type":"RECORD","stream":"MYSTREAM","record":{"email":"alice@example.com","count":21,"user":{"id":1,"sub":{"num":1,"custom_obj":"obj-hello"},"some_numbers":[3.14,2.718]}},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"MYSTREAM","record":{"email":"bob@example.com","count":13,"user":{"id":2,"sub":{"num":2,"custom_obj":"obj-world"},"some_numbers":[10.32,1.618]}},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"MYSTREAM","record":{"email":"charlie@example.com","count":19,"user":{"id":3,"sub":{"num":3,"custom_obj":"obj-hello"},"some_numbers":[1.414,1.732]}},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"STATE","value":{"bookmarks":{"mystream":{}}}}


### PR DESCRIPTION
## Description

Allow users to reference the stream name in stream maps __alias__ fields, under a special key:

```
{
    "stream_maps": {
        "*": {
            "__alias__": "'raw_' + __stream_name__"
        },
}
```

## Related

* Closes #2700 
* Similar to #2283 but `__alias__` was not an evaluated field before now

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2701.org.readthedocs.build/en/2701/

<!-- readthedocs-preview meltano-sdk end -->