### PR TITLE
chore: Update samples to use uv

### DIFF
--- a/samples/aapl/README.md
+++ b/samples/aapl/README.md
@@ -5,12 +5,12 @@ This tap sample helps in evaluating the performance of catalog parsing and strea
 ## Execution
 
 ```shell
-poetry run python samples/aapl
+uv run python samples/aapl
 ```
 
 Or if you want to trace the execution
 
 ```shell
-poetry run viztracer samples/aapl/__main__.py
-poetry run vizviewer result.json
+uv run viztracer samples/aapl/__main__.py
+uv run vizviewer result.json
 ```

--- a/samples/sample_tap_dummy_json/.github/workflows/test.yml
+++ b/samples/sample_tap_dummy_json/.github/workflows/test.yml
@@ -13,20 +13,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install Poetry
-      run: |
-        pip install poetry
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        version: ">=0.5.19"
     - name: Install dependencies
       run: |
         poetry env use ${{ matrix.python-version }}
         poetry install
     - name: Test with pytest
       run: |
-        poetry run pytest
+        uv run -p ${{ matrix.python-version }} pytest

--- a/samples/sample_tap_dummy_json/.gitignore
+++ b/samples/sample_tap_dummy_json/.gitignore
@@ -1,5 +1,5 @@
-# Poetry
-poetry.lock
+# uv
+uv.lock
 
 # Secrets and internal config files
 **/.secrets/*

--- a/samples/sample_tap_dummy_json/README.md
+++ b/samples/sample_tap_dummy_json/README.md
@@ -76,8 +76,7 @@ Follow these instructions to contribute to this project.
 ### Initialize your Development Environment
 
 ```bash
-pipx install poetry
-poetry install
+uv sync
 ```
 
 ### Create and Run Tests
@@ -86,13 +85,13 @@ Create tests within the `tests` subfolder and
   then run:
 
 ```bash
-poetry run pytest
+uv run pytest
 ```
 
 You can also test the `tap-dummyjson` CLI interface directly using `poetry run`:
 
 ```bash
-poetry run tap-dummyjson --help
+uv run tap-dummyjson --help
 ```
 
 ### Testing with [Meltano](https://www.meltano.com)

--- a/samples/sample_tap_dummy_json/pyproject.toml
+++ b/samples/sample_tap_dummy_json/pyproject.toml
@@ -1,9 +1,9 @@
-[tool.poetry]
+[project]
 name = "tap-dummyjson"
 version = "0.0.1"
 description = "Singer tap for DummyJSON, built with the Meltano Singer SDK."
 readme = "README.md"
-authors = ["Edgar Ramírez-Mondragón <edgar@arch.dev>"]
+authors = [{ name = "Edgar Ramírez-Mondragón", email = "edgar@arch.dev" }]
 keywords = [
     "ELT",
     "DummyJSON",
@@ -18,27 +18,33 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 license = "Apache-2.0"
+license-files = ["LICENSE"]
+requires-python = ">=3.9"
+dependencies = [
+    "requests~=2.32.3",
+    "singer-sdk",
+]
+optional-dependencies.s3 = [
+    "fs-s3fs~=1.1.1",
+]
 
-[tool.poetry.dependencies]
-python = ">=3.9"
-requests = "~=2.32.3"
-singer-sdk = {path = "../..", develop = true}
+[project.scripts]
+# CLI declaration
+tap-dummyjson = 'tap_dummyjson.tap:TapDummyJSON.cli'
 
-[tool.poetry.group.dev.dependencies]
-pytest = ">=8"
-singer-sdk = {path = "../..", develop = true, extras = ["testing"]}
-
-[tool.poetry.extras]
-s3 = ["fs-s3fs"]
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "singer-sdk[testing]",
+]
 
 [tool.mypy]
 python_version = "3.12"
 warn_unused_configs = true
 
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+[tool.uv.sources]
+singer-sdk = { path = "../../", editable = true }
 
-[tool.poetry.scripts]
-# CLI declaration
-tap-dummyjson = 'tap_dummyjson.tap:TapDummyJSON.cli'
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary by Sourcery

Update project configuration to use `uv` instead of `poetry`.

Build:
- Replace `poetry` with `uv` for dependency management and build processes.

CI:
- Update CI workflows to use `uv` instead of `poetry` for dependency management and testing.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2860.org.readthedocs.build/en/2860/

<!-- readthedocs-preview meltano-sdk end -->