### PR TITLE
chore: Add Slack badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@ de-facto open source standard for extract and load pipelines.
 </br>
 
 <div align="center">
+  <a href="https://meltano.com/slack">
+    <img alt="Meltano Community Slack" src="https://img.shields.io/badge/Slack-Join%20the%20Community-blue?logo=slack"/>
+  </a>
   <a href="https://pypi.org/project/singer-sdk">
    <img alt="Python Versions" src="https://img.shields.io/pypi/pyversions/singer-sdk"/>
   </a>
   <a href="https://pypi.org/project/singer-sdk">
    <img alt="Downloads" src="https://img.shields.io/pypi/dw/singer-sdk?color=blue"/>
   </a>
+  </br>
   <a href="https://pypi.org/project/singer-sdk">
    <img alt="PyPI Version" src="https://img.shields.io/pypi/v/singer-sdk?color=blue"/>
   </a>


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add a badge linking to the Meltano Slack community to the project's README file.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2853.org.readthedocs.build/en/2853/

<!-- readthedocs-preview meltano-sdk end -->