### PR TITLE
fix: The path of the offending field is now printed for config validation errors

### DIFF
--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -11,8 +11,10 @@ from typing_extensions import override
 from singer_sdk import Stream, Tap
 from singer_sdk.helpers._compat import datetime_fromisoformat
 from singer_sdk.typing import (
+    ArrayType,
     DateTimeType,
     IntegerType,
+    ObjectType,
     PropertiesList,
     Property,
     StringType,
@@ -82,6 +84,22 @@ class SimpleTestTap(Tap):
         Property("username", StringType, required=True),
         Property("password", StringType, required=True),
         Property("start_date", DateTimeType),
+        Property(
+            "nested",
+            ObjectType(
+                Property("key", StringType, required=True),
+            ),
+            required=False,
+        ),
+        Property(
+            "array",
+            ArrayType(
+                ObjectType(
+                    Property("key", StringType, required=True),
+                ),
+            ),
+            required=False,
+        ),
         additional_properties=False,
     ).to_dict()
 

--- a/tests/core/test_tap_class.py
+++ b/tests/core/test_tap_class.py
@@ -35,6 +35,30 @@ if t.TYPE_CHECKING:
             id="extra_property",
         ),
         pytest.param(
+            {"username": None, "password": "ptest"},
+            pytest.raises(ConfigValidationError, match="Config validation failed"),
+            ["None is not of type 'string' in config['username']"],
+            id="null_username",
+        ),
+        pytest.param(
+            {"username": "utest", "password": "ptest", "nested": {}},
+            pytest.raises(ConfigValidationError, match="Config validation failed"),
+            ["'key' is a required property in config['nested']"],
+            id="missing_required_nested_key",
+        ),
+        pytest.param(
+            {"username": "utest", "password": "ptest", "array": []},
+            nullcontext(),
+            [],
+            id="empty_array",
+        ),
+        pytest.param(
+            {"username": "utest", "password": "ptest", "array": [{}]},
+            pytest.raises(ConfigValidationError, match="Config validation failed"),
+            ["'key' is a required property in config['array'][0]"],
+            id="array_with_empty_object",
+        ),
+        pytest.param(
             {"username": "utest", "password": "ptest"},
             nullcontext(),
             [],


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2778.org.readthedocs.build/en/2778/

<!-- readthedocs-preview meltano-sdk end -->