### PR TITLE
fix: Use a SQLAlchemy to generate an insert statement

### DIFF
--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -840,6 +840,10 @@ class SQLConnector:  # noqa: PLR0904
                 pool_pre_ping=True,
             )
 
+    @deprecated(
+        "This method is deprecated. Use or override `FullyQualifiedName` instead.",
+        category=SingerSDKDeprecationWarning,
+    )
     def quote(self, name: str) -> str:
         """Quote a name if it needs quoting, using '.' as a name-part delimiter.
 
@@ -853,7 +857,7 @@ class SQLConnector:  # noqa: PLR0904
         Returns:
             str: The quoted name.
         """
-        return ".".join(
+        return ".".join(  # pragma: no cover
             [
                 self._dialect.identifier_preparer.quote(name_part)
                 for name_part in name.split(".")

--- a/tests/samples/test_target_sqlite.py
+++ b/tests/samples/test_target_sqlite.py
@@ -646,12 +646,7 @@ def test_record_with_missing_properties(
                 },
             },
             [],
-            dedent(
-                """\
-                INSERT INTO test_stream
-                (id, name, "table")
-                VALUES (:id, :name, :table)""",
-            ),
+            'INSERT INTO test_stream (id, name, "table") VALUES (:id, :name, :table)',
         ),
     ],
     ids=[
@@ -676,7 +671,7 @@ def test_sqlite_generate_insert_statement(
         sink.full_table_name,
         sink.schema,
     )
-    assert dml == expected_dml
+    assert str(dml) == expected_dml
 
 
 def test_hostile_to_sqlite(


### PR DESCRIPTION
## Summary by Sourcery

Update insert statements to use SQLAlchemy executables.

Bug Fixes:
- Fix insert statements to use SQLAlchemy to prevent SQL injection vulnerabilities.

Enhancements:
- Refactor SQL insert statement generation to use SQLAlchemy.

Tests:
- Update tests to reflect the changes in insert statement generation.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2843.org.readthedocs.build/en/2843/

<!-- readthedocs-preview meltano-sdk end -->