### PR TITLE
chore: Use `importlib.resources` from the standard library

### DIFF
--- a/singer_sdk/testing/templates.py
+++ b/singer_sdk/testing/templates.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import contextlib
+import importlib.resources
 import typing as t
 import warnings
 
-from singer_sdk.helpers._compat import importlib_resources
 from singer_sdk.testing import target_test_streams
 
 if t.TYPE_CHECKING:
@@ -337,4 +337,4 @@ class TargetFileTestTemplate(TargetTestTemplate):
         Returns:
             The expected Path to this tests singer file.
         """
-        return importlib_resources.files(target_test_streams) / f"{self.name}.singer"
+        return importlib.resources.files(target_test_streams) / f"{self.name}.singer"


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2752.org.readthedocs.build/en/2752/

<!-- readthedocs-preview meltano-sdk end -->