### PR TITLE
feat(taps): Numeric values are now parsed as `decimal.Decimal` in REST and GraphQL stream responses

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/graphql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/graphql-client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import decimal
 import typing as t
 
 import requests  # noqa: TCH002
@@ -61,7 +62,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
             Each record from the source.
         """
         # TODO: Parse response body and return a set of records.
-        resp_json = response.json()
+        resp_json = response.json(parse_float=decimal.Decimal)
         yield from resp_json.get("<TODO>")
 
     def post_process(

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import decimal
 import typing as t
 {% if cookiecutter.auth_method in ("OAuth2", "JWT") -%}
 from functools import cached_property
@@ -204,7 +205,10 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
             Each record from the source.
         """
         # TODO: Parse response body and return a set of records.
-        yield from extract_jsonpath(self.records_jsonpath, input=response.json())
+        yield from extract_jsonpath(
+            self.records_jsonpath,
+            input=response.json(parse_float=decimal.Decimal),
+        )
 
     def post_process(
         self,

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import abc
 import copy
+import decimal
 import logging
 import sys
 import typing as t
@@ -779,7 +780,10 @@ class RESTStream(_HTTPStream, t.Generic[_TToken], metaclass=abc.ABCMeta):
         Yields:
             One item for every item found in the response.
         """
-        yield from extract_jsonpath(self.records_jsonpath, input=response.json())
+        yield from extract_jsonpath(
+            self.records_jsonpath,
+            input=response.json(parse_float=decimal.Decimal),
+        )
 
     def get_new_paginator(self) -> BaseAPIPaginator:
         """Get a fresh paginator for this API endpoint.


### PR DESCRIPTION
This means under normal circumstances, `decimal.Decimal` would be used across the board:

1. A float value of `"value": 3.14` in the API response is parsed as `Decimal("3.14")`
2. The `Decimal("3.14")` value is serialized to JSON as `value: 3.14` in the tap output
3. The float value of `"value": 3.14` in the `RECORD` Singer message will be parsed as `Decimal("3.14")` by the target.

That should ensure we preserve precision through the pipeline.

> [!CAUTION]
> Now, this _could_ be a breaking change if folks are doing floating-point math with these values, but I think it's rare enough that we can make do with a call-out in the release notes.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2780.org.readthedocs.build/en/2780/

<!-- readthedocs-preview meltano-sdk end -->