### PR TITLE
chore: Update `main` from `v0.42`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Singer SDK Version
       description: Version of the library you are using
-      placeholder: "0.42.0"
+      placeholder: "0.42.1"
     validations:
       required: true
   - type: checkboxes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.42.1 (2024-11-11)
+
+### 🐛 Fixes
+
+- [#2756](https://github.com/meltano/sdk/issues/2756) Safely compare UUID replication keys with state bookmarks -- _**Thanks @nikzavada!**_
+
 ## v0.42.0 (2024-11-11)
 
 ### ✨ New

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -31,12 +31,12 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.9"
-singer-sdk = { version="~=0.42.0"{{ ', extras = ["faker"]' if cookiecutter.faker_extra }} }
+singer-sdk = { version="~=0.42.1"{{ ', extras = ["faker"]' if cookiecutter.faker_extra }} }
 fs-s3fs = { version = "~=1.1.1", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8"
-singer-sdk = { version="~=0.42.0", extras = ["testing"] }
+singer-sdk = { version="~=0.42.1", extras = ["testing"] }
 
 [tool.poetry.extras]
 s3 = ["fs-s3fs"]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -30,7 +30,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.9"
-singer-sdk = { version="~=0.42.0", extras = [
+singer-sdk = { version="~=0.42.1", extras = [
     {%- if cookiecutter.auth_method == "JWT" -%}"jwt", {% endif -%}
     {%- if cookiecutter.faker_extra -%}"faker",{%- endif -%}
 ] }
@@ -42,9 +42,9 @@ requests = "~=2.32.3"
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8"
 {%- if cookiecutter.auth_method == "JWT" %}
-singer-sdk = { version="~=0.42.0", extras = ["jwt", "testing"] }
+singer-sdk = { version="~=0.42.1", extras = ["jwt", "testing"] }
 {%- else %}
-singer-sdk = { version="~=0.42.0", extras = ["testing"] }
+singer-sdk = { version="~=0.42.1", extras = ["testing"] }
 {%- endif %}
 
 [tool.poetry.extras]

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -30,7 +30,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.9"
-singer-sdk = { version="~=0.42.0"{{ ', extras = ["faker"]' if cookiecutter.faker_extra }} }
+singer-sdk = { version="~=0.42.1"{{ ', extras = ["faker"]' if cookiecutter.faker_extra }} }
 fs-s3fs = { version = "~=1.1.1", optional = true }
 {%- if cookiecutter.serialization_method != "SQL" %}
 requests = "~=2.32.3"
@@ -38,7 +38,7 @@ requests = "~=2.32.3"
 
 [tool.poetry.dev-dependencies]
 pytest = ">=8"
-singer-sdk = { version="~=0.42.0", extras = ["testing"] }
+singer-sdk = { version="~=0.42.1", extras = ["testing"] }
 
 [tool.poetry.extras]
 s3 = ["fs-s3fs"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ copyright = f"{datetime.now().year}, Arch Data, Inc and Contributors"  # noqa: A
 author = "Meltano Core Team and Contributors"
 
 # The full version, including alpha/beta/rc tags
-release = "0.42.0"
+release = "0.42.1"
 
 
 # -- General configuration -------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ xfail_strict = false
 
 [tool.commitizen]
 name = "cz_version_bump"
-version = "0.42.0"
+version = "0.42.1"
 changelog_merge_prerelease = true
 prerelease_offset = 1
 tag_format = "v$major.$minor.$patch$prerelease"


### PR DESCRIPTION
- **chore: Final v0.42.0 (#2750)**
- **fix: Safely compare UUID replication keys with state bookmarks (#2756)**
- **chore: Use the branch checked out in the version bump workflow**
- **chore: Release v0.42.1 (#2759)**


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2760.org.readthedocs.build/en/2760/

<!-- readthedocs-preview meltano-sdk end -->