### PR TITLE
packaging: SQL taps now require SQLAlchemy 2.0+

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -38,6 +38,9 @@ fs-s3fs = { version = "~=1.1.1", optional = true }
 {%- if cookiecutter.stream_type in ["REST", "GraphQL"] %}
 requests = "~=2.32.3"
 {%- endif %}
+{%- if cookiecutter.stream_type == "SQL" %}
+sqlalchemy = "~=2.0.36"
+{%- endif %}
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8"

--- a/docs/guides/sql-tap.md
+++ b/docs/guides/sql-tap.md
@@ -1,5 +1,9 @@
 # Building SQL taps
 
+```{warning}
+Starting with version `0.43.0`, SQL taps require SQLAlchemy 2.0 or newer.
+```
+
 ## Mapping SQL types to JSON Schema
 
 Starting with version `0.41.0`, the Meltano Singer SDK provides a clean way to map SQL types to JSON Schema. This is useful when the SQL dialect you are using has custom types that need to be mapped accordingly to JSON Schema.


### PR DESCRIPTION
Related:

- #1667 

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2797.org.readthedocs.build/en/2797/

<!-- readthedocs-preview meltano-sdk end -->