### PR TITLE
feat: Log a stream's bookmark (if it's avaiable) when its sync starts

### DIFF
--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -440,6 +440,8 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
                 else:
                     value = self.compare_start_date(value, start_date_value)
 
+            self.logger.info("Starting incremental sync with bookmark value: %s", value)
+
         write_starting_replication_value(state, value)
 
     def get_replication_key_signpost(


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2775.org.readthedocs.build/en/2775/

<!-- readthedocs-preview meltano-sdk end -->