### PR TITLE
fix: Safely compare UUID replication keys with state bookmarks

### DIFF
--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -218,6 +218,10 @@ def increment_state(
                 extra={"replication_key": replication_key},
             )
         progress_dict = stream_or_partition_state[PROGRESS_MARKERS]
+    # TODO: Instead of forcing all values to be JSON-compatible strings and hope
+    # we catch all cases, we should allow the stream to define how to
+    # the values from the state and the record should be pre-processed.
+    # https://github.com/meltano/sdk/issues/2753
     old_rk_value = to_json_compatible(progress_dict.get("replication_key_value"))
     new_rk_value = to_json_compatible(latest_record[replication_key])
 

--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import datetime
+import uuid
 import logging
 import typing as t
 from enum import Enum
@@ -42,6 +43,8 @@ def to_json_compatible(val: t.Any) -> t.Any:  # noqa: ANN401
     if isinstance(val, (datetime.datetime,)):
         # Make naive datetimes UTC
         return (val.replace(tzinfo=UTC) if val.tzinfo is None else val).isoformat("T")
+    elif isinstance(val, (uuid.UUID,)):
+        return str(val)
     return val
 
 

--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import copy
 import datetime
-import uuid
 import logging
 import typing as t
+import uuid
 from enum import Enum
 from functools import lru_cache
 
@@ -43,7 +43,7 @@ def to_json_compatible(val: t.Any) -> t.Any:  # noqa: ANN401
     if isinstance(val, (datetime.datetime,)):
         # Make naive datetimes UTC
         return (val.replace(tzinfo=UTC) if val.tzinfo is None else val).isoformat("T")
-    elif isinstance(val, (uuid.UUID,)):
+    if isinstance(val, (uuid.UUID,)):
         return str(val)
     return val
 

--- a/tests/core/test_state_handling.py
+++ b/tests/core/test_state_handling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 
 import pytest
 
@@ -155,3 +156,21 @@ def test_null_replication_value(caplog):
     ), "State should not be updated."
     assert caplog.records[0].levelname == "WARNING"
     assert "is null" in caplog.records[0].message
+
+
+def test_uuidv7_replication_value():
+    stream_state = {
+        "replication_key": "id",
+        "replication_key_value": "01931c63-b14e-7ff3-8621-e577ed392dc8",
+    }
+    new_string_val = "01931c63-b14e-7ff3-8621-e578edbca9a3"
+
+    _state.increment_state(
+        stream_state,
+        latest_record={"id": uuid.UUID(new_string_val)},
+        replication_key="id",
+        is_sorted=True,
+        check_sorted=True,
+    )
+
+    assert stream_state["replication_key_value"] == new_string_val


### PR DESCRIPTION
This change will return a stringified value for an instance of uuid.UUID.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2755.org.readthedocs.build/en/2755/

<!-- readthedocs-preview meltano-sdk end -->