### PR TITLE
chore: Bump Nox

### DIFF
--- a/.github/workflows/cookiecutter-e2e.yml
+++ b/.github/workflows/cookiecutter-e2e.yml
@@ -8,6 +8,7 @@ on:
     - "cookiecutter/**"
     - "e2e-tests/cookiecutters/**"
     - ".github/workflows/cookiecutter-e2e.yml"
+    - ".github/workflows/resources/requirements.txt"
   push:
     branches:
     - main
@@ -17,6 +18,7 @@ on:
     - "cookiecutter/**"
     - "e2e-tests/cookiecutters/**"
     - ".github/workflows/cookiecutter-e2e.yml"
+    - ".github/workflows/resources/requirements.txt"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/resources/requirements.txt
+++ b/.github/workflows/resources/requirements.txt
@@ -1,4 +1,4 @@
 griffe~=1.5
-nox @ git+https://github.com/wntrblm/nox.git@refs/pull/921/head
+nox==2025.2.9
 pre-commit==4.1.0
 twine==6.1.0

--- a/.github/workflows/resources/requirements.txt
+++ b/.github/workflows/resources/requirements.txt
@@ -1,4 +1,4 @@
 griffe~=1.5
-nox==2024.10.9
+nox @ git+https://github.com/wntrblm/nox.git@refs/pull/921/head
 pre-commit==4.1.0
 twine==6.1.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,14 +31,15 @@ python_versions = [
 ]
 main_python_version = "3.13"
 locations = "singer_sdk", "tests", "noxfile.py", "docs/conf.py"
-nox.options.sessions = [
+nox.options.sessions = (
     "mypy",
     "tests",
     "benches",
     "doctest",
     "test_cookiecutter",
-]
+)
 
+# TODO: https://github.com/wntrblm/nox/pull/917
 dependency_groups = nox.project.load_toml("pyproject.toml")["dependency-groups"]
 test_dependencies: list[str] = dependency_groups["dev"]
 typing_dependencies: list[str] = dependency_groups["typing"]
@@ -219,9 +220,7 @@ def test_cookiecutter(session: nox.Session, replay_file_path: Path) -> None:
     # TODO: Use uvx
     # https://github.com/wntrblm/nox/pull/920
     session.run(
-        "uv",
-        "tool",
-        "run",
+        "uvx",
         "cookiecutter",
         "--replay-file",
         str(replay_file),
@@ -243,11 +242,11 @@ def test_cookiecutter(session: nox.Session, replay_file_path: Path) -> None:
 
     # Check that the project can be built for distribution
     session.run("uv", "build")
-    session.run("uv", "tool", "run", "twine", "check", "dist/*")
+    session.run("uvx", "twine", "check", "dist/*")
 
     session.run("git", "init", "-b", "main", external=True)
     session.run("git", "add", ".", external=True)
-    session.run("uv", "tool", "run", "pre-commit", "run", "--all-files", external=True)
+    session.run("uvx", "pre-commit", "run", "--all-files", external=True)
 
 
 @nox.session(name="version-bump")

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import nox
 
-nox.needs_version = ">=2024.4.15"
+nox.needs_version = ">=2025.2.9"
 nox.options.default_venv_backend = "uv"
 
 RUFF_OVERRIDES = """\
@@ -31,16 +31,15 @@ python_versions = [
 ]
 main_python_version = "3.13"
 locations = "singer_sdk", "tests", "noxfile.py", "docs/conf.py"
-nox.options.sessions = (
+nox.options.sessions = [
     "mypy",
     "tests",
     "benches",
     "doctest",
     "test_cookiecutter",
-)
+]
 
-# TODO: https://github.com/wntrblm/nox/pull/917
-dependency_groups = nox.project.load_toml("pyproject.toml")["dependency-groups"]
+dependency_groups = nox.project.load_toml()["dependency-groups"]
 test_dependencies: list[str] = dependency_groups["dev"]
 typing_dependencies: list[str] = dependency_groups["typing"]
 
@@ -275,7 +274,6 @@ def version_bump(session: nox.Session) -> None:
 def api_changes(session: nox.Session) -> None:
     """Check for API changes."""
     args = [
-        "griffe",
         "check",
         "singer_sdk",
     ]
@@ -286,4 +284,4 @@ def api_changes(session: nox.Session) -> None:
     if "GITHUB_ACTIONS" in os.environ:
         args.append("-f=github")
 
-    session.run("uv", "tool", "run", *args, external=True)
+    session.run("uvx", "griffe", *args, external=True)


### PR DESCRIPTION
- https://github.com/wntrblm/nox/pull/917
- https://github.com/wntrblm/nox/pull/920
- https://github.com/wntrblm/nox/pull/921

## Summary by Sourcery

Upgrade Nox to 2025.2.9 and use uvx instead of uv tool run.

Build:
- Update Nox version in noxfile.py and requirements.txt.
- Use uvx instead of uv tool run in noxfile.py

CI:
- Add .github/workflows/resources/requirements.txt to the cookiecutter-e2e workflow trigger paths.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2865.org.readthedocs.build/en/2865/

<!-- readthedocs-preview meltano-sdk end -->