### PR TITLE
feat(targets): Support a `x-sql-datatype` JSON Schema annotation to let targets customize SQL type handling

### DIFF
--- a/docs/guides/sql-target.md
+++ b/docs/guides/sql-target.md
@@ -50,3 +50,56 @@ class MyConnector(SQLConnector):
         to_sql.register_format_handler("uri", URI)
         return to_sql
 ```
+
+### Use the `x-sql-datatype` JSON Schema extension
+
+You can register new type handlers for the `x-sql-datatype` extension:
+
+```python
+from my_sqlalchemy_dialect import URI
+
+
+class MyConnector(SQLConnector):
+    @functools.cached_property
+    def jsonschema_to_sql(self):
+        to_sql = JSONSchemaToSQL()
+        to_sql.register_sql_datatype_handler("smallint", sa.types.SMALLINT)
+        return to_sql
+```
+
+Then you can annotate the tap' catalog to specify the SQL type:
+
+````{tab} meltano.yml
+```yaml
+# https://docs.meltano.com/concepts/plugins/#schema-extra
+plugins:
+  extractors:
+  - name: tap-example
+    schema:
+      addresses:
+        number:
+          x-sql-datatype: smallint
+```
+````
+
+````{tab} JSON catalog
+```json
+{
+  "streams": [
+    {
+      "stream": "addresses",
+      "tap_stream_id": "addresses",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "number": {
+            "type": "integer",
+            "x-sql-datatype": "smallint"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+````

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -400,9 +400,15 @@ class JSONSchemaToSQL:
             SQL type if one can be determined, None otherwise.
         """
         # Check x-sql-datatype first
-        if x_sql_datatype := schema.get("x-sql-datatype"):  # noqa: SIM102
+        if x_sql_datatype := schema.get("x-sql-datatype"):
             if handler := self._sql_datatype_mapping.get(x_sql_datatype):
                 return self._invoke_handler(handler, schema)
+
+            warnings.warn(
+                f"This target does not support the x-sql-datatype '{x_sql_datatype}'",
+                UserWarning,
+                stacklevel=2,
+            )
 
         # Check if this is a string with format then
         if schema.get("type") == "string" and "format" in schema:  # noqa: SIM102

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -349,12 +349,17 @@ class JSONSchemaToSQL:
         sql_datatype: str,
         handler: JSONtoSQLHandler,
     ) -> None:
-        """Register a custom x-sql-datatype handler.
+        """Register a custom ``x-sql-datatype`` handler.
 
         Args:
             sql_datatype: The x-sql-datatype string.
             handler: Either a SQLAlchemy type class or a callable that takes a schema
                     dict and returns a SQLAlchemy type instance.
+
+        Example:
+            >>> from sqlalchemy.types import SMALLINT
+            >>> to_sql = JSONSchemaToSQL()
+            >>> to_sql.register_sql_datatype_handler("smallint", SMALLINT)
         """
         self._sql_datatype_mapping[sql_datatype] = handler
 

--- a/tests/core/test_connector_sql.py
+++ b/tests/core/test_connector_sql.py
@@ -717,6 +717,13 @@ class TestJSONSchemaToSQL:  # noqa: PLR0904
         result = json_schema_to_sql.to_sql_type(image_type)
         assert isinstance(result, sa.types.LargeBinary)
 
+    def test_annotation_sql_datatype(self):
+        json_schema_to_sql = JSONSchemaToSQL()
+        json_schema_to_sql.register_sql_datatype_handler("json", sa.types.JSON)
+        jsonschema_type = {"type": ["string"], "x-sql-datatype": "json"}
+        result = json_schema_to_sql.to_sql_type(jsonschema_type)
+        assert isinstance(result, sa.types.JSON)
+
 
 def test_bench_discovery(benchmark, tmp_path: Path):
     def _discover_catalog(connector):

--- a/tests/core/test_connector_sql.py
+++ b/tests/core/test_connector_sql.py
@@ -724,6 +724,15 @@ class TestJSONSchemaToSQL:  # noqa: PLR0904
         result = json_schema_to_sql.to_sql_type(jsonschema_type)
         assert isinstance(result, sa.types.JSON)
 
+        unknown_type = {"type": ["string"], "x-sql-datatype": "unknown"}
+        with pytest.warns(
+            UserWarning,
+            match="This target does not support the x-sql-datatype",
+        ):
+            result = json_schema_to_sql.to_sql_type(unknown_type)
+
+        assert isinstance(result, sa.types.VARCHAR)
+
 
 def test_bench_discovery(benchmark, tmp_path: Path):
     def _discover_catalog(connector):


### PR DESCRIPTION
```[tasklist]
### Tasks
- [x] Add documentation
- [ ] Update JSON typing helpers?
- [ ] Use a JSON schema vocabulary in the SCHEMA messages (https://github.com/meltano/sdk/issues/2783)
``` 

### Docs

- [Updated SQL target guide](https://meltano-sdk--2829.org.readthedocs.build/en/2829/guides/sql-target.html#use-the-x-sql-datatype-json-schema-extension)
- [`JSONSchemaToSQL` reference docs](https://meltano-sdk--2829.org.readthedocs.build/en/2829/classes/singer_sdk.connectors.sql.JSONSchemaToSQL.html#singer_sdk.connectors.sql.JSONSchemaToSQL.register_sql_datatype_handler)

### Related

- #1323
- #1872
- Closes #2102
- #2783

### References

1. [JSON Schema blog: The Last Breaking Change](https://json-schema.org/blog/posts/the-last-breaking-change)
2. [JSON Schema blog: Custom Annotations Will Continue](https://json-schema.org/blog/posts/custom-annotations-will-continue)

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2829.org.readthedocs.build/en/2829/

<!-- readthedocs-preview meltano-sdk end -->