### PR TITLE
packaging: Use PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 readme = "README.md"
-license.file = "LICENSE"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
 
 dependencies = [


### PR DESCRIPTION
https://peps.python.org/pep-0639/

## Summary by Sourcery

Build:
- Specify the license in the `pyproject.toml` file using the `license` field.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2854.org.readthedocs.build/en/2854/

<!-- readthedocs-preview meltano-sdk end -->