### PR TITLE
fix(taps): Do not emit a warning needlessly when `rest_method` is not set in a stream class

### DIFF
--- a/singer_sdk/streams/graphql.py
+++ b/singer_sdk/streams/graphql.py
@@ -24,7 +24,7 @@ class GraphQLStream(RESTStream, t.Generic[_TToken], metaclass=abc.ABCMeta):
     """
 
     path = ""
-    rest_method = "POST"
+    http_method = "POST"
 
     @classproperty
     def records_jsonpath(cls) -> str:  # type: ignore[override] # noqa: N805

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -150,7 +150,7 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
                 SingerSDKDeprecationWarning,
                 stacklevel=2,
             )
-            return self.rest_method
+            return self.rest_method  # type: ignore[no-any-return]
 
         return "GET"
 

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -6,7 +6,6 @@ import abc
 import copy
 import decimal
 import logging
-import sys
 import typing as t
 from functools import cached_property
 from http import HTTPStatus
@@ -28,11 +27,6 @@ from singer_sdk.pagination import (
     SimpleHeaderPaginator,
 )
 from singer_sdk.streams.core import Stream
-
-if sys.version_info < (3, 13):
-    from typing_extensions import deprecated
-else:
-    from warnings import deprecated  # pragma: no cover
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -145,38 +139,20 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
     # HTTP Request functions
 
     @property
-    @deprecated(
-        "Use `http_method` instead.",
-        category=SingerSDKDeprecationWarning,
-    )
-    def rest_method(self) -> str:
-        """HTTP method to use for requests. Defaults to "GET".
-
-        .. deprecated:: 0.43.0
-           Override :meth:`~singer_sdk.RESTStream.http_method` instead.
-        """
-        return self._http_method or "GET"
-
-    @rest_method.setter
-    @deprecated(
-        "Use `http_method` instead.",
-        category=SingerSDKDeprecationWarning,
-    )
-    def rest_method(self, value: str) -> None:
-        """Set the HTTP method for requests.
-
-        Args:
-            value: The HTTP method to use for requests.
-
-        .. deprecated:: 0.43.0
-           Override :meth:`~singer_sdk.RESTStream.http_method` instead.
-        """
-        self._http_method = value
-
-    @property
     def http_method(self) -> str:
         """HTTP method to use for requests. Defaults to "GET"."""
-        return self._http_method or self.rest_method
+        if self._http_method:
+            return self._http_method
+
+        if hasattr(self, "rest_method"):
+            warn(
+                "Use `http_method` instead.",
+                SingerSDKDeprecationWarning,
+                stacklevel=2,
+            )
+            return self.rest_method
+
+        return "GET"
 
     @http_method.setter
     def http_method(self, value: str) -> None:


### PR DESCRIPTION
## Related

- https://github.com/meltano/sdk/issues/2869

## Summary by Sourcery

Bug Fixes:
- Resolve an issue where a warning was unnecessarily emitted when `rest_method` was not set in a stream class.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2870.org.readthedocs.build/en/2870/

<!-- readthedocs-preview meltano-sdk end -->