### PR TITLE
feat: Load project `.env` for built-in tests

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/tests/test_core.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/tests/test_core.py
@@ -2,9 +2,13 @@
 
 import datetime
 
+from dotenv import load_dotenv
 from singer_sdk.testing import get_tap_test_class
 
 from {{ cookiecutter.library_name }}.tap import Tap{{ cookiecutter.source_name }}
+
+load_dotenv()
+
 
 SAMPLE_CONFIG = {
     "start_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),


### PR DESCRIPTION
In my VSCode config, I have

```
  "python.envFile": "",
```

to stop it auto-loading the contents of my project `.env` file into the environment. A drawback of doing this is that Pytest discovery fails for my SDK plugin projects  with `ConfigValidationError`s until I manually export the `.env` or temporarily provide sensitive config in `tests/test_core.py` and hope I don't accidentally commit it. :grimacing:

This change loads the project `.env` file before test discovery runs. I was only able to get in working in `tests/test_core.py` in the limited time that I had today (which means this would really only be beneficial for new SDK taps/targets), but let me know if it is possible somewhere that would mean I don't have to update all my plugin `tests/test_core.py` files manually (e.g. in `TapTestClassFactory.new_test_class`).

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2835.org.readthedocs.build/en/2835/

<!-- readthedocs-preview meltano-sdk end -->