### PR TITLE
chore: Use public log levels mapping in Python 3.11+

### DIFF
--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -38,6 +38,11 @@ from singer_sdk.typing import (
     extend_validator_with_defaults,
 )
 
+if sys.version_info >= (3, 11):
+    _LOG_LEVELS_MAPPING = logging.getLevelNamesMapping()
+else:
+    _LOG_LEVELS_MAPPING = logging._nameToLevel  # noqa: SLF001
+
 if t.TYPE_CHECKING:
     from jsonschema import ValidationError
 
@@ -137,7 +142,7 @@ class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
         logger = logging.getLogger(cls.name)
 
-        if log_level is not None and log_level.upper() in logging._levelToName.values():  # noqa: SLF001
+        if log_level is not None and log_level.upper() in _LOG_LEVELS_MAPPING:
             logger.setLevel(log_level.upper())
 
         return logger


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Use public log levels mapping in Python 3.11 and above for better compatibility.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2850.org.readthedocs.build/en/2850/

<!-- readthedocs-preview meltano-sdk end -->