### PR TITLE
chore: Require uv be used with Nox

### DIFF
--- a/.github/workflows/api-changes.yml
+++ b/.github/workflows/api-changes.yml
@@ -43,7 +43,6 @@ jobs:
 
     - name: Install tools
       run: |
-        uv tool install griffe
         uv tool install nox
         uv tool list
 

--- a/.github/workflows/api-changes.yml
+++ b/.github/workflows/api-changes.yml
@@ -14,6 +14,7 @@ concurrency:
 
 env:
   FORCE_COLOR: 1
+  UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
   UV_VERSION: 0.5.26
 
 permissions:  # added using https://github.com/step-security/secure-repo
@@ -41,8 +42,6 @@ jobs:
         version: ${{ env.UV_VERSION }}
 
     - name: Install tools
-      env:
-        UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
       run: |
         uv tool install griffe
         uv tool install nox

--- a/.github/workflows/api-changes.yml
+++ b/.github/workflows/api-changes.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: 1
+  UV_VERSION: 0.5.26
+
 permissions:  # added using https://github.com/step-security/secure-repo
   contents: read
 
@@ -32,13 +36,17 @@ jobs:
       with:
         python-version: 3.x
 
+    - uses: astral-sh/setup-uv@v5
+      with:
+        version: ${{ env.UV_VERSION }}
+
     - name: Install tools
       env:
-        PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
+        UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
       run: |
-        python -Im pip install -U pip
-        pipx install griffe nox
-        pipx list
+        uv tool install griffe
+        uv tool install nox
+        uv tool list
 
     - name: Set REF
       id: set-ref

--- a/.github/workflows/cookiecutter-e2e.yml
+++ b/.github/workflows/cookiecutter-e2e.yml
@@ -25,6 +25,7 @@ concurrency:
 
 env:
   FORCE_COLOR: "1"
+  UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
 
 jobs:
   lint:
@@ -44,15 +45,11 @@ jobs:
         python-version: 3.x
 
     - name: Install Nox
-      env:
-        UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
       run: |
         uv tool install nox
         nox --version
 
     - name: Run Nox
-      env:
-        UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
       run: |
         nox --session=test_cookiecutter
 

--- a/.github/workflows/resources/requirements.txt
+++ b/.github/workflows/resources/requirements.txt
@@ -1,5 +1,4 @@
 griffe~=1.5
 nox==2024.10.9
-pip==25.0
 pre-commit==4.1.0
 twine==6.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ concurrency:
 
 env:
   FORCE_COLOR: "1"
+  UV_VERSION: 0.5.26
 
 jobs:
   tests:
@@ -69,29 +70,25 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
 
-    - name: Upgrade pip
-      env:
-        PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
-      run: |
-        pip install pip
-        pip --version
+    - uses: astral-sh/setup-uv@v5
+      with:
+        version: ${{ env.UV_VERSION }}
 
     - name: Install Nox
       env:
-        PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
+        UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
       run: |
-        pipx install 'nox[uv]'
+        uv tool install 'nox[uv]'
         nox --version
 
     - uses: actions/cache@v4
       if: matrix.session == 'tests'
       with:
         path: http_cache.sqlite
-        key: http_cache-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.sqlalchemy }}
+        key: http_cache-${{ runner.os }}-${{ matrix.python-version }}
 
     - name: Run Nox
       env:
-        PIP_PRE: "1"
         UV_PRERELEASE: allow
       run: |
         nox --verbose
@@ -100,7 +97,7 @@ jobs:
       if: always() && (matrix.session == 'tests')
       with:
         include-hidden-files: true
-        name: coverage-data-nox_-${{ matrix.os }}-py${{ matrix.python-version }}_sqlalchemy_${{ matrix.sqlalchemy }}
+        name: coverage-data-nox_-${{ matrix.os }}-py${{ matrix.python-version }}
         path: ".coverage.*"
 
   tests-external:
@@ -124,23 +121,19 @@ jobs:
       with:
         python-version: ${{ env.NOXPYTHON }}
 
-    - name: Upgrade pip
-      env:
-        PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
-      run: |
-        pip install pip
-        pip --version
+    - uses: astral-sh/setup-uv@v5
+      with:
+        version: ${{ env.UV_VERSION }}
 
     - name: Install Nox
       env:
-        PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
+        UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
       run: |
-        pipx install 'nox[uv]'
+        uv tool install 'nox[uv]'
         nox --version
 
     - name: Run Nox
       env:
-        PIP_PRE: "1"
         UV_PRERELEASE: allow
       run: |
         nox -- -m "external"
@@ -157,23 +150,20 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Upgrade pip
-      env:
-        PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
-      run: |
-        pip install pip
-        pip --version
-
     - uses: actions/download-artifact@v4
       with:
         pattern: coverage-data-*
         merge-multiple: true
 
+    - uses: astral-sh/setup-uv@v5
+      with:
+        version: ${{ env.UV_VERSION }}
+
     - name: Install Nox
       env:
-        PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
+        UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
       run: |
-        pipx install 'nox[uv]'
+        uv tool install 'nox[uv]'
         nox --version
 
     - run: nox --install-only

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ concurrency:
 
 env:
   FORCE_COLOR: "1"
+  UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
   UV_VERSION: 0.5.26
 
 jobs:
@@ -75,8 +76,6 @@ jobs:
         version: ${{ env.UV_VERSION }}
 
     - name: Install Nox
-      env:
-        UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
       run: |
         uv tool install 'nox[uv]'
         nox --version
@@ -126,8 +125,6 @@ jobs:
         version: ${{ env.UV_VERSION }}
 
     - name: Install Nox
-      env:
-        UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
       run: |
         uv tool install 'nox[uv]'
         nox --version
@@ -160,8 +157,6 @@ jobs:
         version: ${{ env.UV_VERSION }}
 
     - name: Install Nox
-      env:
-        UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
       run: |
         uv tool install 'nox[uv]'
         nox --version

--- a/noxfile.py
+++ b/noxfile.py
@@ -287,4 +287,4 @@ def api_changes(session: nox.Session) -> None:
     if "GITHUB_ACTIONS" in os.environ:
         args.append("-f=github")
 
-    session.run(*args, external=True)
+    session.run("uv", "tool", "run", *args, external=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import nox
 
 nox.needs_version = ">=2024.4.15"
-nox.options.default_venv_backend = "uv|virtualenv"
+nox.options.default_venv_backend = "uv"
 
 RUFF_OVERRIDES = """\
 extend = "./pyproject.toml"


### PR DESCRIPTION
## Summary by Sourcery

Require the use of `uv` as the virtual environment backend for Nox.

Enhancements:
- Set `nox.options.default_venv_backend = "uv"`.

CI:
- Install Nox using `uv tool install` instead of `pipx`.
- Use `astral-sh/setup-uv@v5` to set up `uv`.
- Remove the upgrade pip step and related caching.
- Update coverage data artifact name to remove SQLAlchemy version.
- Set the `UV_VERSION` environment variable.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2866.org.readthedocs.build/en/2866/

<!-- readthedocs-preview meltano-sdk end -->