### PR TITLE
feat: Added an extensible API for stream schema sources

### DIFF
--- a/samples/sample_tap_gitlab/gitlab_rest_streams.py
+++ b/samples/sample_tap_gitlab/gitlab_rest_streams.py
@@ -9,6 +9,7 @@ from requests_cache import CachedSession
 
 from singer_sdk.authenticators import SimpleAuthenticator
 from singer_sdk.pagination import SimpleHeaderPaginator
+from singer_sdk.schema import LocalSchemaSource
 from singer_sdk.streams.rest import RESTStream
 from singer_sdk.typing import (
     ArrayType,
@@ -21,7 +22,7 @@ from singer_sdk.typing import (
     StringType,
 )
 
-SCHEMAS_DIR = importlib.resources.files(__package__) / "schemas"
+LOCAL_SCHEMAS = LocalSchemaSource(importlib.resources.files(__package__) / "schemas")
 
 DEFAULT_URL_BASE = "https://gitlab.com/api/v4"
 
@@ -115,7 +116,7 @@ class ProjectsStream(ProjectBasedStream):
     primary_keys = ("id",)
     replication_key = "last_activity_at"
     is_sorted = True
-    schema_filepath = SCHEMAS_DIR / "projects.json"
+    schema = LOCAL_SCHEMAS("projects")
 
 
 class ReleasesStream(ProjectBasedStream):
@@ -125,7 +126,7 @@ class ReleasesStream(ProjectBasedStream):
     path = "/projects/{project_id}/releases"
     primary_keys = ("project_id", "tag_name")
     replication_key = None
-    schema_filepath = SCHEMAS_DIR / "releases.json"
+    schema = LOCAL_SCHEMAS("releases")
 
 
 class IssuesStream(ProjectBasedStream):
@@ -136,7 +137,7 @@ class IssuesStream(ProjectBasedStream):
     primary_keys = ("id",)
     replication_key = "updated_at"
     is_sorted = False
-    schema_filepath = SCHEMAS_DIR / "issues.json"
+    schema = LOCAL_SCHEMAS("issues")
 
 
 class CommitsStream(ProjectBasedStream):
@@ -149,7 +150,7 @@ class CommitsStream(ProjectBasedStream):
     primary_keys = ("id",)
     replication_key = "created_at"
     is_sorted = False
-    schema_filepath = SCHEMAS_DIR / "commits.json"
+    schema = LOCAL_SCHEMAS("commits")
 
 
 class EpicsStream(ProjectBasedStream):
@@ -214,7 +215,7 @@ class EpicIssuesStream(GitlabStream):
     path = "/groups/{group_id}/epics/{epic_iid}/issues"
     primary_keys = ("id",)
     replication_key = None
-    schema_filepath = SCHEMAS_DIR / "epic_issues.json"
+    schema = LOCAL_SCHEMAS("epic_issues")
     parent_stream_type = EpicsStream  # Stream should wait for parents to complete.
 
     def get_url_params(

--- a/singer_sdk/schema.py
+++ b/singer_sdk/schema.py
@@ -1,0 +1,108 @@
+"""Schema sources."""
+
+from __future__ import annotations
+
+import functools
+import json
+import sys
+import typing as t
+from pathlib import Path
+
+import requests
+
+from singer_sdk.singerlib import resolve_schema_references
+
+if sys.version_info < (3, 12):
+    from importlib.abc import Traversable
+else:
+    from importlib.resources.abc import Traversable
+
+
+class BaseSchemaSource:
+    """Base schema source."""
+
+    def __init__(self) -> None:
+        """Initialize the schema source."""
+        self._registry: dict[str, dict] = {}
+
+    def get_schema(self, *args: t.Any, **kwargs: t.Any) -> dict:
+        """Get schema from reference.
+
+        Raises:
+            NotImplementedError: If the method is not implemented by the subclass.
+        """
+        msg = "Subclasses must implement this method."
+        raise NotImplementedError(msg)
+
+    def __call__(self, *args: t.Any, **kwargs: t.Any) -> dict:
+        """Get schema for the given stream name or reference.
+
+        Returns:
+            The schema dictionary.
+        """
+        return self.get_schema(*args, **kwargs)
+
+
+class LocalSchemaSource(BaseSchemaSource):
+    """Local schema source."""
+
+    def __init__(self, path: Path | Traversable) -> None:
+        """Initialize the schema source."""
+        super().__init__()
+        self.path = path
+
+    def get_schema(self, name: str) -> dict:
+        """Get schema from reference.
+
+        Args:
+            name: Name of the stream.
+
+        Returns:
+            The schema dictionary.
+        """
+        if name not in self._registry:
+            schema_path = self.path / f"{name}.json"
+            self._registry[name] = json.loads(schema_path.read_text())
+
+        return self._registry[name]
+
+
+class OpenAPISchemaSource(BaseSchemaSource):
+    """OpenAPI schema source."""
+
+    def __init__(self, path: str | Path | Traversable) -> None:
+        """Initialize the schema source."""
+        super().__init__()
+        self.path = path
+
+    @functools.cached_property
+    def spec_dict(self) -> dict:
+        """OpenAPI spec dictionary.
+
+        Raises:
+            ValueError: If the path type is not supported.
+        """
+        if isinstance(self.path, (Path, Traversable)):
+            return json.loads(self.path.read_text())  # type: ignore[no-any-return]
+
+        if self.path.startswith("http"):
+            return requests.get(self.path, timeout=10).json()  # type: ignore[no-any-return]
+
+        msg = f"Unsupported path type: {self.path}"
+        raise ValueError(msg)
+
+    def get_schema(self, ref: str) -> dict:
+        """Get schema from reference.
+
+        Args:
+            ref: Reference to the schema.
+
+        Returns:
+            The schema dictionary.
+        """
+        if ref not in self._registry:
+            schema = {"$ref": f"#/components/schemas/{ref}"}
+            schema["components"] = self.spec_dict["components"]
+            self._registry[ref] = resolve_schema_references(schema)
+
+        return self._registry[ref]

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -1,70 +1,32 @@
-"""
-Testing that Schema can convert schemas lossless from and to dicts.
-
-Schemas are taken from these examples;
-https://json-schema.org/learn/miscellaneous-examples.html
-
-NOTE: The following properties are not currently supported;
-pattern
-unevaluatedProperties
-propertyNames
-minProperties
-maxProperties
-prefixItems
-contains
-minContains
-maxContains
-minItems
-maxItems
-uniqueItems
-enum
-const
-contentMediaType
-contentEncoding
-allOf
-oneOf
-not
-
-Some of these could be trivially added (if they are SIMPLE_PROPERTIES.
-Some might need more thinking if they can contain schemas (though, note that we also
-treat 'additionalProperties', 'anyOf' and' patternProperties' as SIMPLE even though they
-can contain schemas.
-"""
+"""Test the schema sources."""
 
 from __future__ import annotations
 
-from singer_sdk.singerlib import Schema
+import typing as t
+
+from singer_sdk.schema import LocalSchemaSource, OpenAPISchemaSource
+
+if t.TYPE_CHECKING:
+    import pytest
 
 
-def test_simple_schema():
-    simple_schema = {
-        "title": "Longitude and Latitude Values",
-        "description": "A geographical coordinate.",
-        "required": ["latitude", "longitude"],
-        "type": "object",
-        "properties": {
-            "latitude": {"type": "number", "minimum": -90, "maximum": 90},
-            "longitude": {"type": "number", "minimum": -180, "maximum": 180},
-        },
-    }
-
-    schema_plus = Schema.from_dict(simple_schema)
-    assert schema_plus.to_dict() == simple_schema
-    assert schema_plus.required == ["latitude", "longitude"]
-    assert isinstance(schema_plus.properties["latitude"], Schema)
-    latitude = schema_plus.properties["latitude"]
-    assert latitude.type == "number"
+def test_local_schema_source(pytestconfig: pytest.Config):
+    schema_dir = pytestconfig.rootpath / "tests/fixtures/schemas"
+    schema_source = LocalSchemaSource(schema_dir)
+    schema = schema_source("user")
+    assert isinstance(schema, dict)
+    assert schema["type"] == "object"
+    assert "items" not in schema
+    assert "properties" in schema
+    assert "id" in schema["properties"]
 
 
-def test_schema_with_items():
-    schema = {
-        "description": "A representation of a person, company, organization, or place",
-        "type": "object",
-        "properties": {"fruits": {"type": "array", "items": {"type": "string"}}},
-    }
-    schema_plus = Schema.from_dict(schema)
-    assert schema_plus.to_dict() == schema
-    assert isinstance(schema_plus.properties["fruits"], Schema)
-    fruits = schema_plus.properties["fruits"]
-    assert isinstance(fruits.items, Schema)
-    assert fruits.items.type == "string"
+def test_openapi_schema_source(pytestconfig: pytest.Config):
+    openapi_path = pytestconfig.rootpath / "tests/fixtures/openapi.json"
+    schema_source = OpenAPISchemaSource(openapi_path)
+    schema = schema_source("ProjectListItem")
+    assert isinstance(schema, dict)
+    assert schema["type"] == "object"
+    assert "items" not in schema
+    assert "properties" in schema
+    assert "id" in schema["properties"]

--- a/tests/fixtures/openapi.json
+++ b/tests/fixtures/openapi.json
@@ -1,0 +1,8850 @@
+{
+  "openapi": "3.0.3",
+  "servers": [
+    {
+      "url": "https://console.neon.tech/api/v2"
+    }
+  ],
+  "info": {
+    "title": "Neon API",
+    "description": "The Neon API allows you to access and manage Neon programmatically. You can use the Neon API to manage API keys, projects, branches, compute endpoints, databases, roles, and operations. For information about these features, refer to the [Neon documentation](https://neon.tech/docs/manage/overview/).\n\nYou can run Neon API requests from this API reference using the **Try It** feature. Enter your API key as a **Bearer** token in the **Authorization** section of the page.\n\nYou can create and manage API keys in the Neon Console. See [Manage API keys](https://neon.tech/docs/manage/api-keys/) for instructions.",
+    "version": "v2",
+    "contact": {
+      "email": "support@neon.tech"
+    },
+    "license": {
+      "name": "Proprietary"
+    }
+  },
+  "security": [
+    {
+      "BearerAuth": []
+    },
+    {
+      "CookieAuth": []
+    },
+    {
+      "TokenCookieAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "API Key",
+      "description": "These methods allow you to create and manage API keys for your Neon account. For related information, see [Manage API keys](https://neon.tech/docs/manage/api-keys)."
+    },
+    {
+      "name": "Operation",
+      "description": "These methods allow you to view operation details for your Neon project. For related information, see [Operations](https://neon.tech/docs/manage/operations)."
+    },
+    {
+      "name": "Project",
+      "description": "These methods allow you to create and manage Neon projects. For related information, see [Manage projects](https://neon.tech/docs/manage/projects)."
+    },
+    {
+      "name": "Branch",
+      "description": "These methods allow you to create and manage branches in your Neon project. For related information, see [Manage branches](https://neon.tech/docs/manage/branches)."
+    },
+    {
+      "name": "Endpoint",
+      "description": "These methods allow you to create and manage compute endpoints in your Neon project. For related information, see [Manage compute endpoints](https://neon.tech/docs/manage/endpoints)."
+    },
+    {
+      "name": "Preview",
+      "description": "New API methods that are in a Preview state and may be subject to changes."
+    },
+    {
+      "name": "Region",
+      "description": "These methods allow you to inspect Neon regions."
+    },
+    {
+      "name": "Users",
+      "description": "These methods allow you to manage your Neon user account."
+    },
+    {
+      "name": "Consumption",
+      "description": "These methods allow you to view consumption details for your Neon account."
+    },
+    {
+      "name": "Organizations",
+      "description": "These methods allow you to manage your Neon organizations."
+    }
+  ],
+  "paths": {
+    "/api_keys": {
+      "get": {
+        "summary": "Get a list of API keys",
+        "description": "Retrieves the API keys for your Neon account.\nThe response does not include API key tokens. A token is only provided when creating an API key.\nAPI keys can also be managed in the Neon Console.\nFor more information, see [Manage API keys](https://neon.tech/docs/manage/api-keys/).\n",
+        "tags": [
+          "API Key"
+        ],
+        "operationId": "listApiKeys",
+        "responses": {
+          "200": {
+            "description": "Returned the API keys for the Neon account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ApiKeysListResponseItem"
+                  },
+                  "example": [
+                    {
+                      "id": 165432,
+                      "name": "mykey_1",
+                      "created_at": "2022-11-15T20:13:35Z",
+                      "created_by": {
+                        "id": "629982cc-de05-43db-ae16-28f2399c4910",
+                        "name": "John Smith",
+                        "image": "http://link.to.image"
+                      },
+                      "last_used_at": "2022-11-15T20:22:51Z",
+                      "last_used_from_addr": "192.0.2.255"
+                    },
+                    {
+                      "id": 165433,
+                      "name": "mykey_2",
+                      "created_at": "2022-11-15T20:12:36Z",
+                      "created_by": {
+                        "id": "629982cc-de05-43db-ae16-28f2399c4910",
+                        "name": "John Smith",
+                        "image": "http://link.to.image"
+                      },
+                      "last_used_at": "2022-11-15T20:15:04Z",
+                      "last_used_from_addr": "192.0.2.255"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create an API key",
+        "description": "Creates an API key.\nThe `key_name` is a user-specified name for the key.\nThis method returns an `id` and `key`. The `key` is a randomly generated, 64-bit token required to access the Neon API.\nAPI keys can also be managed in the Neon Console.\nSee [Manage API keys](https://neon.tech/docs/manage/api-keys/).\n",
+        "tags": [
+          "API Key"
+        ],
+        "operationId": "createApiKey",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiKeyCreateRequest"
+              },
+              "example": {
+                "key_name": "mykey"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Created an API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyCreateResponse"
+                },
+                "example": {
+                  "id": 165434,
+                  "key": "9v1faketcjbl4sn1013keyd43n2a8qlfakeog8yvp40hx16keyjo1bpds4y2dfms3",
+                  "name": "mykey",
+                  "created_at": "2022-11-15T20:13:35Z",
+                  "created_by": "629982cc-de05-43db-ae16-28f2399c4910"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/api_keys/{key_id}": {
+      "delete": {
+        "summary": "Revoke an API key",
+        "description": "Revokes the specified API key.\nAn API key that is no longer needed can be revoked.\nThis action cannot be reversed.\nYou can obtain `key_id` values by listing the API keys for your Neon account.\nAPI keys can also be managed in the Neon Console.\nSee [Manage API keys](https://neon.tech/docs/manage/api-keys/).\n",
+        "tags": [
+          "API Key"
+        ],
+        "operationId": "revokeApiKey",
+        "parameters": [
+          {
+            "name": "key_id",
+            "in": "path",
+            "description": "The API key ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Revoked the specified API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyRevokeResponse"
+                },
+                "example": {
+                  "id": 165435,
+                  "name": "mykey",
+                  "created_at": "2022-11-15T20:13:35Z",
+                  "created_by": "629982cc-de05-43db-ae16-28f2399c4910",
+                  "last_used_at": "2022-11-15T20:15:04Z",
+                  "last_used_from_addr": "192.0.2.255",
+                  "revoked": true
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/operations/{operation_id}": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "operation_id",
+          "in": "path",
+          "description": "The operation ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get operation details",
+        "description": "Retrieves details for the specified operation.\nAn operation is an action performed on a Neon project resource.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain a `operation_id` by listing operations for the project.\n",
+        "tags": [
+          "Operation"
+        ],
+        "operationId": "getProjectOperation",
+        "responses": {
+          "200": {
+            "description": "Returned details for the specified operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationResponse"
+                },
+                "example": {
+                  "operation": {
+                    "id": "a07f8772-1877-4da9-a939-3a3ae62d1d8d",
+                    "project_id": "floral-king-961888",
+                    "branch_id": "br-bitter-sound-247814",
+                    "endpoint_id": "ep-dark-snowflake-942567",
+                    "action": "create_timeline",
+                    "status": "finished",
+                    "failures_count": 0,
+                    "created_at": "2022-10-04T18:20:17Z",
+                    "updated_at": "2022-10-04T18:20:18Z",
+                    "total_duration_ms": 100
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects": {
+      "get": {
+        "summary": "Get a list of projects",
+        "description": "Retrieves a list of projects for the Neon account.\nA project is the top-level object in the Neon object hierarchy.\nFor more information, see [Manage projects](https://neon.tech/docs/manage/projects/).\n",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "listProjects",
+        "parameters": [
+          {
+            "name": "cursor",
+            "description": "Specify the cursor value from the previous response to retrieve the next batch of projects.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Specify a value from 1 to 400 to limit number of projects in the response.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 10,
+              "maximum": 400
+            }
+          },
+          {
+            "name": "search",
+            "description": "Search by project `name` or `id`. You can specify partial `name` or `id` values to filter results.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org_id",
+            "description": "Search for projects by `org_id`.",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TimeoutParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returned a list of projects for the Neon account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ProjectsResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PaginationResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ProjectsApplicationsMapResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ProjectsIntegrationsMapResponse"
+                    }
+                  ]
+                },
+                "example": {
+                  "projects": [
+                    {
+                      "id": "shiny-wind-028834",
+                      "platform_id": "aws",
+                      "region_id": "aws-us-east-2",
+                      "name": "shiny-wind-028834",
+                      "provisioner": "k8s-pod",
+                      "pg_version": 15,
+                      "created_at": "2022-11-23T17:42:25Z",
+                      "updated_at": "2022-11-23T17:42:25Z",
+                      "proxy_host": "us-east-2.aws.neon.tech",
+                      "cpu_used_sec": 0,
+                      "branch_logical_size_limit": 0,
+                      "owner_id": "1232111",
+                      "creation_source": "console",
+                      "store_passwords": true,
+                      "branch_logical_size_limit_bytes": 10800,
+                      "active_time": 100
+                    },
+                    {
+                      "id": "winter-boat-259881",
+                      "platform_id": "aws",
+                      "region_id": "aws-us-east-2",
+                      "name": "winter-boat-259881",
+                      "provisioner": "k8s-pod",
+                      "pg_version": 15,
+                      "created_at": "2022-11-23T17:52:25Z",
+                      "updated_at": "2022-11-23T17:52:25Z",
+                      "proxy_host": "us-east-2.aws.neon.tech",
+                      "cpu_used_sec": 0,
+                      "branch_logical_size_limit": 0,
+                      "owner_id": "1232111",
+                      "creation_source": "console",
+                      "store_passwords": true,
+                      "branch_logical_size_limit_bytes": 10800,
+                      "active_time": 100,
+                      "org_id": "org-morning-bread-81040908"
+                    }
+                  ],
+                  "applications": {
+                    "winter-boat-259881": [
+                      "vercel",
+                      "github"
+                    ]
+                  },
+                  "integrations": {
+                    "winter-boat-259881": [
+                      "vercel",
+                      "github"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a project",
+        "description": "Creates a Neon project.\nA project is the top-level object in the Neon object hierarchy.\nPlan limits define how many projects you can create.\nFor more information, see [Manage projects](https://neon.tech/docs/manage/projects/).\n\nYou can specify a region and Postgres version in the request body.\nNeon currently supports PostgreSQL 14, 15, 16, and 17.\nFor supported regions and `region_id` values, see [Regions](https://neon.tech/docs/introduction/regions/).\n",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "createProject",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectCreateRequest"
+              },
+              "examples": {
+                "required_attributes_only": {
+                  "summary": "Required attributes only",
+                  "value": {
+                    "project": {
+                      "name": "myproject"
+                    }
+                  }
+                },
+                "commonly_specified_attributes": {
+                  "summary": "Commonly-specified attributes",
+                  "value": {
+                    "project": {
+                      "name": "myproject",
+                      "region_id": "aws-us-east-2",
+                      "pg_version": 15
+                    }
+                  }
+                },
+                "with_autoscaling": {
+                  "summary": "With autoscaling attributes",
+                  "value": {
+                    "project": {
+                      "name": "myproject",
+                      "region_id": "aws-us-east-2",
+                      "pg_version": 15,
+                      "autoscaling_limit_min_cu": 0.25,
+                      "autoscaling_limit_max_cu": 1,
+                      "provisioner": "k8s-neonvm"
+                    }
+                  }
+                },
+                "with_branch_attributes": {
+                  "summary": "With branch attributes",
+                  "value": {
+                    "project": {
+                      "name": "myproject",
+                      "region_id": "aws-us-east-2",
+                      "pg_version": 15,
+                      "branch": {
+                        "name": "mybranch",
+                        "role_name": "sally",
+                        "database_name": "mydb"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/CreatedProject"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/shared": {
+      "get": {
+        "summary": "Get a list of shared projects",
+        "description": "Retrieves a list of shared projects for the Neon account.\nA project is the top-level object in the Neon object hierarchy.\nFor more information, see [Manage projects](https://neon.tech/docs/manage/projects/).\n",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "listSharedProjects",
+        "parameters": [
+          {
+            "name": "cursor",
+            "description": "Specify the cursor value from the previous response to get the next batch of projects.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Specify a value from 1 to 400 to limit number of projects in the response.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 10,
+              "maximum": 400
+            }
+          },
+          {
+            "name": "search",
+            "description": "Search query by name or id.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TimeoutParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returned a list of shared projects for the Neon account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ProjectsResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PaginationResponse"
+                    }
+                  ]
+                },
+                "example": {
+                  "projects": [
+                    {
+                      "id": "shiny-wind-028834",
+                      "platform_id": "aws",
+                      "region_id": "aws-us-east-2",
+                      "name": "shiny-wind-028834",
+                      "provisioner": "k8s-pod",
+                      "pg_version": 15,
+                      "created_at": "2022-11-23T17:42:25Z",
+                      "updated_at": "2022-11-23T17:42:25Z",
+                      "proxy_host": "us-east-2.aws.neon.tech",
+                      "cpu_used_sec": 0,
+                      "branch_logical_size_limit": 0,
+                      "owner_id": "1232111",
+                      "creation_source": "console",
+                      "store_passwords": true,
+                      "branch_logical_size_limit_bytes": 10800,
+                      "active_time": 100
+                    },
+                    {
+                      "id": "winter-boat-259881",
+                      "platform_id": "aws",
+                      "region_id": "aws-us-east-2",
+                      "name": "winter-boat-259881",
+                      "provisioner": "k8s-pod",
+                      "pg_version": 15,
+                      "created_at": "2022-11-23T17:52:25Z",
+                      "updated_at": "2022-11-23T17:52:25Z",
+                      "proxy_host": "us-east-2.aws.neon.tech",
+                      "cpu_used_sec": 0,
+                      "branch_logical_size_limit": 0,
+                      "owner_id": "1232111",
+                      "creation_source": "console",
+                      "store_passwords": true,
+                      "branch_logical_size_limit_bytes": 10800,
+                      "active_time": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get project details",
+        "description": "Retrieves information about the specified project.\nA project is the top-level object in the Neon object hierarchy.\nYou can obtain a `project_id` by listing the projects for your Neon account.\n",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "getProject",
+        "responses": {
+          "200": {
+            "description": "Returned information about the specified project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                },
+                "example": {
+                  "project": {
+                    "id": "shiny-wind-028834",
+                    "platform_id": "aws",
+                    "region_id": "aws-us-east-2",
+                    "name": "shiny-wind-028834",
+                    "provisioner": "k8s-pod",
+                    "pg_version": 15,
+                    "history_retention_seconds": 604800,
+                    "created_at": "2022-11-23T17:42:25Z",
+                    "updated_at": "2022-11-23T17:42:25Z",
+                    "proxy_host": "us-east-2.aws.neon.tech",
+                    "branch_logical_size_limit": 0,
+                    "cpu_used_sec": 10,
+                    "owner_id": "1232111",
+                    "owner": {
+                      "name": "John Smith",
+                      "email": "some@email.com",
+                      "branches_limit": 10,
+                      "subscription_type": "scale"
+                    },
+                    "creation_source": "console",
+                    "store_passwords": true,
+                    "branch_logical_size_limit_bytes": 10500,
+                    "data_storage_bytes_hour": 1040,
+                    "data_transfer_bytes": 1000000,
+                    "written_data_bytes": 100800,
+                    "compute_time_seconds": 100,
+                    "active_time_seconds": 100,
+                    "consumption_period_start": "2023-02-01T00:00:00Z",
+                    "consumption_period_end": "2023-03-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update a project",
+        "description": "Updates the specified project.\nYou can obtain a `project_id` by listing the projects for your Neon account.\n",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "updateProject",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectUpdateRequest"
+              },
+              "example": {
+                "project": {
+                  "name": "myproject"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated the specified project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ProjectResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OperationsResponse"
+                    }
+                  ]
+                },
+                "example": {
+                  "operations": [],
+                  "project": {
+                    "id": "shiny-wind-028834",
+                    "platform_id": "aws",
+                    "region_id": "aws-us-east-2",
+                    "name": "myproject",
+                    "provisioner": "k8s-pod",
+                    "pg_version": 15,
+                    "created_at": "2022-11-23T17:42:25Z",
+                    "updated_at": "2022-12-04T02:39:25Z",
+                    "proxy_host": "us-east-2.aws.neon.tech",
+                    "branch_logical_size_limit": 0,
+                    "cpu_used_sec": 213230,
+                    "owner_id": "1232111",
+                    "creation_source": "console",
+                    "store_passwords": true,
+                    "branch_logical_size_limit_bytes": 10500,
+                    "data_storage_bytes_hour": 1040,
+                    "data_transfer_bytes": 1000000,
+                    "written_data_bytes": 100800,
+                    "compute_time_seconds": 100,
+                    "active_time_seconds": 100,
+                    "history_retention_seconds": 604800,
+                    "consumption_period_start": "2023-02-01T00:00:00Z",
+                    "consumption_period_end": "2023-03-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a project",
+        "description": "Deletes the specified project.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nDeleting a project is a permanent action.\nDeleting a project also deletes endpoints, branches, databases, and users that belong to the project.\n",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "deleteProject",
+        "responses": {
+          "200": {
+            "description": "Deleted the specified project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                },
+                "example": {
+                  "project": {
+                    "id": "bold-cloud-468218",
+                    "platform_id": "aws",
+                    "region_id": "aws-us-east-2",
+                    "name": "bold-cloud-468218",
+                    "provisioner": "k8s-pod",
+                    "pg_version": 15,
+                    "created_at": "2022-11-30T18:41:29Z",
+                    "updated_at": "2022-11-30T18:41:29Z",
+                    "proxy_host": "us-east-2.aws.neon.tech",
+                    "cpu_used_sec": 23004200,
+                    "branch_logical_size_limit": 0,
+                    "owner_id": "1232111",
+                    "creation_source": "console",
+                    "store_passwords": true,
+                    "branch_logical_size_limit_bytes": 10500,
+                    "data_storage_bytes_hour": 1040,
+                    "data_transfer_bytes": 1000000,
+                    "written_data_bytes": 100800,
+                    "compute_time_seconds": 100,
+                    "active_time_seconds": 100,
+                    "history_retention_seconds": 604800,
+                    "consumption_period_start": "2023-02-01T00:00:00Z",
+                    "consumption_period_end": "2023-03-01T00:00:00Z"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/operations": {
+      "get": {
+        "summary": "Get a list of operations",
+        "description": "Retrieves a list of operations for the specified Neon project.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nThe number of operations returned can be large.\nTo paginate the response, issue an initial request with a `limit` value.\nThen, add the `cursor` value that was returned in the response to the next request.\n",
+        "tags": [
+          "Operation"
+        ],
+        "operationId": "listProjectOperations",
+        "parameters": [
+          {
+            "name": "cursor",
+            "description": "Specify the cursor value from the previous response to get the next batch of operations",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Specify a value from 1 to 1000 to limit number of operations in the response",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "The Neon project ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ListOperations"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/permissions": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "List project access",
+        "description": "Retrieves details about users who have access to the project, including the permission `id`, the granted-to email address, and the date project access was granted.",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "listProjectPermissions",
+        "responses": {
+          "200": {
+            "description": "Returned project access details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectPermissions"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "post": {
+        "summary": "Grant project access",
+        "description": "Grants project access to the account associated with the specified email address",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "grantPermissionToProject",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GrantPermissionToProjectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Granted project access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectPermission"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/permissions/{permission_id}": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "permission_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "delete": {
+        "summary": "Revoke project access",
+        "description": "Revokes project access from the user associated with the specified permission `id`. You can retrieve a user's permission `id` by listing project access.",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "revokePermissionFromProject",
+        "responses": {
+          "200": {
+            "description": "Revoked project access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectPermission"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/jwks": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Returns all available JWKS URLs for a project",
+        "description": "Returns all the available JWKS URLs that can be used for verifying JWTs used as the authentication mechanism for the specified project.\n",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "getProjectJWKS",
+        "responses": {
+          "200": {
+            "description": "The JWKS URLs available for the project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectJWKSResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "post": {
+        "summary": "Adds a JWKS URL to a project",
+        "description": "Add a new JWKS URL to a project, such that it can be used for verifying JWTs used as the authentication mechanism for the specified project.\n\nThe URL must be a valid HTTPS URL that returns a JSON Web Key Set.\n\nThe `provider_name` field allows you to specify which authentication provider you're using (e.g., Clerk, Auth0, AWS Cognito, etc.).\n\nThe `branch_id` can be used to specify on which branches the JWKS URL will be accepted. If not specified, then it will work on any branch.\n\nThe `role_names` can be used to specify for which roles the JWKS URL will be accepted.\n\nThe `jwt_audience` can be used to specify which \"aud\" values should be accepted by Neon in the JWTs that are used for authentication.\n",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "addProjectJWKS",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddProjectJWKSRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The JWKS URL was added to the project's authentication connections",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JWKSCreationOperation"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/jwks/{jwks_id}": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "jwks_id",
+          "in": "path",
+          "description": "The JWKS ID",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "delete": {
+        "summary": "Delete a JWKS URL",
+        "description": "Deletes a JWKS URL from the specified project",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "deleteProjectJWKS",
+        "responses": {
+          "200": {
+            "description": "Deleted a JWKS URL from the project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JWKS"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/connection_uri": {
+      "get": {
+        "summary": "Get a connection URI",
+        "description": "Retrieves a connection URI for the specified database.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `database_name` by listing the databases for a branch.\nYou can obtain a `role_name` by listing the roles for a branch.\n",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "getConnectionURI",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "The Neon project ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          },
+          {
+            "name": "branch_id",
+            "in": "query",
+            "description": "The branch ID. Defaults to your project's default `branch_id` if not specified.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          },
+          {
+            "name": "endpoint_id",
+            "in": "query",
+            "description": "The endpoint ID. Defaults to the read-write `endpoint_id` associated with the `branch_id` if not specified.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          },
+          {
+            "name": "database_name",
+            "in": "query",
+            "description": "The database name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "role_name",
+            "in": "query",
+            "description": "The role name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pooled",
+            "in": "query",
+            "description": "Adds the `-pooler` option to the connection URI when set to `true`, creating a pooled connection URI.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returned the connection URI",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionURIResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Create a branch",
+        "description": "Creates a branch in the specified project.\nYou can obtain a `project_id` by listing the projects for your Neon account.\n\nThis method does not require a request body, but you can specify one to create a compute endpoint for the branch or to select a non-default parent branch.\nThe default behavior is to create a branch from the project's default branch with no compute endpoint, and the branch name is auto-generated.\nThere is a maximum of one read-write endpoint per branch.\nA branch can have multiple read-only endpoints.\nFor related information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "createProjectBranch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BranchCreateRequest"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AnnotationCreateValueRequest"
+                  }
+                ]
+              },
+              "examples": {
+                "branch_only": {
+                  "summary": "Branch only",
+                  "value": {
+                    "branch": {
+                      "parent_id": "br-aged-salad-637688",
+                      "name": "mybranch"
+                    }
+                  }
+                },
+                "branch_with_endpoint": {
+                  "summary": "Branch with endpoint",
+                  "value": {
+                    "endpoints": [
+                      {
+                        "type": "read_write"
+                      }
+                    ],
+                    "branch": {
+                      "parent_id": "br-aged-salad-637688",
+                      "name": "mybranch"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/CreatedBranch"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "get": {
+        "summary": "Get a list of branches",
+        "description": "Retrieves a list of branches for the specified project.\nYou can obtain a `project_id` by listing the projects for your Neon account.\n\nEach Neon project has a root branch named `main`.\nA `branch_id` value has a `br-` prefix.\nA project may contain child branches that were branched from `main` or from another branch.\nA parent branch is identified by the `parent_id` value, which is the `id` of the parent branch.\nFor related information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "listProjectBranches",
+        "parameters": [
+          {
+            "name": "search",
+            "description": "Search by branch `name` or `id`. You can specify partial `name` or `id` values to filter results.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort_by",
+            "description": "Sort the branches by sort_field. If not provided, branches will be sorted by updated_at descending order",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "updated_at",
+              "enum": [
+                "name",
+                "created_at",
+                "updated_at"
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/CursorParam"
+          },
+          {
+            "$ref": "#/components/parameters/SortOrderParam"
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returned a list of branches for the specified project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/BranchesResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AnnotationsMapResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CursorPaginationResponse"
+                    }
+                  ]
+                },
+                "example": {
+                  "branches": [
+                    {
+                      "id": "br-aged-salad-637688",
+                      "project_id": "shiny-wind-028834",
+                      "name": "main",
+                      "current_state": "ready",
+                      "state_changed_at": "2022-11-30T20:09:48Z",
+                      "logical_size": 28,
+                      "created_at": "2022-11-23T17:42:25Z",
+                      "updated_at": "2022-11-23T17:42:26Z",
+                      "data_transfer_bytes": 1000000,
+                      "written_data_bytes": 100800,
+                      "compute_time_seconds": 100,
+                      "active_time_seconds": 100,
+                      "cpu_used_sec": 100,
+                      "default": true,
+                      "protected": false,
+                      "creation_source": "console"
+                    },
+                    {
+                      "id": "br-sweet-breeze-497520",
+                      "project_id": "shiny-wind-028834",
+                      "parent_id": "br-aged-salad-637688",
+                      "parent_lsn": "0/1DE2850",
+                      "name": "dev2",
+                      "current_state": "ready",
+                      "state_changed_at": "2022-11-30T20:09:48Z",
+                      "logical_size": 28,
+                      "created_at": "2022-11-30T19:09:48Z",
+                      "updated_at": "2022-11-30T19:09:49Z",
+                      "data_transfer_bytes": 1000000,
+                      "written_data_bytes": 100800,
+                      "compute_time_seconds": 100,
+                      "active_time_seconds": 100,
+                      "cpu_used_sec": 100,
+                      "default": true,
+                      "protected": false,
+                      "creation_source": "console"
+                    },
+                    {
+                      "id": "br-raspy-hill-832856",
+                      "project_id": "shiny-wind-028834",
+                      "parent_id": "br-aged-salad-637688",
+                      "parent_lsn": "0/19623D8",
+                      "name": "dev1",
+                      "current_state": "ready",
+                      "state_changed_at": "2022-11-30T20:09:48Z",
+                      "logical_size": 21,
+                      "created_at": "2022-11-30T17:36:57Z",
+                      "updated_at": "2022-11-30T17:36:57Z",
+                      "data_transfer_bytes": 1000000,
+                      "written_data_bytes": 100800,
+                      "compute_time_seconds": 100,
+                      "active_time_seconds": 100,
+                      "cpu_used_sec": 100,
+                      "default": true,
+                      "protected": false,
+                      "creation_source": "console"
+                    }
+                  ],
+                  "annotations": {
+                    "br-aged-salad-637688": {
+                      "object": {
+                        "type": "console/branch",
+                        "id": "br-aged-salad-637688"
+                      },
+                      "value": {
+                        "vercel-commit-ref": "test"
+                      },
+                      "created_at": "2022-11-23T17:42:25Z",
+                      "updated_at": "2022-11-23T17:42:26Z"
+                    }
+                  },
+                  "pagination": {
+                    "next": "eyJjcmVhdGV",
+                    "sort_by": "updated_at",
+                    "sort_order": "desc"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches/count": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get the total number of branches in a project",
+        "description": "Retrieves the total number of branches in the specified project.\nYou can obtain a `project_id` by listing the projects for your Neon account.\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "countProjectBranches",
+        "parameters": [
+          {
+            "name": "search",
+            "description": "Count branches matching the `name` in search query",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          },
+          "200": {
+            "description": "Returned a count of branches for the specified project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/BranchesCountResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches/{branch_id}": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "branch_id",
+          "in": "path",
+          "description": "The branch ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get branch details",
+        "description": "Retrieves information about the specified branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain a `branch_id` by listing the project's branches.\nA `branch_id` value has a `br-` prefix.\n\nEach Neon project is initially created with a root and default branch named `main`.\nA project can contain one or more branches.\nA parent branch is identified by a `parent_id` value, which is the `id` of the parent branch.\nFor related information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "getProjectBranch",
+        "responses": {
+          "200": {
+            "description": "Returned information about the specified branch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/BranchResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AnnotationResponse"
+                    }
+                  ]
+                },
+                "example": {
+                  "branch": {
+                    "id": "br-aged-salad-637688",
+                    "project_id": "shiny-wind-028834",
+                    "name": "main",
+                    "current_state": "ready",
+                    "state_changed_at": "2022-11-30T20:09:48Z",
+                    "logical_size": 28,
+                    "created_at": "2022-11-23T17:42:25Z",
+                    "updated_at": "2022-11-23T17:42:26Z",
+                    "data_transfer_bytes": 1000000,
+                    "written_data_bytes": 100800,
+                    "compute_time_seconds": 100,
+                    "active_time_seconds": 100,
+                    "cpu_used_sec": 100,
+                    "default": true,
+                    "protected": false,
+                    "creation_source": "console"
+                  },
+                  "annotation": {
+                    "object": {
+                      "type": "console/branch",
+                      "id": "br-aged-salad-637688"
+                    },
+                    "value": {
+                      "vercel-commit-ref": "test"
+                    },
+                    "created_at": "2022-11-23T17:42:25Z",
+                    "updated_at": "2022-11-23T17:42:26Z"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a branch",
+        "description": "Deletes the specified branch from a project, and places\nall compute endpoints into an idle state, breaking existing client connections.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain a `branch_id` by listing the project's branches.\nFor related information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n\nWhen a successful response status is received, the compute endpoints are still active,\nand the branch is not yet deleted from storage.\nThe deletion occurs after all operations finish.\nYou cannot delete a project's root or default branch, and you cannot delete a branch that has a child branch.\nA project must have at least one branch.\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "deleteProjectBranch",
+        "responses": {
+          "200": {
+            "description": "Deleted the specified branch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BranchOperations"
+                },
+                "example": {
+                  "branch": {
+                    "id": "br-aged-salad-637688",
+                    "project_id": "shiny-wind-028834",
+                    "name": "main",
+                    "current_state": "ready",
+                    "state_changed_at": "2022-11-30T20:09:48Z",
+                    "logical_size": 28,
+                    "created_at": "2022-11-23T17:42:25Z",
+                    "updated_at": "2022-11-23T17:42:26Z",
+                    "data_transfer_bytes": 1000000,
+                    "written_data_bytes": 100800,
+                    "compute_time_seconds": 100,
+                    "active_time_seconds": 100,
+                    "cpu_used_sec": 100,
+                    "default": true,
+                    "protected": false,
+                    "creation_source": "console"
+                  },
+                  "operations": [
+                    {
+                      "id": "b6afbc21-2990-4a76-980b-b57d8c2948f2",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-sweet-breeze-497520",
+                      "endpoint_id": "ep-soft-violet-752733",
+                      "action": "suspend_compute",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-01T19:53:05Z",
+                      "updated_at": "2022-12-01T19:53:05Z",
+                      "total_duration_ms": 100
+                    },
+                    {
+                      "id": "b6afbc21-2990-4a76-980b-b57d8c2948f2",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-sweet-breeze-497520",
+                      "action": "delete_timeline",
+                      "status": "scheduling",
+                      "failures_count": 0,
+                      "created_at": "2022-12-01T19:53:05Z",
+                      "updated_at": "2022-12-01T19:53:05Z",
+                      "total_duration_ms": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "Returned if the branch doesn't exist or has already been deleted"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Branch"
+        ],
+        "summary": "Update a branch",
+        "description": "Updates the specified branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nFor more information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n",
+        "operationId": "updateProjectBranch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BranchUpdateRequest"
+              },
+              "example": {
+                "branch": {
+                  "name": "mybranch"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Updated the specified branch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BranchOperations"
+                },
+                "example": {
+                  "branch": {
+                    "id": "br-icy-dream-250089",
+                    "project_id": "shiny-wind-028834",
+                    "parent_id": "br-aged-salad-637688",
+                    "parent_lsn": "0/1E19478",
+                    "name": "mybranch",
+                    "current_state": "ready",
+                    "state_changed_at": "2022-11-30T20:09:48Z",
+                    "created_at": "2022-11-23T17:42:25Z",
+                    "updated_at": "2022-11-23T17:42:26Z",
+                    "data_transfer_bytes": 1000000,
+                    "written_data_bytes": 100800,
+                    "compute_time_seconds": 100,
+                    "active_time_seconds": 100,
+                    "cpu_used_sec": 100,
+                    "default": true,
+                    "protected": false,
+                    "creation_source": "console"
+                  },
+                  "operations": []
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches/{branch_id}/restore": {
+      "post": {
+        "tags": [
+          "Branch"
+        ],
+        "summary": "Restore a branch",
+        "description": "Restores a branch to an earlier state in its own or another branch's history",
+        "operationId": "restoreProjectBranch",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "The Neon project ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          },
+          {
+            "name": "branch_id",
+            "in": "path",
+            "description": "The branch ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BranchRestoreRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Updated the specified branch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BranchOperations"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches/{branch_id}/schema": {
+      "get": {
+        "tags": [
+          "Branch"
+        ],
+        "summary": "Get the database schema",
+        "description": "Retrieves the schema from the specified database. The `lsn` and `timestamp` values cannot be specified at the same time. If both are omitted, the database schema is retrieved from database's head.",
+        "operationId": "getProjectBranchSchema",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "The Neon project ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          },
+          {
+            "name": "branch_id",
+            "in": "path",
+            "description": "The branch ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          },
+          {
+            "name": "db_name",
+            "in": "query",
+            "description": "Name of the database for which the schema is retrieved",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lsn",
+            "in": "query",
+            "description": "The Log Sequence Number (LSN) for which the schema is retrieved\n",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "timestamp",
+            "in": "query",
+            "description": "The point in time for which the schema is retrieved\n",
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "example": "2022-11-30T20:09:48Z"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Schema definition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BranchSchemaResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches/{branch_id}/compare_schema": {
+      "get": {
+        "tags": [
+          "Branch"
+        ],
+        "summary": "Compare the database schema with another branch's schema",
+        "description": "Compares the schema from the specified database with another branch's schema. Hidden from the public spec.",
+        "operationId": "getProjectBranchSchemaComparison",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "The Neon project ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          },
+          {
+            "name": "branch_id",
+            "in": "path",
+            "description": "The branch ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          },
+          {
+            "name": "base_branch_id",
+            "in": "query",
+            "description": "The branch ID to compare the schema with",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          },
+          {
+            "name": "db_name",
+            "in": "query",
+            "description": "Name of the database for which the schema is retrieved",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lsn",
+            "in": "query",
+            "description": "The Log Sequence Number (LSN) for which the schema is retrieved\n",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "timestamp",
+            "in": "query",
+            "description": "The point in time for which the schema is retrieved\n",
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "example": "2022-11-30T20:09:48Z"
+            }
+          },
+          {
+            "name": "base_lsn",
+            "in": "query",
+            "description": "The Log Sequence Number (LSN) for the base branch schema\n",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "base_timestamp",
+            "in": "query",
+            "description": "The point in time for the base branch schema\n",
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "example": "2022-11-30T20:09:48Z"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Difference between the schemas",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BranchSchemaCompareResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches/{branch_id}/set_as_default": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "branch_id",
+          "in": "path",
+          "description": "The branch ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "post": {
+        "tags": [
+          "Branch"
+        ],
+        "summary": "Set branch as default",
+        "description": "Sets the specified branch as the project's default branch.\nThe default designation is automatically removed from the previous default branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nFor more information, see [Manage branches](https://neon.tech/docs/manage/branches/).\n",
+        "operationId": "setDefaultProjectBranch",
+        "responses": {
+          "200": {
+            "description": "Updated the specified branch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BranchOperations"
+                },
+                "example": {
+                  "branch": {
+                    "cpu_used_sec": 1,
+                    "active_time_seconds": 1,
+                    "compute_time_seconds": 1,
+                    "written_data_bytes": 100,
+                    "data_transfer_bytes": 100,
+                    "id": "br-icy-dream-250089",
+                    "project_id": "shiny-wind-028834",
+                    "parent_id": "br-aged-salad-637688",
+                    "parent_lsn": "0/1E19478",
+                    "name": "mybranch",
+                    "current_state": "ready",
+                    "state_changed_at": "2022-11-30T20:09:48Z",
+                    "created_at": "2022-11-23T17:42:25Z",
+                    "updated_at": "2022-11-23T17:42:26Z",
+                    "default": true,
+                    "protected": false,
+                    "creation_source": "console"
+                  },
+                  "operations": []
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches/{branch_id}/endpoints": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "branch_id",
+          "in": "path",
+          "description": "The branch ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get a list of branch endpoints",
+        "description": "Retrieves a list of compute endpoints for the specified branch.\nNeon permits only one read-write compute endpoint per branch.\nA branch can have multiple read-only compute endpoints.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "listProjectBranchEndpoints",
+        "responses": {
+          "200": {
+            "description": "Returned a list of endpoints for the specified branch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointsResponse"
+                },
+                "example": {
+                  "endpoints": [
+                    {
+                      "host": "ep-little-smoke-851426.us-east-2.aws.neon.tech",
+                      "id": "ep-little-smoke-851426",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-aged-salad-637688",
+                      "autoscaling_limit_min_cu": 1,
+                      "autoscaling_limit_max_cu": 1,
+                      "region_id": "aws-us-east-2",
+                      "type": "read_write",
+                      "current_state": "idle",
+                      "settings": {
+                        "pg_settings": {}
+                      },
+                      "pooler_enabled": false,
+                      "pooler_mode": "transaction",
+                      "disabled": false,
+                      "passwordless_access": true,
+                      "last_active": "2022-11-23T17:00:00Z",
+                      "created_at": "2022-11-23T17:42:25Z",
+                      "updated_at": "2022-11-30T18:25:21Z",
+                      "proxy_host": "us-east-2.aws.neon.tech",
+                      "creation_source": "console",
+                      "provisioner": "k8s-pod",
+                      "suspend_timeout_seconds": 10800
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches/{branch_id}/databases": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "branch_id",
+          "in": "path",
+          "description": "The branch ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get a list of databases",
+        "description": "Retrieves a list of databases for the specified branch.\nA branch can have multiple databases.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nFor related information, see [Manage databases](https://neon.tech/docs/manage/databases/).\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "listProjectBranchDatabases",
+        "responses": {
+          "200": {
+            "description": "Returned a list of databases of the specified branch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabasesResponse"
+                },
+                "example": {
+                  "databases": [
+                    {
+                      "id": 834686,
+                      "branch_id": "br-aged-salad-637688",
+                      "name": "main",
+                      "owner_name": "casey",
+                      "created_at": "2022-11-30T18:25:15Z",
+                      "updated_at": "2022-11-30T18:25:15Z"
+                    },
+                    {
+                      "id": 834686,
+                      "branch_id": "br-aged-salad-637688",
+                      "name": "mydb",
+                      "owner_name": "casey",
+                      "created_at": "2022-10-30T17:14:13Z",
+                      "updated_at": "2022-10-30T17:14:13Z"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Branch"
+        ],
+        "summary": "Create a database",
+        "description": "Creates a database in the specified branch.\nA branch can have multiple databases.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nFor related information, see [Manage databases](https://neon.tech/docs/manage/databases/).\n",
+        "operationId": "createProjectBranchDatabase",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatabaseCreateRequest"
+              },
+              "example": {
+                "database": {
+                  "name": "mydb",
+                  "owner_name": "casey"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created a database in the specified branch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseOperations"
+                },
+                "example": {
+                  "database": {
+                    "id": 876692,
+                    "branch_id": "br-aged-salad-637688",
+                    "name": "mydb",
+                    "owner_name": "casey",
+                    "created_at": "2022-12-04T00:15:04Z",
+                    "updated_at": "2022-12-04T00:15:04Z"
+                  },
+                  "operations": [
+                    {
+                      "id": "39426015-db00-40fa-85c5-1c7072df46d0",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-aged-salad-637688",
+                      "endpoint_id": "ep-little-smoke-851426",
+                      "action": "apply_config",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-04T00:15:04Z",
+                      "updated_at": "2022-12-04T00:15:04Z",
+                      "total_duration_ms": 100
+                    },
+                    {
+                      "id": "b7483d4e-33da-4d40-b319-ac858d4d3e69",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-aged-salad-637688",
+                      "endpoint_id": "ep-little-smoke-851426",
+                      "action": "suspend_compute",
+                      "status": "scheduling",
+                      "failures_count": 0,
+                      "created_at": "2022-12-04T00:15:04Z",
+                      "updated_at": "2022-12-04T00:15:04Z",
+                      "total_duration_ms": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches/{branch_id}/databases/{database_name}": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "branch_id",
+          "in": "path",
+          "description": "The branch ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "database_name",
+          "in": "path",
+          "description": "The database name",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get database details",
+        "description": "Retrieves information about the specified database.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` and `database_name` by listing the branch's databases.\nFor related information, see [Manage databases](https://neon.tech/docs/manage/databases/).\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "getProjectBranchDatabase",
+        "responses": {
+          "200": {
+            "description": "Returned the database details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseResponse"
+                },
+                "example": {
+                  "database": {
+                    "id": 834686,
+                    "branch_id": "br-aged-salad-637688",
+                    "name": "main",
+                    "owner_name": "casey",
+                    "created_at": "2022-11-30T18:25:15Z",
+                    "updated_at": "2022-11-30T18:25:15Z"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Branch"
+        ],
+        "summary": "Update a database",
+        "description": "Updates the specified database in the branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` and `database_name` by listing the branch's databases.\nFor related information, see [Manage databases](https://neon.tech/docs/manage/databases/).\n",
+        "operationId": "updateProjectBranchDatabase",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatabaseUpdateRequest"
+              },
+              "example": {
+                "database": {
+                  "name": "mydb",
+                  "owner_name": "sally"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Updated the database",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseOperations"
+                },
+                "example": {
+                  "database": {
+                    "id": 876692,
+                    "branch_id": "br-aged-salad-637688",
+                    "name": "mydb",
+                    "owner_name": "sally",
+                    "created_at": "2022-12-04T00:15:04Z",
+                    "updated_at": "2022-12-04T00:15:04Z"
+                  },
+                  "operations": [
+                    {
+                      "id": "9ef1c2ed-dce4-43aa-bae8-78aea636bf8a",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-aged-salad-637688",
+                      "endpoint_id": "ep-little-smoke-851426",
+                      "action": "apply_config",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-04T00:21:01Z",
+                      "updated_at": "2022-12-04T00:21:01Z",
+                      "total_duration_ms": 100
+                    },
+                    {
+                      "id": "42dafb46-f861-497b-ae89-f2bec54f4966",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-aged-salad-637688",
+                      "endpoint_id": "ep-little-smoke-851426",
+                      "action": "suspend_compute",
+                      "status": "scheduling",
+                      "failures_count": 0,
+                      "created_at": "2022-12-04T00:21:01Z",
+                      "updated_at": "2022-12-04T00:21:01Z",
+                      "total_duration_ms": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a database",
+        "description": "Deletes the specified database from the branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` and `database_name` by listing the branch's databases.\nFor related information, see [Manage databases](https://neon.tech/docs/manage/databases/).\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "deleteProjectBranchDatabase",
+        "responses": {
+          "200": {
+            "description": "Deleted the specified database",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseOperations"
+                },
+                "example": {
+                  "database": {
+                    "id": 851537,
+                    "branch_id": "br-raspy-hill-832856",
+                    "name": "mydb",
+                    "owner_name": "casey",
+                    "created_at": "2022-12-01T19:41:46Z",
+                    "updated_at": "2022-12-01T19:41:46Z"
+                  },
+                  "operations": [
+                    {
+                      "id": "9ef1c2ed-dce4-43aa-bae8-78aea636bf8a",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-raspy-hill-832856",
+                      "endpoint_id": "ep-steep-bush-777093",
+                      "action": "apply_config",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-01T19:51:41Z",
+                      "updated_at": "2022-12-01T19:51:41Z",
+                      "total_duration_ms": 100
+                    },
+                    {
+                      "id": "42dafb46-f861-497b-ae89-f2bec54f4966",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-raspy-hill-832856",
+                      "endpoint_id": "ep-steep-bush-777093",
+                      "action": "suspend_compute",
+                      "status": "scheduling",
+                      "failures_count": 0,
+                      "created_at": "2022-12-01T19:51:41Z",
+                      "updated_at": "2022-12-01T19:51:41Z",
+                      "total_duration_ms": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "Returned if the database doesn't exist or has already been deleted"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches/{branch_id}/roles": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "branch_id",
+          "in": "path",
+          "description": "The branch ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get a list of roles",
+        "description": "Retrieves a list of Postgres roles from the specified branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "listProjectBranchRoles",
+        "responses": {
+          "200": {
+            "description": "Returned a list of roles from the specified branch.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RolesResponse"
+                },
+                "example": {
+                  "roles": [
+                    {
+                      "branch_id": "br-aged-salad-637688",
+                      "name": "casey",
+                      "protected": false,
+                      "created_at": "2022-11-23T17:42:25Z",
+                      "updated_at": "2022-11-23T17:42:25Z"
+                    },
+                    {
+                      "branch_id": "br-aged-salad-637688",
+                      "name": "thomas",
+                      "protected": false,
+                      "created_at": "2022-10-22T17:38:21Z",
+                      "updated_at": "2022-10-22T17:38:21Z"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a role",
+        "description": "Creates a Postgres role in the specified branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n\nConnections established to the active compute endpoint will be dropped.\nIf the compute endpoint is idle, the endpoint becomes active for a short period of time and is suspended afterward.\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "createProjectBranchRole",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoleCreateRequest"
+              },
+              "example": {
+                "role": {
+                  "name": "sally"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created a role in the specified branch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleOperations"
+                },
+                "example": {
+                  "role": {
+                    "branch_id": "br-noisy-sunset-458773",
+                    "name": "sally",
+                    "password": "Onf1AjayKwe0",
+                    "protected": false,
+                    "created_at": "2022-12-03T11:58:29Z",
+                    "updated_at": "2022-12-03T11:58:29Z"
+                  },
+                  "operations": [
+                    {
+                      "id": "2c2be371-d5ac-4db5-8b68-79f05e8bc287",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-noisy-sunset-458773",
+                      "endpoint_id": "ep-small-pine-767857",
+                      "action": "apply_config",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-03T11:58:29Z",
+                      "updated_at": "2022-12-03T11:58:29Z",
+                      "total_duration_ms": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches/{branch_id}/roles/{role_name}": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "branch_id",
+          "in": "path",
+          "description": "The branch ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "role_name",
+          "in": "path",
+          "description": "The role name",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get role details",
+        "description": "Retrieves details about the specified role.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nYou can obtain the `role_name` by listing the roles for a branch.\nIn Neon, the terms \"role\" and \"user\" are synonymous.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "getProjectBranchRole",
+        "responses": {
+          "200": {
+            "description": "Returned details for the specified role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleResponse"
+                },
+                "example": {
+                  "role": {
+                    "branch_id": "br-noisy-sunset-458773",
+                    "name": "casey",
+                    "protected": false,
+                    "created_at": "2022-11-23T17:42:25Z",
+                    "updated_at": "2022-11-23T17:42:25Z"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a role",
+        "description": "Deletes the specified Postgres role from the branch.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nYou can obtain the `role_name` by listing the roles for a branch.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "deleteProjectBranchRole",
+        "responses": {
+          "200": {
+            "description": "Deleted the specified role from the branch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleOperations"
+                },
+                "example": {
+                  "role": {
+                    "branch_id": "br-raspy-hill-832856",
+                    "name": "thomas",
+                    "protected": false,
+                    "created_at": "2022-12-01T14:36:23Z",
+                    "updated_at": "2022-12-01T14:36:23Z"
+                  },
+                  "operations": [
+                    {
+                      "id": "db646be3-eace-4910-9f60-8150823c5cb8",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-raspy-hill-832856",
+                      "endpoint_id": "ep-steep-bush-777093",
+                      "action": "apply_config",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-01T19:48:11Z",
+                      "updated_at": "2022-12-01T19:48:11Z",
+                      "total_duration_ms": 100
+                    },
+                    {
+                      "id": "ab94cdad-7630-4943-a55e-5a0952d2e598",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-raspy-hill-832856",
+                      "endpoint_id": "ep-steep-bush-777093",
+                      "action": "suspend_compute",
+                      "status": "scheduling",
+                      "failures_count": 0,
+                      "created_at": "2022-12-01T19:48:11Z",
+                      "updated_at": "2022-12-01T19:48:11Z",
+                      "total_duration_ms": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "Returned if the role doesn't exist or has already been deleted"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches/{branch_id}/roles/{role_name}/reveal_password": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "branch_id",
+          "in": "path",
+          "description": "The branch ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "role_name",
+          "in": "path",
+          "description": "The role name",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get role password",
+        "description": "Retrieves the password for the specified Postgres role, if possible.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nYou can obtain the `role_name` by listing the roles for a branch.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "getProjectBranchRolePassword",
+        "responses": {
+          "200": {
+            "description": "Returned password for the specified role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RolePasswordResponse"
+                },
+                "example": {
+                  "password": "mypass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Role not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "Storing passwords is disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/branches/{branch_id}/roles/{role_name}/reset_password": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "branch_id",
+          "in": "path",
+          "description": "The branch ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "role_name",
+          "in": "path",
+          "description": "The role name",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Reset the role password",
+        "description": "Resets the password for the specified Postgres role.\nReturns a new password and operations. The new password is ready to use when the last operation finishes.\nThe old password remains valid until last operation finishes.\nConnections to the compute endpoint are dropped. If idle,\nthe compute endpoint becomes active for a short period of time.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain the `branch_id` by listing the project's branches.\nYou can obtain the `role_name` by listing the roles for a branch.\nFor related information, see [Manage roles](https://neon.tech/docs/manage/roles/).\n",
+        "tags": [
+          "Branch"
+        ],
+        "operationId": "resetProjectBranchRolePassword",
+        "responses": {
+          "200": {
+            "description": "Reset the password for the specified role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleOperations"
+                },
+                "example": {
+                  "role": {
+                    "branch_id": "br-noisy-sunset-458773",
+                    "name": "sally",
+                    "password": "ClfD0aVuK3eK",
+                    "protected": false,
+                    "created_at": "2022-12-03T12:39:39Z",
+                    "updated_at": "2022-12-03T12:58:18Z"
+                  },
+                  "operations": [
+                    {
+                      "id": "6bef07a0-ebca-40cd-9100-7324036cfff2",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-noisy-sunset-458773",
+                      "endpoint_id": "ep-small-pine-767857",
+                      "action": "apply_config",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-03T12:58:18Z",
+                      "updated_at": "2022-12-03T12:58:18Z",
+                      "total_duration_ms": 100
+                    },
+                    {
+                      "id": "16b5bfca-4697-4194-a338-d2cdc9aca2af",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-noisy-sunset-458773",
+                      "endpoint_id": "ep-small-pine-767857",
+                      "action": "suspend_compute",
+                      "status": "scheduling",
+                      "failures_count": 0,
+                      "created_at": "2022-12-03T12:58:18Z",
+                      "updated_at": "2022-12-03T12:58:18Z",
+                      "total_duration_ms": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/vpc_endpoints": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get the list of VPC endpoint restrictions",
+        "description": "Retrieves the list of VPC endpoint restrictions for the specified project.\nThis endpoint is under active development and its semantics may change in the future.\n",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "listProjectVPCEndpoints",
+        "responses": {
+          "200": {
+            "description": "The list of configured VPC endpoint restrictions for the specified project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VPCEndpointsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/vpc_endpoints/{vpc_endpoint_id}": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "vpc_endpoint_id",
+          "in": "path",
+          "description": "The VPC endpoint ID",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Assign or update a VPC endpoint restriction",
+        "description": "Configures the specified VPC endpoint as restriction for the project,\nor updates the existing restriction. When a VPC endpoint is assigned\nas a restriction, only connections from this specific VPC are accepted.\nNote that a VPC endpoint can only used as a restriction on a project\nafter it has been assigned to the parent organization.\nThis endpoint is under active development and its semantics may change in the future.\n",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "assignProjectVPCEndpoint",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VPCEndpointAssignment"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Configured the specified VPC endpoint as a restriction for the specified project."
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a VPC endpoint",
+        "description": "Deletes the specified VPC endpoint restriction from the specified project.\nThis endpoint is under active development and its semantics may change in the future.\n",
+        "tags": [
+          "Project"
+        ],
+        "operationId": "deleteProjectVPCEndpoint",
+        "responses": {
+          "200": {
+            "description": "Deleted the specified VPC endpoint restriction from the specified project"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/endpoints": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Create a compute endpoint",
+        "description": "Creates a compute endpoint for the specified branch.\nAn endpoint is a Neon compute instance.\nThere is a maximum of one read-write compute endpoint per branch.\nIf the specified branch already has a read-write compute endpoint, the operation fails.\nA branch can have multiple read-only compute endpoints.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain `branch_id` by listing the project's branches.\nA `branch_id` has a `br-` prefix.\nFor supported regions and `region_id` values, see [Regions](https://neon.tech/docs/introduction/regions/).\nFor more information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
+        "tags": [
+          "Endpoint"
+        ],
+        "operationId": "createProjectEndpoint",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EndpointCreateRequest"
+              },
+              "examples": {
+                "required_attributes_only": {
+                  "summary": "Required attributes only",
+                  "value": {
+                    "endpoint": {
+                      "branch_id": "br-floral-mountain-251143",
+                      "type": "read_write"
+                    }
+                  }
+                },
+                "with_region_attribute": {
+                  "summary": "With region attribute",
+                  "value": {
+                    "endpoint": {
+                      "branch_id": "br-floral-mountain-251143",
+                      "type": "read_write",
+                      "region_id": "aws-us-east-2"
+                    }
+                  }
+                },
+                "with_pooler_attribute": {
+                  "summary": "With pooler attribute",
+                  "value": {
+                    "endpoint": {
+                      "branch_id": "br-floral-mountain-251143",
+                      "type": "read_write",
+                      "pooler_enabled": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created a compute endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointOperations"
+                },
+                "example": {
+                  "endpoint": {
+                    "host": "ep-shrill-thunder-454069.us-east-2.aws.neon.tech",
+                    "id": "ep-shrill-thunder-454069",
+                    "project_id": "bitter-meadow-966132",
+                    "branch_id": "br-proud-paper-090813",
+                    "autoscaling_limit_min_cu": 1,
+                    "autoscaling_limit_max_cu": 1,
+                    "region_id": "aws-us-east-2",
+                    "type": "read_write",
+                    "current_state": "init",
+                    "pending_state": "active",
+                    "settings": {
+                      "pg_settings": {}
+                    },
+                    "pooler_enabled": false,
+                    "pooler_mode": "transaction",
+                    "disabled": false,
+                    "passwordless_access": true,
+                    "created_at": "2022-12-03T15:37:07Z",
+                    "updated_at": "2022-12-03T15:37:07Z",
+                    "proxy_host": "us-east-2.aws.neon.tech",
+                    "creation_source": "console",
+                    "suspend_timeout_seconds": 10800,
+                    "provisioner": "k8s-pod"
+                  },
+                  "operations": [
+                    {
+                      "id": "874f8bfe-f51d-4c61-85af-a29bea73e0e2",
+                      "project_id": "bitter-meadow-966132",
+                      "branch_id": "br-proud-paper-090813",
+                      "endpoint_id": "ep-shrill-thunder-454069",
+                      "action": "start_compute",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-03T15:37:07Z",
+                      "updated_at": "2022-12-03T15:37:07Z",
+                      "total_duration_ms": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "get": {
+        "summary": "Get a list of compute endpoints",
+        "description": "Retrieves a list of compute endpoints for the specified project.\nA compute endpoint is a Neon compute instance.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nFor information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
+        "tags": [
+          "Endpoint"
+        ],
+        "operationId": "listProjectEndpoints",
+        "responses": {
+          "200": {
+            "description": "Returned a list of endpoints for the specified project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointsResponse"
+                },
+                "example": {
+                  "endpoints": [
+                    {
+                      "host": "ep-little-smoke-851426.us-east-2.aws.neon.tech",
+                      "creation_source": "console",
+                      "suspend_timeout_seconds": 10800,
+                      "provisioner": "k8s-pod",
+                      "id": "ep-little-smoke-851426",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-aged-salad-637688",
+                      "autoscaling_limit_min_cu": 1,
+                      "autoscaling_limit_max_cu": 1,
+                      "region_id": "aws-us-east-2",
+                      "type": "read_write",
+                      "current_state": "idle",
+                      "settings": {
+                        "pg_settings": {}
+                      },
+                      "pooler_enabled": false,
+                      "pooler_mode": "transaction",
+                      "disabled": false,
+                      "passwordless_access": true,
+                      "last_active": "2022-11-23T17:00:00Z",
+                      "created_at": "2022-11-23T17:42:25Z",
+                      "updated_at": "2022-11-30T18:25:21Z",
+                      "proxy_host": "us-east-2.aws.neon.tech"
+                    },
+                    {
+                      "host": "ep-steep-bush-777093.us-east-2.aws.neon.tech",
+                      "creation_source": "console",
+                      "suspend_timeout_seconds": 10800,
+                      "provisioner": "k8s-pod",
+                      "id": "ep-steep-bush-777093",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-raspy-hill-832856",
+                      "autoscaling_limit_min_cu": 1,
+                      "autoscaling_limit_max_cu": 1,
+                      "region_id": "aws-us-east-2",
+                      "type": "read_write",
+                      "current_state": "idle",
+                      "settings": {
+                        "pg_settings": {}
+                      },
+                      "pooler_enabled": false,
+                      "pooler_mode": "transaction",
+                      "disabled": false,
+                      "passwordless_access": true,
+                      "last_active": "2022-11-30T17:00:00Z",
+                      "created_at": "2022-11-30T17:36:57Z",
+                      "updated_at": "2022-11-30T18:42:58Z",
+                      "proxy_host": "us-east-2.aws.neon.tech"
+                    },
+                    {
+                      "host": "ep-soft-violet-752733.us-east-2.aws.neon.tech",
+                      "creation_source": "console",
+                      "suspend_timeout_seconds": 10800,
+                      "provisioner": "k8s-pod",
+                      "id": "ep-soft-violet-752733",
+                      "project_id": "shiny-wind-028834",
+                      "branch_id": "br-sweet-breeze-497520",
+                      "autoscaling_limit_min_cu": 1,
+                      "autoscaling_limit_max_cu": 1,
+                      "region_id": "aws-us-east-2",
+                      "type": "read_write",
+                      "current_state": "idle",
+                      "settings": {
+                        "pg_settings": {}
+                      },
+                      "pooler_enabled": false,
+                      "pooler_mode": "transaction",
+                      "disabled": false,
+                      "passwordless_access": true,
+                      "last_active": "2022-11-30T19:00:00Z",
+                      "created_at": "2022-11-30T19:09:48Z",
+                      "updated_at": "2022-11-30T19:14:51Z",
+                      "proxy_host": "us-east-2.aws.neon.tech"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/endpoints/{endpoint_id}": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "endpoint_id",
+          "in": "path",
+          "description": "The endpoint ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get a compute endpoint",
+        "description": "Retrieves information about the specified compute endpoint.\nA compute endpoint is a Neon compute instance.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's compute endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
+        "tags": [
+          "Endpoint"
+        ],
+        "operationId": "getProjectEndpoint",
+        "responses": {
+          "200": {
+            "description": "Returned information about the specified endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointResponse"
+                },
+                "example": {
+                  "endpoint": {
+                    "host": "ep-little-smoke-851426.us-east-2.aws.neon.tech",
+                    "id": "ep-little-smoke-851426",
+                    "project_id": "shiny-wind-028834",
+                    "branch_id": "br-aged-salad-637688",
+                    "autoscaling_limit_min_cu": 1,
+                    "autoscaling_limit_max_cu": 1,
+                    "region_id": "aws-us-east-2",
+                    "type": "read_write",
+                    "current_state": "idle",
+                    "settings": {
+                      "pg_settings": {}
+                    },
+                    "pooler_enabled": false,
+                    "pooler_mode": "transaction",
+                    "disabled": false,
+                    "passwordless_access": true,
+                    "last_active": "2022-11-23T17:00:00Z",
+                    "created_at": "2022-11-23T17:42:25Z",
+                    "updated_at": "2022-11-30T18:25:21Z",
+                    "proxy_host": "us-east-2.aws.neon.tech",
+                    "creation_source": "console",
+                    "provisioner": "k8s-pod",
+                    "suspend_timeout_seconds": 10800
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a compute endpoint",
+        "description": "Delete the specified compute endpoint.\nA compute endpoint is a Neon compute instance.\nDeleting a compute endpoint drops existing network connections to the compute endpoint.\nThe deletion is completed when last operation in the chain finishes successfully.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's compute endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
+        "tags": [
+          "Endpoint"
+        ],
+        "operationId": "deleteProjectEndpoint",
+        "responses": {
+          "200": {
+            "description": "Deleted the specified compute endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointOperations"
+                },
+                "example": {
+                  "endpoint": {
+                    "host": "ep-steep-bush-777093.us-east-2.aws.neon.tech",
+                    "id": "ep-steep-bush-777093",
+                    "project_id": "shiny-wind-028834",
+                    "branch_id": "br-raspy-hill-832856",
+                    "autoscaling_limit_min_cu": 1,
+                    "autoscaling_limit_max_cu": 1,
+                    "region_id": "aws-us-east-2",
+                    "type": "read_write",
+                    "current_state": "idle",
+                    "settings": {
+                      "pg_settings": {}
+                    },
+                    "pooler_enabled": false,
+                    "pooler_mode": "transaction",
+                    "disabled": false,
+                    "passwordless_access": true,
+                    "last_active": "2022-12-03T15:00:00Z",
+                    "created_at": "2022-12-03T15:37:07Z",
+                    "updated_at": "2022-12-03T15:49:10Z",
+                    "proxy_host": "us-east-2.aws.neon.tech",
+                    "creation_source": "console",
+                    "provisioner": "k8s-pod",
+                    "suspend_timeout_seconds": 10800
+                  },
+                  "operations": [
+                    {
+                      "id": "fd11748e-3c68-458f-b9e3-66d409e3eef0",
+                      "project_id": "bitter-meadow-966132",
+                      "branch_id": "br-proud-paper-090813",
+                      "endpoint_id": "ep-shrill-thunder-454069",
+                      "action": "suspend_compute",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-03T15:51:06Z",
+                      "updated_at": "2022-12-03T15:51:06Z",
+                      "total_duration_ms": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "Returned if the endpoint doesn't exist or has already been deleted"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Endpoint"
+        ],
+        "summary": "Update a compute endpoint",
+        "description": "Updates the specified compute endpoint.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` and `branch_id` by listing your project's compute endpoints.\nAn `endpoint_id` has an `ep-` prefix. A `branch_id` has a `br-` prefix.\n For more information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n\nIf the returned list of operations is not empty, the compute endpoint is not ready to use.\nThe client must wait for the last operation to finish before using the compute endpoint.\nIf the compute endpoint was idle before the update, it becomes active for a short period of time,\nand the control plane suspends it again after the update.\n",
+        "operationId": "updateProjectEndpoint",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EndpointUpdateRequest"
+              },
+              "example": {
+                "endpoint": {
+                  "suspend_timeout_seconds": 300
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated the specified compute endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointOperations"
+                },
+                "example": {
+                  "endpoint": {
+                    "host": "ep-steep-bush-777093.us-east-2.aws.neon.tech",
+                    "id": "ep-steep-bush-777093",
+                    "project_id": "shiny-wind-028834",
+                    "branch_id": "br-raspy-hill-832856",
+                    "autoscaling_limit_min_cu": 1,
+                    "autoscaling_limit_max_cu": 1,
+                    "region_id": "aws-us-east-2",
+                    "type": "read_write",
+                    "current_state": "idle",
+                    "settings": {
+                      "pg_settings": {}
+                    },
+                    "pooler_enabled": false,
+                    "pooler_mode": "transaction",
+                    "disabled": false,
+                    "passwordless_access": true,
+                    "last_active": "2022-12-03T15:00:00Z",
+                    "created_at": "2022-12-03T15:37:07Z",
+                    "updated_at": "2022-12-03T15:49:10Z",
+                    "proxy_host": "us-east-2.aws.neon.tech",
+                    "creation_source": "console",
+                    "provisioner": "k8s-pod",
+                    "suspend_timeout_seconds": 10800
+                  },
+                  "operations": [
+                    {
+                      "id": "3fc98ab8-f191-47b8-a427-5eb668ccc5b9",
+                      "project_id": "bitter-meadow-966132",
+                      "branch_id": "br-proud-paper-090813",
+                      "endpoint_id": "ep-shrill-thunder-454069",
+                      "action": "apply_config",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-03T15:51:06Z",
+                      "updated_at": "2022-12-03T15:51:06Z",
+                      "total_duration_ms": 100
+                    },
+                    {
+                      "id": "9ffda74b-a582-4cff-b0f0-aaa8d14b8e6a",
+                      "project_id": "bitter-meadow-966132",
+                      "branch_id": "br-proud-paper-090813",
+                      "endpoint_id": "ep-shrill-thunder-454069",
+                      "action": "suspend_compute",
+                      "status": "scheduling",
+                      "failures_count": 0,
+                      "created_at": "2022-12-03T15:51:06Z",
+                      "updated_at": "2022-12-03T15:51:06Z",
+                      "total_duration_ms": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/endpoints/{endpoint_id}/start": {
+      "post": {
+        "summary": "Start a compute endpoint",
+        "description": "Starts a compute endpoint. The compute endpoint is ready to use\nafter the last operation in chain finishes successfully.\n\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's compute endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
+        "tags": [
+          "Endpoint"
+        ],
+        "operationId": "startProjectEndpoint",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "The Neon project ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          },
+          {
+            "name": "endpoint_id",
+            "in": "path",
+            "description": "The endpoint ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Started the specified compute endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointOperations"
+                },
+                "example": {
+                  "endpoint": {
+                    "host": "ep-steep-bush-777093.us-east-2.aws.neon.tech",
+                    "id": "ep-steep-bush-777093",
+                    "project_id": "shiny-wind-028834",
+                    "branch_id": "br-raspy-hill-832856",
+                    "autoscaling_limit_min_cu": 1,
+                    "autoscaling_limit_max_cu": 1,
+                    "region_id": "aws-us-east-2",
+                    "type": "read_write",
+                    "current_state": "idle",
+                    "settings": {
+                      "pg_settings": {}
+                    },
+                    "pooler_enabled": false,
+                    "pooler_mode": "transaction",
+                    "disabled": false,
+                    "passwordless_access": true,
+                    "last_active": "2022-12-03T15:00:00Z",
+                    "created_at": "2022-12-03T15:37:07Z",
+                    "updated_at": "2022-12-03T15:49:10Z",
+                    "proxy_host": "us-east-2.aws.neon.tech",
+                    "creation_source": "console",
+                    "provisioner": "k8s-pod",
+                    "suspend_timeout_seconds": 10800
+                  },
+                  "operations": [
+                    {
+                      "id": "e061087e-3c99-4856-b9c8-6b7751a253af",
+                      "project_id": "bitter-meadow-966132",
+                      "branch_id": "br-proud-paper-090813",
+                      "endpoint_id": "ep-shrill-thunder-454069",
+                      "action": "start_compute",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-03T15:51:06Z",
+                      "updated_at": "2022-12-03T15:51:06Z",
+                      "total_duration_ms": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/endpoints/{endpoint_id}/suspend": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "endpoint_id",
+          "in": "path",
+          "description": "The endpoint ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Suspend a compute endpoint",
+        "description": "Suspend the specified compute endpoint\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's compute endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
+        "tags": [
+          "Endpoint"
+        ],
+        "operationId": "suspendProjectEndpoint",
+        "responses": {
+          "200": {
+            "description": "Suspended the specified endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointOperations"
+                },
+                "example": {
+                  "endpoint": {
+                    "host": "ep-steep-bush-777093.us-east-2.aws.neon.tech",
+                    "id": "ep-steep-bush-777093",
+                    "project_id": "shiny-wind-028834",
+                    "branch_id": "br-raspy-hill-832856",
+                    "autoscaling_limit_min_cu": 1,
+                    "autoscaling_limit_max_cu": 1,
+                    "region_id": "aws-us-east-2",
+                    "type": "read_write",
+                    "current_state": "idle",
+                    "settings": {
+                      "pg_settings": {}
+                    },
+                    "pooler_enabled": false,
+                    "pooler_mode": "transaction",
+                    "disabled": false,
+                    "passwordless_access": true,
+                    "last_active": "2022-12-03T15:00:00Z",
+                    "created_at": "2022-12-03T15:37:07Z",
+                    "updated_at": "2022-12-03T15:49:10Z",
+                    "proxy_host": "us-east-2.aws.neon.tech",
+                    "creation_source": "console",
+                    "provisioner": "k8s-pod",
+                    "suspend_timeout_seconds": 10800
+                  },
+                  "operations": [
+                    {
+                      "id": "e061087e-3c99-4856-b9c8-6b7751a253af",
+                      "project_id": "bitter-meadow-966132",
+                      "branch_id": "br-proud-paper-090813",
+                      "endpoint_id": "ep-shrill-thunder-454069",
+                      "action": "suspend_compute",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-03T15:51:06Z",
+                      "updated_at": "2022-12-03T15:51:06Z",
+                      "total_duration_ms": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/projects/{project_id}/endpoints/{endpoint_id}/restart": {
+      "parameters": [
+        {
+          "name": "project_id",
+          "in": "path",
+          "description": "The Neon project ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "endpoint_id",
+          "in": "path",
+          "description": "The endpoint ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Restart a compute endpoint",
+        "description": "Restart the specified compute endpoint: suspend immediately followed by start operations.\nYou can obtain a `project_id` by listing the projects for your Neon account.\nYou can obtain an `endpoint_id` by listing your project's compute endpoints.\nAn `endpoint_id` has an `ep-` prefix.\nFor information about compute endpoints, see [Manage computes](https://neon.tech/docs/manage/endpoints/).\n",
+        "tags": [
+          "Endpoint"
+        ],
+        "operationId": "restartProjectEndpoint",
+        "responses": {
+          "200": {
+            "description": "Restarted endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointOperations"
+                },
+                "example": {
+                  "endpoint": {
+                    "host": "ep-steep-bush-777093.us-east-2.aws.neon.tech",
+                    "id": "ep-steep-bush-777093",
+                    "project_id": "shiny-wind-028834",
+                    "branch_id": "br-raspy-hill-832856",
+                    "autoscaling_limit_min_cu": 1,
+                    "autoscaling_limit_max_cu": 1,
+                    "region_id": "aws-us-east-2",
+                    "type": "read_write",
+                    "current_state": "idle",
+                    "settings": {
+                      "pg_settings": {}
+                    },
+                    "pooler_enabled": false,
+                    "pooler_mode": "transaction",
+                    "disabled": false,
+                    "passwordless_access": true,
+                    "last_active": "2022-12-03T15:00:00Z",
+                    "created_at": "2022-12-03T15:37:07Z",
+                    "updated_at": "2022-12-03T15:49:10Z",
+                    "proxy_host": "us-east-2.aws.neon.tech",
+                    "creation_source": "console",
+                    "provisioner": "k8s-pod",
+                    "suspend_timeout_seconds": 10800
+                  },
+                  "operations": [
+                    {
+                      "id": "e061087e-3c99-4856-b9c8-6b7751a253af",
+                      "project_id": "bitter-meadow-966132",
+                      "branch_id": "br-proud-paper-090813",
+                      "endpoint_id": "ep-shrill-thunder-454069",
+                      "action": "suspend_compute",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-03T15:51:06Z",
+                      "updated_at": "2022-12-03T15:51:06Z",
+                      "total_duration_ms": 100
+                    },
+                    {
+                      "id": "e061087e-3c99-4856-b9c8-6b7751a253af",
+                      "project_id": "bitter-meadow-966132",
+                      "branch_id": "br-proud-paper-090813",
+                      "endpoint_id": "ep-shrill-thunder-454069",
+                      "action": "start_compute",
+                      "status": "running",
+                      "failures_count": 0,
+                      "created_at": "2022-12-03T15:51:06Z",
+                      "updated_at": "2022-12-03T15:51:06Z",
+                      "total_duration_ms": 100
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/consumption_history/account": {
+      "get": {
+        "summary": "Get account consumption metrics",
+        "description": "Retrieves consumption metrics for Scale, Business, and Enterprise plan accounts. History begins at the time of upgrade.\n",
+        "tags": [
+          "Consumption"
+        ],
+        "operationId": "getConsumptionHistoryPerAccount",
+        "parameters": [
+          {
+            "name": "from",
+            "description": "Specify the start `date-time` for the consumption period.\nThe `date-time` value is rounded according to the specified `granularity`.\nFor example, `2024-03-15T15:30:00Z` for `daily` granularity will be rounded to `2024-03-15T00:00:00Z`.\nThe specified `date-time` value must respect the specified granularity:\n- For `hourly`, consumption metrics are limited to the last 168 hours.\n- For `daily`, consumption metrics are limited to the last 60 days.\n- For `monthly`, consumption metrics are limited to the past year.\n\nThe consumption history is available starting from `March 1, 2024, at 00:00:00 UTC`.\n",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "required": true
+          },
+          {
+            "name": "to",
+            "description": "Specify the end `date-time` for the consumption period.\nThe `date-time` value is rounded according to the specified granularity.\nFor example, `2024-03-15T15:30:00Z` for `daily` granularity will be rounded to `2024-03-15T00:00:00Z`.\nThe specified `date-time` value must respect the specified granularity:\n- For `hourly`, consumption metrics are limited to the last 168 hours.\n- For `daily`, consumption metrics are limited to the last 60 days.\n- For `monthly`, consumption metrics are limited to the past year.\n",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "required": true
+          },
+          {
+            "name": "granularity",
+            "description": "Specify the granularity of consumption metrics.\nHourly, daily, and monthly metrics are available for the last 168 hours, 60 days,\nand 1 year, respectively.\n",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ConsumptionHistoryGranularity"
+            },
+            "required": true
+          },
+          {
+            "name": "org_id",
+            "description": "Specify the organization for which the consumption metrics should be returned.\nIf this parameter is not provided, the endpoint will return the metrics for the\nauthenticated user's account.\n",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          },
+          {
+            "name": "include_v1_metrics",
+            "description": "Include metrics utilized in previous pricing models.\n- **data_storage_bytes_hour**: The sum of the maximum observed storage values for each hour\n  for each project, which never decreases.\n",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returned consumption metrics for the Neon account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsumptionHistoryPerAccountResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "This endpoint is not available. It is only supported for Scale, Business, and Enterprise plan accounts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Account is not a member of the organization specified by `org_id`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "The specified `date-time` range is outside the boundaries of the specified `granularity`.\nAdjust your `from` and `to` values or select a different `granularity`.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/consumption_history/projects": {
+      "get": {
+        "summary": "Get consumption metrics for each project",
+        "description": "Retrieves consumption metrics for Scale, Business, and Enterprise plan projects. History begins at the time of upgrade.\nIssuing a call to this API does not wake a project's compute endpoint.\n",
+        "tags": [
+          "Consumption"
+        ],
+        "operationId": "getConsumptionHistoryPerProject",
+        "parameters": [
+          {
+            "name": "cursor",
+            "description": "Specify the cursor value from the previous response to get the next batch of projects.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "description": "Specify a value from 1 to 100 to limit number of projects in the response.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 10,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "project_ids",
+            "description": "Specify a list of project IDs to filter the response.\nIf omitted, the response will contain all projects.\nA list of project IDs can be specified as an array of parameter values or as a comma-separated list in a single parameter value.\n- As an array of parameter values: `project_ids=cold-poetry-09157238%20&project_ids=quiet-snow-71788278`\n- As a comma-separated list in a single parameter value: `project_ids=cold-poetry-09157238,quiet-snow-71788278`\n",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "pattern": "^([a-z0-9-]{1,60}(,[a-z0-9-]{1,60}){0,99})?$",
+                "type": "string"
+              },
+              "minItems": 0,
+              "maxItems": 100
+            }
+          },
+          {
+            "name": "from",
+            "description": "Specify the start `date-time` for the consumption period.\nThe `date-time` value is rounded according to the specified `granularity`.\nFor example, `2024-03-15T15:30:00Z` for `daily` granularity will be rounded to `2024-03-15T00:00:00Z`.\nThe specified `date-time` value must respect the specified `granularity`:\n- For `hourly`, consumption metrics are limited to the last 168 hours.\n- For `daily`, consumption metrics are limited to the last 60 days.\n- For `monthly`, consumption metrics are limited to the last year.\n\nThe consumption history is available starting from `March 1, 2024, at 00:00:00 UTC`.\n",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "required": true
+          },
+          {
+            "name": "to",
+            "description": "Specify the end `date-time` for the consumption period.\nThe `date-time` value is rounded according to the specified granularity.\nFor example, `2024-03-15T15:30:00Z` for `daily` granularity will be rounded to `2024-03-15T00:00:00Z`.\nThe specified `date-time` value must respect the specified `granularity`:\n- For `hourly`, consumption metrics are limited to the last 168 hours.\n- For `daily`, consumption metrics are limited to the last 60 days.\n- For `monthly`, consumption metrics are limited to the last year.\n",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "required": true
+          },
+          {
+            "name": "granularity",
+            "description": "Specify the granularity of consumption metrics.\nHourly, daily, and monthly metrics are available for the last 168 hours, 60 days,\nand 1 year, respectively.\n",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ConsumptionHistoryGranularity"
+            },
+            "required": true
+          },
+          {
+            "name": "org_id",
+            "description": "Specify the organization for which the project consumption metrics should be returned.\nIf this parameter is not provided, the endpoint will return the metrics for the\nauthenticated user's projects.\n",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          },
+          {
+            "name": "include_v1_metrics",
+            "description": "Include metrics utilized in previous pricing models.\n- **data_storage_bytes_hour**: The sum of the maximum observed storage values for each hour,\n  which never decreases.\n",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returned project consumption metrics for the Neon account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ConsumptionHistoryPerProjectResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PaginationResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "This endpoint is not available. It is only supported with Scale, Business, and Enterprise plan accounts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Account is not a member of the organization specified by `org_id`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "The specified `date-time` range is outside the boundaries of the specified `granularity`.\nAdjust your `from` and `to` values or select a different `granularity`.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/organizations/{org_id}": {
+      "parameters": [
+        {
+          "name": "org_id",
+          "in": "path",
+          "description": "The Neon organization ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get organization details",
+        "description": "Retrieves information about the specified organization.\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "getOrganization",
+        "responses": {
+          "200": {
+            "description": "Returned information about the organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                },
+                "example": {
+                  "id": "my-organization-morning-bread-81040908",
+                  "name": "my-organization",
+                  "handle": "my-organization-my-organization-morning-bread-81040908",
+                  "plan": "scale",
+                  "managed_by": "console",
+                  "created_at": "2024-02-23T17:42:25Z",
+                  "updated_at": "2024-02-26T20:41:25Z"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/organizations/{org_id}/api_keys": {
+      "parameters": [
+        {
+          "name": "org_id",
+          "in": "path",
+          "description": "The Neon organization ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get a list of organization API keys",
+        "description": "Retrieves the API keys for the specified organization.\nThe response does not include API key tokens. A token is only provided when creating an API key.\nAPI keys can also be managed in the Neon Console.\nFor more information, see [Manage API keys](https://neon.tech/docs/manage/api-keys/).\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "listOrgApiKeys",
+        "responses": {
+          "200": {
+            "description": "Returned the API keys for the specified organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OrgApiKeysListResponseItem"
+                  },
+                  "example": [
+                    {
+                      "id": 165432,
+                      "name": "orgkey_1",
+                      "created_at": "2022-11-15T20:13:35Z",
+                      "created_by": {
+                        "id": "629982cc-de05-43db-ae16-28f2399c4910",
+                        "name": "John Smith",
+                        "image": "http://link.to.image"
+                      },
+                      "last_used_at": "2022-11-15T20:22:51Z",
+                      "last_used_from_addr": "192.0.2.255"
+                    },
+                    {
+                      "id": 165433,
+                      "name": "orgkey_2",
+                      "created_at": "2022-11-15T20:12:36Z",
+                      "created_by": {
+                        "id": "629982cc-de05-43db-ae16-28f2399c4910",
+                        "name": "John Smith",
+                        "image": "http://link.to.image"
+                      },
+                      "last_used_at": "2022-11-15T20:15:04Z",
+                      "last_used_from_addr": "192.0.2.255"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create an organization API key",
+        "description": "Creates an API key for the specified organization.\nThe `key_name` is a user-specified name for the key.\nThis method returns an `id` and `key`. The `key` is a randomly generated, 64-bit token required to access the Neon API.\nAPI keys can also be managed in the Neon Console.\nSee [Manage API keys](https://neon.tech/docs/manage/api-keys/).\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "createOrgApiKey",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrgApiKeyCreateRequest"
+              },
+              "example": {
+                "key_name": "orgkey"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Created an organization API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgApiKeyCreateResponse"
+                },
+                "example": {
+                  "id": 165434,
+                  "key": "9v1faketcjbl4sn1013keyd43n2a8qlfakeog8yvp40hx16keyjo1bpds4y2dfms3",
+                  "name": "orgkey",
+                  "created_at": "2022-11-15T20:13:35Z",
+                  "created_by": "629982cc-de05-43db-ae16-28f2399c4910"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/organizations/{org_id}/api_keys/{key_id}": {
+      "parameters": [
+        {
+          "name": "org_id",
+          "in": "path",
+          "description": "The Neon organization ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "delete": {
+        "summary": "Revoke an organization API key",
+        "description": "Revokes the specified organization API key.\nAn API key that is no longer needed can be revoked.\nThis action cannot be reversed.\nYou can obtain `key_id` values by listing the API keys for an organization.\nAPI keys can also be managed in the Neon Console.\nSee [Manage API keys](https://neon.tech/docs/manage/api-keys/).\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "revokeOrgApiKey",
+        "parameters": [
+          {
+            "name": "key_id",
+            "in": "path",
+            "description": "The API key ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Revoked the specified organization API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgApiKeyRevokeResponse"
+                },
+                "example": {
+                  "id": 165435,
+                  "name": "orgkey",
+                  "created_at": "2022-11-15T20:13:35Z",
+                  "created_by": "629982cc-de05-43db-ae16-28f2399c4910",
+                  "last_used_at": "2022-11-15T20:15:04Z",
+                  "last_used_from_addr": "192.0.2.255",
+                  "revoked": true
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/organizations/{org_id}/members": {
+      "parameters": [
+        {
+          "name": "org_id",
+          "in": "path",
+          "description": "The Neon organization ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get organization members details",
+        "description": "Retrieves information about the specified organization members.\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "getOrganizationMembers",
+        "responses": {
+          "200": {
+            "description": "Returned information about organization members",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationMembersResponse"
+                },
+                "example": {
+                  "members": [
+                    {
+                      "member": {
+                        "id": "d57833f2-d308-4ede-9d2e-468d9d013d1b",
+                        "user_id": "b107d689-6dd2-4c9a-8b9e-0b25e457cf56",
+                        "org_id": "my-organization-morning-bread-81040908",
+                        "role": "admin",
+                        "joined_at": "2024-02-23T17:42:25Z"
+                      },
+                      "user": {
+                        "email": "user1@email.com"
+                      }
+                    },
+                    {
+                      "member": {
+                        "id": "5fee13ac-957b-40cd-8de0-4d494cc28e28",
+                        "user_id": "6df052ac-ca9a-4321-8963-b6507b2d7dee",
+                        "org_id": "my-organization-morning-bread-81040908",
+                        "role": "member",
+                        "joined_at": "2024-02-21T16:42:25Z"
+                      },
+                      "user": {
+                        "email": "user2@email.com"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/organizations/{org_id}/members/{member_id}": {
+      "parameters": [
+        {
+          "name": "org_id",
+          "in": "path",
+          "description": "The Neon organization ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "member_id",
+          "in": "path",
+          "description": "The Neon organization member ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get organization member details",
+        "description": "Retrieves information about the specified organization member.\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "getOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "Returned information about the organization member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Member"
+                },
+                "example": {
+                  "id": "d57833f2-d308-4ede-9d2e-468d9d013d1b",
+                  "user_id": "b107d689-6dd2-4c9a-8b9e-0b25e457cf56",
+                  "org_id": "my-organization-morning-bread-81040908",
+                  "role": "admin",
+                  "joined_at": "2024-02-23T17:42:25Z"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update the role for an organization member",
+        "description": "Only an admin can perform this action.\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "updateOrganizationMember",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationMemberUpdateRequest"
+              },
+              "example": {
+                "role": "admin"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated organization member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Member"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove member from the organization",
+        "description": "Remove member from the organization.\nOnly an admin of the organization can perform this action.\nIf another admin is being removed, it will not be allows in case it is the only admin left in the organization.\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "removeOrganizationMember",
+        "responses": {
+          "200": {
+            "description": "Removed organization member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/organizations/{org_id}/invitations": {
+      "parameters": [
+        {
+          "name": "org_id",
+          "in": "path",
+          "description": "The Neon organization ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get organization invitation details",
+        "description": "Retrieves information about extended invitations for the specified organization\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "getOrganizationInvitations",
+        "responses": {
+          "200": {
+            "description": "Returned information about the organization invitations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationInvitationsResponse"
+                },
+                "example": {
+                  "invitations": [
+                    {
+                      "id": "db8faf32-b07f-4b0f-94c8-5c288909f5d3",
+                      "email": "invited1@email.com",
+                      "org_id": "my-organization-morning-bread-81040908",
+                      "invited_by": "some@email.com",
+                      "role": "admin",
+                      "invited_at": "2024-02-23T17:42:25Z"
+                    },
+                    {
+                      "id": "c52f0d22-ebd9-4708-ae44-2872cae49a83",
+                      "email": "invited2@email.com",
+                      "org_id": "my-organization-morning-bread-81040908",
+                      "invited_by": "some@email.com",
+                      "role": "member",
+                      "invited_at": "2024-02-23T12:42:25Z"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create organization invitations",
+        "description": "Creates invitations for a specific organization.\nIf the invited user has an existing account, they automatically join as a member.\nIf they don't yet have an account, they are invited to create one, after which they become a member.\nEach invited user receives an email notification.\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "createOrganizationInvitations",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationInvitesCreateRequest"
+              },
+              "example": {
+                "invitations": [
+                  {
+                    "email": "invited-user@email.com",
+                    "role": "member"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The created organization invitation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationInvitationsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/organizations/{org_id}/projects/transfer": {
+      "parameters": [
+        {
+          "name": "org_id",
+          "in": "path",
+          "description": "The Neon organization ID (destination org, where projects will be moved to)",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Transfer projects from organization to a specified destination organization",
+        "description": "Transfers selected projects, identified by their IDs, from your organization to another specified organization.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransferProjectsToOrganizationRequest"
+              }
+            }
+          }
+        },
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "transferProjectsFromOrgToOrg",
+        "responses": {
+          "200": {
+            "description": "Projects successfully transferred from organization to organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Transfer failed - the target organization has too many projects or its plan is incompatible with the source organization. Reduce projects or upgrade the organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LimitsUnsatisfiedResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "One or more of the provided project IDs have GitHub or Vercel integrations installed. Transferring integration projects is currently not supported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectsWithIntegrationResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/organizations/{org_id}/vpc/region/{region_id}/vpc_endpoints": {
+      "parameters": [
+        {
+          "name": "org_id",
+          "in": "path",
+          "description": "The Neon organization ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "region_id",
+          "in": "path",
+          "description": "The Neon region ID",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get the list of VPC endpoints",
+        "description": "Retrieves the list of VPC endpoints for the specified organization.\nThis endpoint is under active development and its semantics may change in the future.\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "listOrganizationVPCEndpoints",
+        "responses": {
+          "200": {
+            "description": "The list of configured VPC endpoint IDs for the specified organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VPCEndpointsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/organizations/{org_id}/vpc/region/{region_id}/vpc_endpoints/{vpc_endpoint_id}": {
+      "parameters": [
+        {
+          "name": "org_id",
+          "in": "path",
+          "description": "The Neon organization ID",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        {
+          "name": "region_id",
+          "in": "path",
+          "description": "The Neon region ID.\nNote that Azure regions are not yet supported.\n",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "vpc_endpoint_id",
+          "in": "path",
+          "description": "The VPC endpoint ID",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Retrieve the state of a VPC endpoint configuration",
+        "description": "Retrieves detailed information about the VPC endpoint.\nThis endpoint is under active development and its semantics may change in the future.\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "getOrganizationVPCEndpointDetails",
+        "responses": {
+          "200": {
+            "description": "The detailed state of the VPC endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VPCEndpointDetails"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "post": {
+        "summary": "Assign or update a VPC endpoint",
+        "description": "Assigns the specified VPC endpoint to the specified organization\nor updates the existing assignment.\nThis endpoint is under active development and its semantics may change in the future.\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "assignOrganizationVPCEndpoint",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VPCEndpointAssignment"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Assigned the specified VPC endpoint to the specified organization"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a VPC endpoint",
+        "description": "Deletes the specified VPC endpoint from the specified organization.\nThis endpoint is under active development and its semantics may change in the future.\n",
+        "tags": [
+          "Organizations"
+        ],
+        "operationId": "deleteOrganizationVPCEndpoint",
+        "responses": {
+          "200": {
+            "description": "Deleted the specified VPC endpoint from the specified organization"
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/regions": {
+      "get": {
+        "summary": "Get current active regions",
+        "description": "Retrieves the list of supported Neon regions\n",
+        "tags": [
+          "Region"
+        ],
+        "operationId": "getActiveRegions",
+        "responses": {
+          "200": {
+            "description": "The list of active regions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActiveRegionsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/users/me": {
+      "get": {
+        "summary": "Get current user details",
+        "description": "Retrieves information about the current Neon user account.\n",
+        "tags": [
+          "Users"
+        ],
+        "operationId": "getCurrentUserInfo",
+        "responses": {
+          "200": {
+            "description": "Returned information about the current user\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentUserInfoResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/users/me/organizations": {
+      "get": {
+        "summary": "Get current user organizations list",
+        "description": "Retrieves information about the current Neon user's organizations\n",
+        "operationId": "getCurrentUserOrganizations",
+        "tags": [
+          "Users",
+          "Organizations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returned information about the current user organizations\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/users/me/projects/transfer": {
+      "post": {
+        "summary": "Transfer projects from your personal account to a specified destination account",
+        "description": "Transfers selected projects, identified by their IDs, from your personal account to a specified organization.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransferProjectsToOrganizationRequest"
+              }
+            }
+          }
+        },
+        "tags": [
+          "Users"
+        ],
+        "operationId": "transferProjectsFromUserToOrg",
+        "responses": {
+          "200": {
+            "description": "Projects successfully transferred from personal account to organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Transfer failed - the target organization has too many projects or its plan is incompatible with the source account. Reduce the number of projects or upgrade the target organization to increase its capacity.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LimitsUnsatisfiedResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "One or more of the provided project IDs have GitHub or Vercel integrations installed. Transferring integration projects is currently not supported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectsWithIntegrationResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/GeneralError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "ListOperations": {
+        "description": "Returned a list of operations\n",
+        "content": {
+          "application/json": {
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/OperationsResponse"
+                },
+                {
+                  "$ref": "#/components/schemas/PaginationResponse"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "CreatedProject": {
+        "description": "Created a project.\nThe project includes a connection URI with a database, password, and role.\nAt least one non-protected role is created with a password.\nWait until the operations are finished before attempting to connect to a project database.\n",
+        "content": {
+          "application/json": {
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                },
+                {
+                  "$ref": "#/components/schemas/ConnectionURIsResponse"
+                },
+                {
+                  "$ref": "#/components/schemas/RolesResponse"
+                },
+                {
+                  "$ref": "#/components/schemas/DatabasesResponse"
+                },
+                {
+                  "$ref": "#/components/schemas/OperationsResponse"
+                },
+                {
+                  "$ref": "#/components/schemas/BranchResponse"
+                },
+                {
+                  "$ref": "#/components/schemas/EndpointsResponse"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "CreatedBranch": {
+        "description": "Created a branch. An endpoint is only created if it was specified in the request.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BranchResponse"
+                },
+                {
+                  "$ref": "#/components/schemas/EndpointsResponse"
+                },
+                {
+                  "$ref": "#/components/schemas/OperationsResponse"
+                },
+                {
+                  "$ref": "#/components/schemas/RolesResponse"
+                },
+                {
+                  "$ref": "#/components/schemas/DatabasesResponse"
+                },
+                {
+                  "$ref": "#/components/schemas/ConnectionURIsOptionalResponse"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "GeneralError": {
+        "description": "General Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            }
+          }
+        }
+      },
+      "HealthCheck": {
+        "description": "Service is running",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/HealthCheck"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "The Neon API requires an API key to authorize your requests, which you can enter below.\nRefer to our documentation to find out how to generate and use [API keys](https://neon.tech/docs/manage/api-keys).\n"
+      },
+      "CookieAuth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "zenith"
+      },
+      "TokenCookieAuth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "keycloak_token"
+      }
+    },
+    "schemas": {
+      "Features": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "boolean"
+        }
+      },
+      "FeatureFlags": {
+        "type": "object",
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "ComputeUnit": {
+        "type": "number",
+        "minimum": 0.25
+      },
+      "Provisioner": {
+        "type": "string",
+        "description": "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n\nProvisioner can be one of the following values:\n* k8s-pod\n* k8s-neonvm\n\nClients must expect, that any string value that is not documented in the description above should be treated as a error. UNKNOWN value if safe to treat as an error too.\n"
+      },
+      "PaginationResponse": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
+        }
+      },
+      "Pagination": {
+        "description": "Cursor based pagination is used. The user must pass the cursor as is to the backend.\nFor more information about cursor based pagination, see\nhttps://learn.microsoft.com/en-us/ef/core/querying/pagination#keyset-pagination\n",
+        "type": "object",
+        "required": [
+          "cursor",
+          "limit"
+        ],
+        "properties": {
+          "cursor": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "example": {
+          "cursor": "2022-12-07T00:45:05.262011Z"
+        }
+      },
+      "EmptyResponse": {
+        "type": "object",
+        "description": "Empty response.",
+        "properties": {}
+      },
+      "AddProjectJWKSRequest": {
+        "description": "Add a new JWKS to a specific endpoint of a project",
+        "type": "object",
+        "required": [
+          "jwks_url",
+          "provider_name",
+          "role_names"
+        ],
+        "properties": {
+          "jwks_url": {
+            "description": "The URL that lists the JWKS",
+            "type": "string"
+          },
+          "provider_name": {
+            "description": "The name of the authentication provider (e.g., Clerk, Stytch, Auth0)",
+            "type": "string"
+          },
+          "branch_id": {
+            "description": "Branch ID",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "jwt_audience": {
+            "description": "The name of the required JWT Audience to be used",
+            "type": "string"
+          },
+          "role_names": {
+            "description": "The roles the JWKS should be mapped to",
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 10,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "JWKS": {
+        "type": "object",
+        "required": [
+          "id",
+          "project_id",
+          "jwks_url",
+          "provider_name",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "id": {
+            "description": "JWKS ID",
+            "type": "string"
+          },
+          "project_id": {
+            "description": "Project ID",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "branch_id": {
+            "description": "Branch ID",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "jwks_url": {
+            "description": "The URL that lists the JWKS",
+            "type": "string"
+          },
+          "provider_name": {
+            "description": "The name of the authentication provider (e.g., Clerk, Stytch, Auth0)",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "The date and time when the JWKS was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the JWKS was last modified",
+            "type": "string",
+            "format": "date-time"
+          },
+          "jwt_audience": {
+            "description": "The name of the required JWT Audience to be used",
+            "type": "string"
+          }
+        }
+      },
+      "ProjectJWKSResponse": {
+        "description": "The list of configured JWKS definitions for a project",
+        "type": "object",
+        "required": [
+          "jwks"
+        ],
+        "properties": {
+          "jwks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JWKS"
+            }
+          }
+        }
+      },
+      "ApiKeyCreateRequest": {
+        "type": "object",
+        "required": [
+          "key_name"
+        ],
+        "properties": {
+          "key_name": {
+            "type": "string",
+            "description": "A user-specified API key name. This value is required when creating an API key.",
+            "maxLength": 64
+          }
+        }
+      },
+      "OrgApiKeyCreateRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApiKeyCreateRequest"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "project_id": {
+                "description": "If set, the API key can access only this project",
+                "type": "string",
+                "pattern": "^[a-z0-9-]{1,60}$"
+              }
+            }
+          }
+        ]
+      },
+      "ApiKeyCreateResponse": {
+        "type": "object",
+        "required": [
+          "key",
+          "id",
+          "name",
+          "created_at",
+          "created_by"
+        ],
+        "properties": {
+          "id": {
+            "description": "The API key ID",
+            "type": "integer",
+            "format": "int64"
+          },
+          "key": {
+            "description": "The generated 64-bit token required to access the Neon API",
+            "type": "string"
+          },
+          "name": {
+            "description": "The user-specified API key name",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "A timestamp indicating when the API key was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "description": "ID of the user who created this API key",
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "OrgApiKeyCreateResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApiKeyCreateResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "project_id": {
+                "description": "If set, the API key can access only this project",
+                "type": "string",
+                "pattern": "^[a-z0-9-]{1,60}$"
+              }
+            }
+          }
+        ]
+      },
+      "ApiKeyRevokeResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "created_at",
+          "created_by",
+          "last_used_from_addr",
+          "revoked"
+        ],
+        "properties": {
+          "id": {
+            "description": "The API key ID",
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "description": "The user-specified API key name",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "A timestamp indicating when the API key was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "description": "ID of the user who created this API key",
+            "type": "string",
+            "format": "uuid"
+          },
+          "last_used_at": {
+            "description": "A timestamp indicating when the API was last used",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "last_used_from_addr": {
+            "description": "The IP address from which the API key was last used",
+            "type": "string"
+          },
+          "revoked": {
+            "description": "A `true` or `false` value indicating whether the API key is revoked",
+            "type": "boolean"
+          }
+        }
+      },
+      "OrgApiKeyRevokeResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApiKeyRevokeResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "project_id": {
+                "description": "If set, the API key can access only this project",
+                "type": "string",
+                "pattern": "^[a-z0-9-]{1,60}$"
+              }
+            }
+          }
+        ]
+      },
+      "ApiKeysListResponseItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "created_at",
+          "created_by",
+          "last_used_from_addr"
+        ],
+        "properties": {
+          "id": {
+            "description": "The API key ID",
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "description": "The user-specified API key name",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "A timestamp indicating when the API key was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/ApiKeyCreatorData"
+          },
+          "last_used_at": {
+            "description": "A timestamp indicating when the API was last used",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "last_used_from_addr": {
+            "description": "The IP address from which the API key was last used",
+            "type": "string"
+          }
+        }
+      },
+      "OrgApiKeysListResponseItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApiKeysListResponseItem"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "project_id": {
+                "description": "If set, the API key can access only this project",
+                "type": "string",
+                "pattern": "^[a-z0-9-]{1,60}$"
+              }
+            }
+          }
+        ]
+      },
+      "ApiKeyCreatorData": {
+        "description": "The user data of the user that created this API key.",
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "image"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the user who created this API key"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the user."
+          },
+          "image": {
+            "type": "string",
+            "description": "The URL to the user's avatar image."
+          }
+        }
+      },
+      "Operation": {
+        "type": "object",
+        "required": [
+          "id",
+          "project_id",
+          "action",
+          "status",
+          "failures_count",
+          "created_at",
+          "updated_at",
+          "total_duration_ms"
+        ],
+        "properties": {
+          "id": {
+            "description": "The operation ID",
+            "type": "string",
+            "format": "uuid"
+          },
+          "project_id": {
+            "description": "The Neon project ID",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "branch_id": {
+            "description": "The branch ID",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "endpoint_id": {
+            "description": "The endpoint ID",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "action": {
+            "$ref": "#/components/schemas/OperationAction"
+          },
+          "status": {
+            "$ref": "#/components/schemas/OperationStatus"
+          },
+          "error": {
+            "description": "The error that occurred",
+            "type": "string"
+          },
+          "failures_count": {
+            "description": "The number of times the operation failed",
+            "type": "integer",
+            "format": "int32"
+          },
+          "retry_at": {
+            "description": "A timestamp indicating when the operation was last retried",
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_at": {
+            "description": "A timestamp indicating when the operation was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "A timestamp indicating when the operation status was last updated",
+            "type": "string",
+            "format": "date-time"
+          },
+          "total_duration_ms": {
+            "description": "The total duration of the operation in milliseconds",
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "example": [
+          {
+            "id": "a07f8772-1877-4da9-a939-3a3ae62d1d8d",
+            "project_id": "spring-example-302709",
+            "branch_id": "br-wispy-meadow-118737",
+            "endpoint_id": "ep-silent-smoke-806639",
+            "action": "create_branch",
+            "status": "running",
+            "failures_count": 0,
+            "created_at": "2022-11-08T23:33:16Z",
+            "updated_at": "2022-11-08T23:33:20Z",
+            "total_duration_ms": 400
+          },
+          {
+            "id": "d8ac46eb-a757-42b1-9907-f78322ee394e",
+            "project_id": "spring-example-302709",
+            "branch_id": "br-wispy-meadow-118737",
+            "endpoint_id": "ep-silent-smoke-806639",
+            "action": "start_compute",
+            "status": "finished",
+            "failures_count": 0,
+            "created_at": "2022-11-15T20:02:00Z",
+            "updated_at": "2022-11-15T20:02:02Z",
+            "total_duration_ms": 200
+          }
+        ]
+      },
+      "OperationResponse": {
+        "type": "object",
+        "required": [
+          "operation"
+        ],
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/Operation"
+          }
+        }
+      },
+      "OperationsResponse": {
+        "type": "object",
+        "required": [
+          "operations"
+        ],
+        "properties": {
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Operation"
+            }
+          }
+        }
+      },
+      "OperationAction": {
+        "description": "The action performed by the operation",
+        "type": "string",
+        "enum": [
+          "create_compute",
+          "create_timeline",
+          "start_compute",
+          "suspend_compute",
+          "apply_config",
+          "check_availability",
+          "delete_timeline",
+          "create_branch",
+          "import_data",
+          "tenant_ignore",
+          "tenant_attach",
+          "tenant_detach",
+          "tenant_reattach",
+          "replace_safekeeper",
+          "disable_maintenance",
+          "apply_storage_config",
+          "prepare_secondary_pageserver",
+          "switch_pageserver",
+          "detach_parent_branch",
+          "timeline_archive",
+          "timeline_unarchive",
+          "start_reserved_compute",
+          "sync_dbs_and_roles_from_compute",
+          "apply_schema_from_branch"
+        ]
+      },
+      "OperationStatus": {
+        "description": "The status of the operation",
+        "type": "string",
+        "enum": [
+          "scheduling",
+          "running",
+          "finished",
+          "failed",
+          "error",
+          "cancelling",
+          "cancelled",
+          "skipped"
+        ]
+      },
+      "ProjectListItem": {
+        "description": "Essential data about the project. Full data is available at the getProject endpoint.\n",
+        "type": "object",
+        "required": [
+          "active_time",
+          "id",
+          "platform_id",
+          "region_id",
+          "name",
+          "pg_version",
+          "proxy_host",
+          "branch_logical_size_limit",
+          "branch_logical_size_limit_bytes",
+          "provisioner",
+          "store_passwords",
+          "cpu_used_sec",
+          "creation_source",
+          "created_at",
+          "updated_at",
+          "owner_id"
+        ],
+        "properties": {
+          "id": {
+            "description": "The project ID",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "platform_id": {
+            "description": "The cloud platform identifier. Currently, only AWS is supported, for which the identifier is `aws`.\n",
+            "type": "string"
+          },
+          "region_id": {
+            "description": "The region identifier\n",
+            "type": "string"
+          },
+          "name": {
+            "description": "The project name\n",
+            "type": "string"
+          },
+          "provisioner": {
+            "$ref": "#/components/schemas/Provisioner"
+          },
+          "default_endpoint_settings": {
+            "$ref": "#/components/schemas/DefaultEndpointSettings"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/ProjectSettingsData"
+          },
+          "pg_version": {
+            "$ref": "#/components/schemas/PgVersion"
+          },
+          "proxy_host": {
+            "description": "The proxy host for the project. This value combines the `region_id`, the `platform_id`, and the Neon domain (`neon.tech`).\n",
+            "type": "string"
+          },
+          "branch_logical_size_limit": {
+            "description": "The logical size limit for a branch. The value is in MiB.\n",
+            "type": "integer",
+            "format": "int64"
+          },
+          "branch_logical_size_limit_bytes": {
+            "description": "The logical size limit for a branch. The value is in B.\n",
+            "type": "integer",
+            "format": "int64"
+          },
+          "store_passwords": {
+            "description": "Whether or not passwords are stored for roles in the Neon project. Storing passwords facilitates access to Neon features that require authorization.\n",
+            "type": "boolean"
+          },
+          "active_time": {
+            "description": "Control plane observed endpoints of this project being active this amount of wall-clock time.\n",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "cpu_used_sec": {
+            "deprecated": true,
+            "description": "DEPRECATED. Use data from the getProject endpoint instead.\n",
+            "type": "integer",
+            "format": "int64"
+          },
+          "maintenance_starts_at": {
+            "description": "A timestamp indicating when project maintenance begins. If set, the project is placed into maintenance mode at this time.\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "creation_source": {
+            "description": "The project creation source\n",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "A timestamp indicating when the project was created\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "A timestamp indicating when the project was last updated\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "synthetic_storage_size": {
+            "description": "The current space occupied by the project in storage, in bytes. Synthetic storage size combines the logical data size and Write-Ahead Log (WAL) size for all branches in a project.\n",
+            "type": "integer",
+            "format": "int64"
+          },
+          "quota_reset_at": {
+            "deprecated": true,
+            "description": "DEPRECATED. Use `consumption_period_end` from the getProject endpoint instead.\nA timestamp indicating when the project quota resets\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "owner_id": {
+            "type": "string"
+          },
+          "compute_last_active_at": {
+            "description": "The most recent time when any endpoint of this project was active.\n\nOmitted when observed no activity for endpoints of this project.\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "org_id": {
+            "description": "Organization id if a project belongs to organization.\nPermissions for the project will be given to organization members as defined by the organization admins.\nThe permissions of the project do not depend on the user that created the project if a project belongs to an organization.\n",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          }
+        },
+        "example": {
+          "id": "spring-example-302709",
+          "platform_id": "aws",
+          "region_id": "aws-us-east-2",
+          "name": "spring-example-302709",
+          "provisioner": "k8s-pod",
+          "pg_version": 15,
+          "proxy_host": "us-east-2.aws.neon.tech",
+          "store_passwords": true,
+          "creation_source": "console",
+          "created_at": "2022-12-13T01:30:55Z",
+          "updated_at": "2022-12-13T01:30:55Z"
+        }
+      },
+      "Project": {
+        "type": "object",
+        "required": [
+          "consumption_period_end",
+          "consumption_period_start",
+          "active_time_seconds",
+          "compute_time_seconds",
+          "written_data_bytes",
+          "data_transfer_bytes",
+          "data_storage_bytes_hour",
+          "id",
+          "platform_id",
+          "region_id",
+          "name",
+          "pg_version",
+          "proxy_host",
+          "branch_logical_size_limit",
+          "branch_logical_size_limit_bytes",
+          "store_passwords",
+          "cpu_used_sec",
+          "provisioner",
+          "creation_source",
+          "history_retention_seconds",
+          "created_at",
+          "updated_at",
+          "owner_id"
+        ],
+        "properties": {
+          "data_storage_bytes_hour": {
+            "description": "Bytes-Hour. Project consumed that much storage hourly during the billing period. The value has some lag.\nThe value is reset at the beginning of each billing period.\n",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "data_transfer_bytes": {
+            "description": "Bytes. Egress traffic from the Neon cloud to the client for given project over the billing period.\nIncludes deleted endpoints. The value has some lag. The value is reset at the beginning of each billing period.\n",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "written_data_bytes": {
+            "description": "Bytes. Amount of WAL that travelled through storage for given project across all branches.\nThe value has some lag. The value is reset at the beginning of each billing period.\n",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "compute_time_seconds": {
+            "description": "Seconds. The number of CPU seconds used by the project's compute endpoints, including compute endpoints that have been deleted.\nThe value has some lag. The value is reset at the beginning of each billing period.\nExamples:\n1. An endpoint that uses 1 CPU for 1 second is equal to `compute_time=1`.\n2. An endpoint that uses 2 CPUs simultaneously for 1 second is equal to `compute_time=2`.\n",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "active_time_seconds": {
+            "description": "Seconds. Control plane observed endpoints of this project being active this amount of wall-clock time.\nThe value has some lag.\nThe value is reset at the beginning of each billing period.\n",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "cpu_used_sec": {
+            "description": "DEPRECATED, use compute_time instead.\n",
+            "type": "integer",
+            "format": "int64",
+            "deprecated": true
+          },
+          "id": {
+            "description": "The project ID",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "platform_id": {
+            "description": "The cloud platform identifier. Currently, only AWS is supported, for which the identifier is `aws`.\n",
+            "type": "string"
+          },
+          "region_id": {
+            "description": "The region identifier\n",
+            "type": "string"
+          },
+          "name": {
+            "description": "The project name\n",
+            "type": "string"
+          },
+          "provisioner": {
+            "$ref": "#/components/schemas/Provisioner"
+          },
+          "default_endpoint_settings": {
+            "$ref": "#/components/schemas/DefaultEndpointSettings"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/ProjectSettingsData"
+          },
+          "pg_version": {
+            "$ref": "#/components/schemas/PgVersion"
+          },
+          "proxy_host": {
+            "description": "The proxy host for the project. This value combines the `region_id`, the `platform_id`, and the Neon domain (`neon.tech`).\n",
+            "type": "string"
+          },
+          "branch_logical_size_limit": {
+            "description": "The logical size limit for a branch. The value is in MiB.\n",
+            "type": "integer",
+            "format": "int64"
+          },
+          "branch_logical_size_limit_bytes": {
+            "description": "The logical size limit for a branch. The value is in B.\n",
+            "type": "integer",
+            "format": "int64"
+          },
+          "store_passwords": {
+            "description": "Whether or not passwords are stored for roles in the Neon project. Storing passwords facilitates access to Neon features that require authorization.\n",
+            "type": "boolean"
+          },
+          "maintenance_starts_at": {
+            "description": "A timestamp indicating when project maintenance begins. If set, the project is placed into maintenance mode at this time.\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "creation_source": {
+            "description": "The project creation source\n",
+            "type": "string"
+          },
+          "history_retention_seconds": {
+            "description": "The number of seconds to retain the shared history for all branches in this project. The default for all plans is 1 day (86400 seconds).\n",
+            "type": "integer",
+            "format": "int32"
+          },
+          "created_at": {
+            "description": "A timestamp indicating when the project was created\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "A timestamp indicating when the project was last updated\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "synthetic_storage_size": {
+            "description": "The current space occupied by the project in storage, in bytes. Synthetic storage size combines the logical data size and Write-Ahead Log (WAL) size for all branches in a project.\n",
+            "type": "integer",
+            "format": "int64"
+          },
+          "consumption_period_start": {
+            "description": "A date-time indicating when Neon Cloud started measuring consumption for current consumption period.\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "consumption_period_end": {
+            "description": "A date-time indicating when Neon Cloud plans to stop measuring consumption for current consumption period.\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "quota_reset_at": {
+            "deprecated": true,
+            "description": "DEPRECATED. Use `consumption_period_end` from the getProject endpoint instead.\nA timestamp indicating when the project quota resets.\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "owner_id": {
+            "type": "string"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/ProjectOwnerData"
+          },
+          "compute_last_active_at": {
+            "description": "The most recent time when any endpoint of this project was active.\n\nOmitted when observed no activity for endpoints of this project.\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "org_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "maintenance_scheduled_for": {
+            "description": "A timestamp indicating when project update begins. If set, computes might experience a brief restart around this time.\n",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "id": "spring-example-302709",
+          "platform_id": "aws",
+          "region_id": "aws-us-east-2",
+          "name": "spring-example-302709",
+          "provisioner": "k8s-pod",
+          "pg_version": 15,
+          "proxy_host": "us-east-2.aws.neon.tech",
+          "store_passwords": true,
+          "creation_source": "console",
+          "history_retention_seconds": 604800,
+          "created_at": "2022-12-13T01:30:55Z",
+          "updated_at": "2022-12-13T01:30:55Z",
+          "owner": {
+            "name": "John Smith",
+            "email": "some@email.com",
+            "branches_limit": 10,
+            "subscription_type": "scale"
+          },
+          "org_id": "org-morning-bread-81040908"
+        }
+      },
+      "ProjectCreateRequest": {
+        "type": "object",
+        "required": [
+          "project"
+        ],
+        "properties": {
+          "project": {
+            "type": "object",
+            "properties": {
+              "settings": {
+                "$ref": "#/components/schemas/ProjectSettingsData"
+              },
+              "name": {
+                "description": "The project name",
+                "type": "string"
+              },
+              "branch": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "The default branch name. If not specified, the default branch name, `main`, will be used.\n",
+                    "type": "string"
+                  },
+                  "role_name": {
+                    "description": "The role name. If not specified, the default role name, `{database_name}_owner`, will be used.\n",
+                    "type": "string"
+                  },
+                  "database_name": {
+                    "description": "The database name. If not specified, the default database name, `neondb`, will be used.\n",
+                    "type": "string"
+                  }
+                }
+              },
+              "autoscaling_limit_min_cu": {
+                "deprecated": true,
+                "description": "DEPRECATED, use default_endpoint_settings.autoscaling_limit_min_cu instead.\n\nThe minimum number of Compute Units. The minimum value is `0.25`.\nSee [Compute size and Autoscaling configuration](https://neon.tech/docs/manage/endpoints#compute-size-and-autoscaling-configuration)\nfor more information.\n",
+                "$ref": "#/components/schemas/ComputeUnit"
+              },
+              "autoscaling_limit_max_cu": {
+                "deprecated": true,
+                "description": "DEPRECATED, use default_endpoint_settings.autoscaling_limit_max_cu instead.\n\nThe maximum number of Compute Units. See [Compute size and Autoscaling configuration](https://neon.tech/docs/manage/endpoints#compute-size-and-autoscaling-configuration)\nfor more information.\n",
+                "$ref": "#/components/schemas/ComputeUnit"
+              },
+              "provisioner": {
+                "$ref": "#/components/schemas/Provisioner"
+              },
+              "region_id": {
+                "description": "The region identifier. Refer to our [Regions](https://neon.tech/docs/introduction/regions) documentation for supported regions. Values are specified in this format: `aws-us-east-1`\n",
+                "type": "string"
+              },
+              "default_endpoint_settings": {
+                "$ref": "#/components/schemas/DefaultEndpointSettings"
+              },
+              "pg_version": {
+                "$ref": "#/components/schemas/PgVersion"
+              },
+              "store_passwords": {
+                "description": "Whether or not passwords are stored for roles in the Neon project. Storing passwords facilitates access to Neon features that require authorization.\n",
+                "type": "boolean"
+              },
+              "history_retention_seconds": {
+                "description": "The number of seconds to retain the shared history for all branches in this project.\nThe default is 1 day (86400 seconds).\n",
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0,
+                "maximum": 2592000
+              },
+              "org_id": {
+                "description": "Organization id in case the project created belongs to an organization.\nIf not present, project is owned by a user and not by org.\n",
+                "type": "string",
+                "pattern": "^[a-z0-9-]{1,60}$"
+              }
+            }
+          }
+        }
+      },
+      "ProjectUpdateRequest": {
+        "type": "object",
+        "required": [
+          "project"
+        ],
+        "properties": {
+          "project": {
+            "type": "object",
+            "properties": {
+              "settings": {
+                "$ref": "#/components/schemas/ProjectSettingsData"
+              },
+              "name": {
+                "description": "The project name",
+                "type": "string"
+              },
+              "default_endpoint_settings": {
+                "$ref": "#/components/schemas/DefaultEndpointSettings"
+              },
+              "history_retention_seconds": {
+                "description": "The number of seconds to retain the shared history for all branches in this project.\nThe default is 1 day (604800 seconds).\n",
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0,
+                "maximum": 2592000
+              }
+            }
+          }
+        }
+      },
+      "ProjectSettingsData": {
+        "type": "object",
+        "properties": {
+          "quota": {
+            "$ref": "#/components/schemas/ProjectQuota"
+          },
+          "allowed_ips": {
+            "$ref": "#/components/schemas/AllowedIps"
+          },
+          "enable_logical_replication": {
+            "description": "Sets wal_level=logical for all compute endpoints in this project.\nAll active endpoints will be suspended.\nOnce enabled, logical replication cannot be disabled.\n",
+            "type": "boolean"
+          },
+          "maintenance_window": {
+            "$ref": "#/components/schemas/MaintenanceWindow"
+          },
+          "block_public_connections": {
+            "description": "When set, connections from the public internet\nare disallowed. This supersedes the AllowedIPs list.\nThis parameter is under active development and its semantics may change in the future.\n",
+            "type": "boolean"
+          },
+          "block_vpc_connections": {
+            "description": "When set, connections using VPC endpoints are disallowed.\nThis parameter is under active development and its semantics may change in the future.\n",
+            "type": "boolean"
+          }
+        }
+      },
+      "ProjectResponse": {
+        "type": "object",
+        "required": [
+          "project"
+        ],
+        "properties": {
+          "project": {
+            "$ref": "#/components/schemas/Project"
+          }
+        }
+      },
+      "ProjectsResponse": {
+        "type": "object",
+        "required": [
+          "projects"
+        ],
+        "properties": {
+          "projects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectListItem"
+            }
+          },
+          "unavailable_project_ids": {
+            "description": "A list of project IDs indicating which projects are known to exist, but whose details could not\nbe fetched within the requested (or implicit) time limit\n",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            }
+          }
+        }
+      },
+      "ProjectPermission": {
+        "type": "object",
+        "required": [
+          "id",
+          "granted_to_email",
+          "granted_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "granted_to_email": {
+            "type": "string"
+          },
+          "granted_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "revoked_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "ProjectPermissions": {
+        "type": "object",
+        "required": [
+          "project_permissions"
+        ],
+        "properties": {
+          "project_permissions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProjectPermission"
+            }
+          }
+        }
+      },
+      "GrantPermissionToProjectRequest": {
+        "type": "object",
+        "required": [
+          "email"
+        ],
+        "properties": {
+          "email": {
+            "type": "string"
+          }
+        }
+      },
+      "ConsumptionHistoryPerAccountResponse": {
+        "type": "object",
+        "properties": {
+          "periods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConsumptionHistoryPerPeriod"
+            }
+          }
+        },
+        "required": [
+          "periods"
+        ]
+      },
+      "ConsumptionHistoryPerProjectResponse": {
+        "type": "object",
+        "properties": {
+          "projects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConsumptionHistoryPerProject"
+            }
+          }
+        },
+        "required": [
+          "projects"
+        ]
+      },
+      "ConsumptionHistoryPerProject": {
+        "type": "object",
+        "properties": {
+          "project_id": {
+            "description": "The project ID",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "periods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConsumptionHistoryPerPeriod"
+            }
+          }
+        },
+        "required": [
+          "project_id",
+          "periods"
+        ]
+      },
+      "ConsumptionHistoryPerPeriod": {
+        "type": "object",
+        "properties": {
+          "period_id": {
+            "description": "The ID assigned to the specified billing period.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "period_plan": {
+            "description": "The billing plan applicable during the billing period.",
+            "type": "string"
+          },
+          "period_start": {
+            "description": "The start date-time of the billing period.\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "period_end": {
+            "description": "The end date-time of the billing period, available for the past periods only.\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "consumption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConsumptionHistoryPerTimeframe"
+            }
+          }
+        },
+        "required": [
+          "period_id",
+          "period_plan",
+          "period_start",
+          "consumption"
+        ],
+        "example": {
+          "period_id": "79ec829f-1828-4006-ac82-9f1828a0067d",
+          "period_plan": "scale",
+          "period_start": "2024-03-01T00:00:00Z",
+          "consumption": [
+            {
+              "timeframe_start": "2024-03-22T00:00:00Z",
+              "timeframe_end": "2024-03-23T00:00:00Z",
+              "active_time_seconds": 27853,
+              "compute_time_seconds": 18346,
+              "written_data_bytes": 1073741824,
+              "synthetic_storage_size_bytes": 5368709120
+            },
+            {
+              "timeframe_start": "2024-03-23T00:00:00Z",
+              "timeframe_end": "2024-03-24T00:00:00Z",
+              "active_time_seconds": 17498,
+              "compute_time_seconds": 3378,
+              "written_data_bytes": 5741824,
+              "synthetic_storage_size_bytes": 2370912
+            }
+          ]
+        }
+      },
+      "ConsumptionHistoryPerTimeframe": {
+        "type": "object",
+        "properties": {
+          "timeframe_start": {
+            "description": "The specified start date-time for the reported consumption.\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeframe_end": {
+            "description": "The specified end date-time for the reported consumption.\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "active_time_seconds": {
+            "description": "Seconds. The amount of time the compute endpoints have been active.\n",
+            "type": "integer",
+            "format": "uint64"
+          },
+          "compute_time_seconds": {
+            "description": "Seconds. The number of CPU seconds used by compute endpoints, including compute endpoints that have been deleted.\n",
+            "type": "integer",
+            "format": "uint64"
+          },
+          "written_data_bytes": {
+            "description": "Bytes. The amount of written data for all branches.\n",
+            "type": "integer",
+            "format": "uint64"
+          },
+          "synthetic_storage_size_bytes": {
+            "description": "Bytes. The space occupied in storage. Synthetic storage size combines the logical data size and Write-Ahead Log (WAL) size for all branches.\n",
+            "type": "integer",
+            "format": "uint64"
+          },
+          "data_storage_bytes_hour": {
+            "description": "Bytes-Hour. The amount of storage consumed hourly.\n",
+            "type": "integer",
+            "format": "uint64"
+          }
+        },
+        "required": [
+          "timeframe_start",
+          "timeframe_end",
+          "active_time_seconds",
+          "compute_time_seconds",
+          "written_data_bytes",
+          "synthetic_storage_size_bytes"
+        ]
+      },
+      "ConsumptionHistoryGranularity": {
+        "type": "string",
+        "enum": [
+          "hourly",
+          "daily",
+          "monthly"
+        ]
+      },
+      "ProjectLimits": {
+        "type": "object",
+        "required": [
+          "limits",
+          "features"
+        ],
+        "properties": {
+          "limits": {
+            "$ref": "#/components/schemas/Limits"
+          },
+          "features": {
+            "$ref": "#/components/schemas/Features"
+          }
+        }
+      },
+      "Limits": {
+        "type": "object",
+        "required": [
+          "active_time",
+          "max_projects",
+          "max_branches",
+          "max_protected_branches",
+          "max_autoscaling_cu",
+          "max_fixed_size_cu",
+          "cpu_seconds",
+          "max_compute_time_non_primary",
+          "max_active_endpoints",
+          "max_read_only_endpoints",
+          "max_allowed_ips",
+          "max_vpc_endpoints_per_region",
+          "max_monitoring_retention_hours",
+          "max_history_retention_seconds",
+          "min_autosuspend_seconds",
+          "max_data_transfer",
+          "min_idle_seconds_to_autoarchive",
+          "min_age_seconds_to_autoarchive",
+          "max_branch_roles",
+          "max_branch_databases",
+          "max_concurrent_scheduled_operation_chains_per_project",
+          "max_concurrent_executing_operation_chains_per_project",
+          "max_root_branches"
+        ],
+        "properties": {
+          "active_time": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "max_projects": {
+            "type": "integer"
+          },
+          "max_branches": {
+            "type": "integer"
+          },
+          "max_protected_branches": {
+            "type": "integer"
+          },
+          "max_autoscaling_cu": {
+            "type": "number",
+            "format": "float64"
+          },
+          "max_fixed_size_cu": {
+            "type": "number",
+            "format": "float64"
+          },
+          "cpu_seconds": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "max_compute_time_non_primary": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "max_active_endpoints": {
+            "type": "integer"
+          },
+          "max_read_only_endpoints": {
+            "type": "integer"
+          },
+          "max_allowed_ips": {
+            "type": "integer"
+          },
+          "max_vpc_endpoints_per_region": {
+            "type": "integer"
+          },
+          "max_monitoring_retention_hours": {
+            "type": "integer"
+          },
+          "max_history_retention_seconds": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "min_autosuspend_seconds": {
+            "type": "integer"
+          },
+          "max_data_transfer": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "min_idle_seconds_to_autoarchive": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "min_age_seconds_to_autoarchive": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "max_branch_roles": {
+            "type": "integer"
+          },
+          "max_branch_databases": {
+            "type": "integer"
+          },
+          "max_concurrent_scheduled_operation_chains_per_project": {
+            "type": "integer"
+          },
+          "max_concurrent_executing_operation_chains_per_project": {
+            "type": "integer"
+          },
+          "max_root_branches": {
+            "type": "integer"
+          }
+        }
+      },
+      "Branch": {
+        "type": "object",
+        "required": [
+          "id",
+          "project_id",
+          "name",
+          "current_state",
+          "state_changed_at",
+          "creation_source",
+          "created_at",
+          "updated_at",
+          "default",
+          "protected",
+          "cpu_used_sec",
+          "active_time_seconds",
+          "compute_time_seconds",
+          "written_data_bytes",
+          "data_transfer_bytes"
+        ],
+        "properties": {
+          "id": {
+            "description": "The branch ID. This value is generated when a branch is created. A `branch_id` value has a `br` prefix. For example: `br-small-term-683261`.\n",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "project_id": {
+            "description": "The ID of the project to which the branch belongs\n",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "parent_id": {
+            "description": "The `branch_id` of the parent branch\n",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "parent_lsn": {
+            "description": "The Log Sequence Number (LSN) on the parent branch from which this branch was created\n",
+            "type": "string"
+          },
+          "parent_timestamp": {
+            "description": "The point in time on the parent branch from which this branch was created\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "description": "The branch name\n",
+            "type": "string"
+          },
+          "current_state": {
+            "$ref": "#/components/schemas/BranchState"
+          },
+          "pending_state": {
+            "$ref": "#/components/schemas/BranchState"
+          },
+          "state_changed_at": {
+            "description": "A UTC timestamp indicating when the `current_state` began\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "logical_size": {
+            "description": "The logical size of the branch, in bytes\n",
+            "type": "integer",
+            "format": "int64"
+          },
+          "creation_source": {
+            "description": "The branch creation source\n",
+            "type": "string"
+          },
+          "primary": {
+            "deprecated": true,
+            "description": "DEPRECATED. Use `default` field.\nWhether the branch is the project's primary branch\n",
+            "type": "boolean"
+          },
+          "default": {
+            "description": "Whether the branch is the project's default branch\n",
+            "type": "boolean"
+          },
+          "protected": {
+            "description": "Whether the branch is protected\n",
+            "type": "boolean"
+          },
+          "cpu_used_sec": {
+            "deprecated": true,
+            "description": "CPU seconds used by all of the branch's compute endpoints, including deleted ones.\nThis value is reset at the beginning of each billing period.\nExamples:\n1. A branch that uses 1 CPU for 1 second is equal to `cpu_used_sec=1`.\n2. A branch that uses 2 CPUs simultaneously for 1 second is equal to `cpu_used_sec=2`.\n",
+            "type": "integer",
+            "format": "int64"
+          },
+          "compute_time_seconds": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "active_time_seconds": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "written_data_bytes": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "data_transfer_bytes": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "created_at": {
+            "description": "A timestamp indicating when the branch was created\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "A timestamp indicating when the branch was last updated\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_reset_at": {
+            "description": "A timestamp indicating when the branch was last reset\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "description": "The resolved user model that contains details of the user/org/integration/api_key used for branch creation. This field is filled only in listing/get/create/get/update/delete methods, if it is empty when calling other handlers, it does not mean that it is empty in the system.\n",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the user."
+              },
+              "image": {
+                "type": "string",
+                "description": "The URL to the user's avatar image."
+              }
+            }
+          }
+        },
+        "example": {
+          "id": "br-wispy-meadow-118737",
+          "project_id": "spring-example-302709",
+          "parent_id": "br-aged-salad-637688",
+          "parent_lsn": "0/1DE2850",
+          "name": "dev2",
+          "protected": false,
+          "current_state": "ready",
+          "state_changed_at": "2022-11-30T20:09:48Z",
+          "creation_source": "console",
+          "created_at": "2022-11-30T19:09:48Z",
+          "updated_at": "2022-12-01T19:53:05Z",
+          "default": true
+        }
+      },
+      "BranchState": {
+        "description": "The branch\u2019s state, indicating if it is initializing, ready for use, or archived.\n  * 'init' - the branch is being created but is not available for querying.\n  * 'ready' - the branch is fully operational and ready for querying. Expect normal query response times.\n  * 'archived' - the branch is stored in cost-effective archival storage. Expect slow query response times.\n",
+        "type": "string"
+      },
+      "BranchCreateRequestEndpointOptions": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/EndpointType"
+          },
+          "autoscaling_limit_min_cu": {
+            "description": "The minimum number of Compute Units. The minimum value is `0.25`.\n    See [Compute size and Autoscaling configuration](https://neon.tech/docs/manage/endpoints#compute-size-and-autoscaling-configuration)\n    for more information.\n",
+            "$ref": "#/components/schemas/ComputeUnit"
+          },
+          "autoscaling_limit_max_cu": {
+            "description": "The maximum number of Compute Units.\n    See [Compute size and Autoscaling configuration](https://neon.tech/docs/manage/endpoints#compute-size-and-autoscaling-configuration)\n    for more information.\n",
+            "$ref": "#/components/schemas/ComputeUnit"
+          },
+          "provisioner": {
+            "$ref": "#/components/schemas/Provisioner"
+          },
+          "suspend_timeout_seconds": {
+            "$ref": "#/components/schemas/SuspendTimeoutSeconds"
+          }
+        }
+      },
+      "BranchCreateRequest": {
+        "type": "object",
+        "properties": {
+          "endpoints": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BranchCreateRequestEndpointOptions"
+            }
+          },
+          "branch": {
+            "type": "object",
+            "properties": {
+              "parent_id": {
+                "description": "The `branch_id` of the parent branch. If omitted or empty, the branch will be created from the project's default branch.\n",
+                "type": "string",
+                "pattern": "^[a-z0-9-]{1,60}$"
+              },
+              "name": {
+                "description": "The branch name\n",
+                "type": "string"
+              },
+              "parent_lsn": {
+                "description": "A Log Sequence Number (LSN) on the parent branch. The branch will be created with data from this LSN.\n",
+                "type": "string"
+              },
+              "parent_timestamp": {
+                "description": "A timestamp identifying a point in time on the parent branch. The branch will be created with data starting from this point in time.\nThe timestamp must be provided in ISO 8601 format; for example: `2024-02-26T12:00:00Z`.\n",
+                "type": "string",
+                "format": "date-time"
+              },
+              "protected": {
+                "description": "Whether the branch is protected\n",
+                "type": "boolean"
+              },
+              "archived": {
+                "description": "Whether to create the branch as archived\n",
+                "type": "boolean"
+              },
+              "init_source": {
+                "description": "The source of initialization for the branch. Valid values are `schema-only` and `parent-data` (default).\n  * `schema-only` - creates a new root branch containing only the schema. Use `parent_id` to specify the source branch. Optionally, you can provide `parent_lsn` or `parent_timestamp` to branch from a specific point in time or LSN. These fields define which branch to copy the schema from and at what point\u2014they do not establish a parent-child relationship between the `parent_id` branch and the new schema-only branch.\n  * `parent-data` - creates the branch with both schema and data from the parent.\n",
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "BranchUpdateRequest": {
+        "type": "object",
+        "required": [
+          "branch"
+        ],
+        "properties": {
+          "branch": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "protected": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "BranchRestoreRequest": {
+        "type": "object",
+        "required": [
+          "source_branch_id"
+        ],
+        "properties": {
+          "source_branch_id": {
+            "description": "The `branch_id` of the restore source branch.\nIf `source_timestamp` and `source_lsn` are omitted, the branch will be restored to head.\nIf `source_branch_id` is equal to the branch's id, `source_timestamp` or `source_lsn` is required.\n",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "source_lsn": {
+            "description": "A Log Sequence Number (LSN) on the source branch. The branch will be restored with data from this LSN.\n",
+            "type": "string"
+          },
+          "source_timestamp": {
+            "description": "A timestamp identifying a point in time on the source branch. The branch will be restored with data starting from this point in time.\nThe timestamp must be provided in ISO 8601 format; for example: `2024-02-26T12:00:00Z`.\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "preserve_under_name": {
+            "description": "If not empty, the previous state of the branch will be saved to a branch with this name.\nIf the branch has children or the `source_branch_id` is equal to the branch id, this field is required. All existing child branches will be moved to the newly created branch under the name `preserve_under_name`.\n",
+            "type": "string"
+          }
+        }
+      },
+      "BranchResponse": {
+        "type": "object",
+        "required": [
+          "branch"
+        ],
+        "properties": {
+          "branch": {
+            "$ref": "#/components/schemas/Branch"
+          }
+        }
+      },
+      "BranchSchemaResponse": {
+        "type": "object",
+        "properties": {
+          "sql": {
+            "type": "string"
+          }
+        }
+      },
+      "BranchSchemaCompareResponse": {
+        "type": "object",
+        "properties": {
+          "diff": {
+            "type": "string"
+          }
+        }
+      },
+      "BranchesResponse": {
+        "type": "object",
+        "required": [
+          "branches"
+        ],
+        "properties": {
+          "branches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Branch"
+            }
+          }
+        }
+      },
+      "BranchesCountResponse": {
+        "type": "object",
+        "required": [
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int"
+          }
+        }
+      },
+      "ConnectionParameters": {
+        "type": "object",
+        "required": [
+          "database",
+          "password",
+          "role",
+          "host",
+          "pooler_host"
+        ],
+        "properties": {
+          "database": {
+            "description": "Database name\n",
+            "type": "string"
+          },
+          "password": {
+            "description": "Password for the role\n",
+            "type": "string"
+          },
+          "role": {
+            "description": "Role name\n",
+            "type": "string"
+          },
+          "host": {
+            "description": "Hostname\n",
+            "type": "string"
+          },
+          "pooler_host": {
+            "description": "Pooler hostname\n",
+            "type": "string"
+          }
+        }
+      },
+      "ConnectionDetails": {
+        "type": "object",
+        "required": [
+          "connection_uri",
+          "connection_parameters"
+        ],
+        "properties": {
+          "connection_uri": {
+            "description": "The connection URI is defined as specified here: [Connection URIs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS)\nThe connection URI can be used to connect to a Postgres database with psql or defined in a DATABASE_URL environment variable.\nWhen creating a branch from a parent with more than one role or database, the response body does not include a connection URI.\n",
+            "type": "string"
+          },
+          "connection_parameters": {
+            "$ref": "#/components/schemas/ConnectionParameters"
+          }
+        }
+      },
+      "ConnectionURIResponse": {
+        "type": "object",
+        "required": [
+          "uri"
+        ],
+        "properties": {
+          "uri": {
+            "description": "The connection URI.\n",
+            "type": "string"
+          }
+        }
+      },
+      "Endpoint": {
+        "type": "object",
+        "required": [
+          "host",
+          "id",
+          "project_id",
+          "branch_id",
+          "region_id",
+          "autoscaling_limit_max_cu",
+          "autoscaling_limit_min_cu",
+          "type",
+          "current_state",
+          "pooler_enabled",
+          "pooler_mode",
+          "disabled",
+          "passwordless_access",
+          "creation_source",
+          "created_at",
+          "updated_at",
+          "settings",
+          "proxy_host",
+          "suspend_timeout_seconds",
+          "provisioner"
+        ],
+        "properties": {
+          "host": {
+            "description": "The hostname of the compute endpoint. This is the hostname specified when connecting to a Neon database.\n",
+            "type": "string"
+          },
+          "id": {
+            "description": "The compute endpoint ID. Compute endpoint IDs have an `ep-` prefix. For example: `ep-little-smoke-851426`\n",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "project_id": {
+            "description": "The ID of the project to which the compute endpoint belongs\n",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "branch_id": {
+            "description": "The ID of the branch that the compute endpoint is associated with\n",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "autoscaling_limit_min_cu": {
+            "description": "The minimum number of Compute Units\n",
+            "$ref": "#/components/schemas/ComputeUnit"
+          },
+          "autoscaling_limit_max_cu": {
+            "description": "The maximum number of Compute Units\n",
+            "$ref": "#/components/schemas/ComputeUnit"
+          },
+          "region_id": {
+            "type": "string",
+            "description": "The region identifier\n"
+          },
+          "type": {
+            "$ref": "#/components/schemas/EndpointType"
+          },
+          "current_state": {
+            "$ref": "#/components/schemas/EndpointState"
+          },
+          "pending_state": {
+            "$ref": "#/components/schemas/EndpointState"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/EndpointSettingsData"
+          },
+          "pooler_enabled": {
+            "description": "Whether connection pooling is enabled for the compute endpoint\n",
+            "type": "boolean"
+          },
+          "pooler_mode": {
+            "$ref": "#/components/schemas/EndpointPoolerMode"
+          },
+          "disabled": {
+            "description": "Whether to restrict connections to the compute endpoint.\nEnabling this option schedules a suspend compute operation.\nA disabled compute endpoint cannot be enabled by a connection or\nconsole action. However, the compute endpoint is periodically\nenabled by check_availability operations.\n",
+            "type": "boolean"
+          },
+          "passwordless_access": {
+            "description": "Whether to permit passwordless access to the compute endpoint\n",
+            "type": "boolean"
+          },
+          "last_active": {
+            "description": "A timestamp indicating when the compute endpoint was last active\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "creation_source": {
+            "description": "The compute endpoint creation source\n",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "A timestamp indicating when the compute endpoint was created\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "A timestamp indicating when the compute endpoint was last updated\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "proxy_host": {
+            "description": "DEPRECATED. Use the \"host\" property instead.\n",
+            "type": "string"
+          },
+          "suspend_timeout_seconds": {
+            "$ref": "#/components/schemas/SuspendTimeoutSeconds"
+          },
+          "provisioner": {
+            "$ref": "#/components/schemas/Provisioner"
+          },
+          "compute_release_version": {
+            "description": "Attached compute's release version number.\n",
+            "type": "string"
+          }
+        },
+        "example": {
+          "host": "ep-silent-smoke-806639.us-east-2.aws.neon.tech",
+          "id": "ep-silent-smoke-806639",
+          "project_id": "spring-example-302709",
+          "branch_id": "br-wispy-meadow-118737",
+          "autoscaling_limit_min_cu": 1,
+          "autoscaling_limit_max_cu": 1,
+          "region_id": "aws-us-east-2",
+          "type": "read_write",
+          "current_state": "init",
+          "pending_state": "active",
+          "settings": {
+            "pg_settings": {}
+          },
+          "pooler_enabled": false,
+          "pooler_mode": "transaction",
+          "disabled": false,
+          "passwordless_access": true,
+          "creation_source": "console",
+          "created_at": "2022-12-03T15:37:07Z",
+          "updated_at": "2022-12-03T15:37:07Z",
+          "proxy_host": "us-east-2.aws.neon.tech",
+          "suspend_timeout_seconds": 0
+        }
+      },
+      "EndpointState": {
+        "description": "The state of the compute endpoint\n",
+        "type": "string",
+        "enum": [
+          "init",
+          "active",
+          "idle"
+        ]
+      },
+      "EndpointType": {
+        "description": "The compute endpoint type. Either `read_write` or `read_only`.\n",
+        "type": "string",
+        "enum": [
+          "read_only",
+          "read_write"
+        ]
+      },
+      "EndpointPoolerMode": {
+        "description": "The connection pooler mode. Neon supports PgBouncer in `transaction` mode only.\n",
+        "type": "string",
+        "enum": [
+          "transaction"
+        ]
+      },
+      "SuspendTimeoutSeconds": {
+        "description": "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.tech/docs/manage/endpoints#scale-to-zero-configuration).\n",
+        "type": "integer",
+        "format": "int64",
+        "minimum": -1,
+        "maximum": 604800
+      },
+      "AllowedIps": {
+        "description": "A list of IP addresses that are allowed to connect to the compute endpoint.\nIf the list is empty or not set, all IP addresses are allowed.\nIf protected_branches_only is true, the list will be applied only to protected branches.\n",
+        "type": "object",
+        "properties": {
+          "ips": {
+            "description": "A list of IP addresses that are allowed to connect to the endpoint.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "protected_branches_only": {
+            "description": "If true, the list will be applied only to protected branches.",
+            "type": "boolean"
+          }
+        }
+      },
+      "MaintenanceWindow": {
+        "description": "A maintenance window is a time period during which Neon may perform maintenance on the project's infrastructure.\nDuring this time, the project's compute endpoints may be unavailable and existing connections can be\ninterrupted.\n",
+        "type": "object",
+        "required": [
+          "weekdays",
+          "start_time",
+          "end_time"
+        ],
+        "properties": {
+          "weekdays": {
+            "description": "A list of weekdays when the maintenance window is active.\nEncoded as ints, where 1 - Monday, and 7 - Sunday.\n",
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "start_time": {
+            "description": "Start time of the maintenance window, in the format of \"HH:MM\". Uses UTC.\n",
+            "type": "string"
+          },
+          "end_time": {
+            "description": "End time of the maintenance window, in the format of \"HH:MM\". Uses UTC.\n",
+            "type": "string"
+          }
+        }
+      },
+      "EndpointCreateRequest": {
+        "type": "object",
+        "required": [
+          "endpoint"
+        ],
+        "properties": {
+          "endpoint": {
+            "type": "object",
+            "required": [
+              "branch_id",
+              "type"
+            ],
+            "properties": {
+              "branch_id": {
+                "description": "The ID of the branch the compute endpoint will be associated with\n",
+                "type": "string",
+                "pattern": "^[a-z0-9-]{1,60}$"
+              },
+              "region_id": {
+                "description": "The region where the compute endpoint will be created. Only the project's `region_id` is permitted.\n",
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/components/schemas/EndpointType"
+              },
+              "settings": {
+                "$ref": "#/components/schemas/EndpointSettingsData"
+              },
+              "autoscaling_limit_min_cu": {
+                "description": "The minimum number of Compute Units. The minimum value is `0.25`.\nSee [Compute size and Autoscaling configuration](https://neon.tech/docs/manage/endpoints#compute-size-and-autoscaling-configuration)\nfor more information.\n",
+                "$ref": "#/components/schemas/ComputeUnit"
+              },
+              "autoscaling_limit_max_cu": {
+                "description": "The maximum number of Compute Units.\nSee [Compute size and Autoscaling configuration](https://neon.tech/docs/manage/endpoints#compute-size-and-autoscaling-configuration)\nfor more information.\n",
+                "$ref": "#/components/schemas/ComputeUnit"
+              },
+              "provisioner": {
+                "$ref": "#/components/schemas/Provisioner"
+              },
+              "pooler_enabled": {
+                "deprecated": true,
+                "description": "Whether to enable connection pooling for the compute endpoint\n",
+                "type": "boolean"
+              },
+              "pooler_mode": {
+                "$ref": "#/components/schemas/EndpointPoolerMode"
+              },
+              "disabled": {
+                "type": "boolean",
+                "description": "Whether to restrict connections to the compute endpoint.\nEnabling this option schedules a suspend compute operation.\nA disabled compute endpoint cannot be enabled by a connection or\nconsole action. However, the compute endpoint is periodically\nenabled by check_availability operations.\n"
+              },
+              "passwordless_access": {
+                "type": "boolean",
+                "description": "NOT YET IMPLEMENTED. Whether to permit passwordless access to the compute endpoint.\n"
+              },
+              "suspend_timeout_seconds": {
+                "$ref": "#/components/schemas/SuspendTimeoutSeconds"
+              }
+            }
+          }
+        }
+      },
+      "EndpointUpdateRequest": {
+        "type": "object",
+        "required": [
+          "endpoint"
+        ],
+        "properties": {
+          "endpoint": {
+            "type": "object",
+            "properties": {
+              "branch_id": {
+                "deprecated": true,
+                "description": "DEPRECATED: This field will be removed in a future release.\nThe destination branch ID. The destination branch must not have an existing read-write endpoint.\n",
+                "type": "string",
+                "pattern": "^[a-z0-9-]{1,60}$"
+              },
+              "autoscaling_limit_min_cu": {
+                "description": "The minimum number of Compute Units. The minimum value is `0.25`.\nSee [Compute size and Autoscaling configuration](https://neon.tech/docs/manage/endpoints#compute-size-and-autoscaling-configuration)\nfor more information.\n",
+                "$ref": "#/components/schemas/ComputeUnit"
+              },
+              "autoscaling_limit_max_cu": {
+                "description": "The maximum number of Compute Units.\nSee [Compute size and Autoscaling configuration](https://neon.tech/docs/manage/endpoints#compute-size-and-autoscaling-configuration)\nfor more information.\n",
+                "$ref": "#/components/schemas/ComputeUnit"
+              },
+              "provisioner": {
+                "$ref": "#/components/schemas/Provisioner"
+              },
+              "settings": {
+                "$ref": "#/components/schemas/EndpointSettingsData"
+              },
+              "pooler_enabled": {
+                "deprecated": true,
+                "description": "Whether to enable connection pooling for the compute endpoint\n",
+                "type": "boolean"
+              },
+              "pooler_mode": {
+                "$ref": "#/components/schemas/EndpointPoolerMode"
+              },
+              "disabled": {
+                "description": "Whether to restrict connections to the compute endpoint.\nEnabling this option schedules a suspend compute operation.\nA disabled compute endpoint cannot be enabled by a connection or\nconsole action. However, the compute endpoint is periodically\nenabled by check_availability operations.\n",
+                "type": "boolean"
+              },
+              "passwordless_access": {
+                "description": "NOT YET IMPLEMENTED. Whether to permit passwordless access to the compute endpoint.\n",
+                "type": "boolean"
+              },
+              "suspend_timeout_seconds": {
+                "$ref": "#/components/schemas/SuspendTimeoutSeconds"
+              }
+            }
+          }
+        }
+      },
+      "EndpointResponse": {
+        "type": "object",
+        "required": [
+          "endpoint"
+        ],
+        "properties": {
+          "endpoint": {
+            "$ref": "#/components/schemas/Endpoint"
+          }
+        }
+      },
+      "ConnectionURIsResponse": {
+        "type": "object",
+        "required": [
+          "connection_uris"
+        ],
+        "properties": {
+          "connection_uris": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConnectionDetails"
+            }
+          }
+        }
+      },
+      "ConnectionURIsOptionalResponse": {
+        "type": "object",
+        "properties": {
+          "connection_uris": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConnectionDetails"
+            }
+          }
+        }
+      },
+      "VPCEndpointsResponse": {
+        "type": "object",
+        "required": [
+          "endpoints"
+        ],
+        "properties": {
+          "endpoints": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VPCEndpoint"
+            }
+          }
+        }
+      },
+      "VPCEndpoint": {
+        "type": "object",
+        "required": [
+          "vpc_endpoint_id",
+          "label"
+        ],
+        "properties": {
+          "vpc_endpoint_id": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          }
+        }
+      },
+      "VPCEndpointDetails": {
+        "type": "object",
+        "required": [
+          "vpc_endpoint_id",
+          "label",
+          "state",
+          "num_restricted_projects",
+          "example_restricted_projects"
+        ],
+        "properties": {
+          "vpc_endpoint_id": {
+            "description": "The ID of the VPC endpoint",
+            "type": "string"
+          },
+          "label": {
+            "description": "The custom descriptive label for the VPC endpoint",
+            "type": "string"
+          },
+          "state": {
+            "description": "The current state of the VPC endpoint. Possible values are\n`new` (just configured, pending acceptance) or `accepted`\n(VPC connection was accepted by Neon).\n",
+            "type": "string"
+          },
+          "num_restricted_projects": {
+            "description": "The number of projects that are restricted to use this VPC endpoint.\n",
+            "type": "integer"
+          },
+          "example_restricted_projects": {
+            "description": "A list of example projects that are restricted to use this VPC endpoint.\nThere are at most 3 projects in the list, even if more projects are restricted.\n",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "VPCEndpointAssignment": {
+        "type": "object",
+        "required": [
+          "label"
+        ],
+        "properties": {
+          "label": {
+            "type": "string"
+          }
+        }
+      },
+      "EndpointsResponse": {
+        "type": "object",
+        "required": [
+          "endpoints"
+        ],
+        "properties": {
+          "endpoints": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Endpoint"
+            }
+          }
+        }
+      },
+      "EndpointPasswordlessSessionAuthRequest": {
+        "type": "object",
+        "required": [
+          "session_id"
+        ],
+        "properties": {
+          "session_id": {
+            "type": "string"
+          }
+        }
+      },
+      "Duration": {
+        "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
+        "type": "integer",
+        "format": "int64"
+      },
+      "StatementResult": {
+        "type": "object",
+        "required": [
+          "query"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/StatementData"
+          },
+          "error": {
+            "type": "string"
+          },
+          "explain_data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExplainData"
+            }
+          },
+          "query": {
+            "type": "string"
+          }
+        }
+      },
+      "StatementData": {
+        "type": "object",
+        "required": [
+          "truncated"
+        ],
+        "properties": {
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "truncated": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ExplainData": {
+        "type": "object",
+        "required": [
+          "QUERY PLAN"
+        ],
+        "properties": {
+          "QUERY PLAN": {
+            "type": "string"
+          }
+        }
+      },
+      "Role": {
+        "type": "object",
+        "required": [
+          "branch_id",
+          "name",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "branch_id": {
+            "description": "The ID of the branch to which the role belongs\n",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "name": {
+            "description": "The role name\n",
+            "type": "string"
+          },
+          "password": {
+            "description": "The role password\n",
+            "type": "string"
+          },
+          "protected": {
+            "description": "Whether or not the role is system-protected\n",
+            "type": "boolean"
+          },
+          "created_at": {
+            "description": "A timestamp indicating when the role was created\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "A timestamp indicating when the role was last updated\n",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "branch_id": "br-wispy-meadow-118737",
+          "name": "casey",
+          "protected": false,
+          "created_at": "2022-11-23T17:42:25Z",
+          "updated_at": "2022-11-23T17:42:25Z"
+        }
+      },
+      "RoleCreateRequest": {
+        "type": "object",
+        "required": [
+          "role"
+        ],
+        "properties": {
+          "role": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "description": "The role name. Cannot exceed 63 bytes in length.\n",
+                "type": "string"
+              },
+              "no_login": {
+                "description": "Whether to create a role that cannot login.\n",
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "RoleResponse": {
+        "type": "object",
+        "required": [
+          "role"
+        ],
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/Role"
+          }
+        }
+      },
+      "JWKSResponse": {
+        "type": "object",
+        "required": [
+          "jwks"
+        ],
+        "properties": {
+          "jwks": {
+            "$ref": "#/components/schemas/JWKS"
+          }
+        }
+      },
+      "RolesResponse": {
+        "type": "object",
+        "required": [
+          "roles"
+        ],
+        "properties": {
+          "roles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Role"
+            }
+          }
+        }
+      },
+      "RolePasswordResponse": {
+        "type": "object",
+        "required": [
+          "password"
+        ],
+        "properties": {
+          "password": {
+            "description": "The role password\n",
+            "type": "string"
+          }
+        }
+      },
+      "PaymentSourceBankCard": {
+        "type": "object",
+        "required": [
+          "last4"
+        ],
+        "properties": {
+          "last4": {
+            "type": "string",
+            "description": "Last 4 digits of the card.\n"
+          },
+          "brand": {
+            "type": "string",
+            "description": "Brand of credit card.\n",
+            "enum": [
+              "amex",
+              "diners",
+              "discover",
+              "jcb",
+              "mastercard",
+              "unionpay",
+              "unknown",
+              "visa"
+            ]
+          },
+          "exp_month": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Credit card expiration month\n"
+          },
+          "exp_year": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Credit card expiration year\n"
+          }
+        }
+      },
+      "PaymentSource": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Type of payment source. E.g. \"card\".\n"
+          },
+          "card": {
+            "$ref": "#/components/schemas/PaymentSourceBankCard"
+          }
+        }
+      },
+      "BillingAccount": {
+        "type": "object",
+        "required": [
+          "state",
+          "payment_source",
+          "subscription_type",
+          "payment_method",
+          "quota_reset_at_last",
+          "name",
+          "email",
+          "address_city",
+          "address_country",
+          "address_line1",
+          "address_line2",
+          "address_postal_code",
+          "address_state"
+        ],
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/BillingAccountState"
+          },
+          "payment_source": {
+            "$ref": "#/components/schemas/PaymentSource"
+          },
+          "subscription_type": {
+            "$ref": "#/components/schemas/BillingSubscriptionType"
+          },
+          "payment_method": {
+            "$ref": "#/components/schemas/BillingPaymentMethod"
+          },
+          "quota_reset_at_last": {
+            "description": "The last time the quota was reset. Defaults to the date-time the account is created.\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "description": "The full name of the individual or entity that owns the billing account. This name appears on invoices.",
+            "type": "string"
+          },
+          "email": {
+            "description": "Billing email, to receive emails related to invoices and subscriptions.\n",
+            "type": "string"
+          },
+          "address_city": {
+            "description": "Billing address city.\n",
+            "type": "string"
+          },
+          "address_country": {
+            "description": "Billing address country code defined by ISO 3166-1 alpha-2.\n",
+            "type": "string"
+          },
+          "address_country_name": {
+            "description": "Billing address country name.\n",
+            "type": "string"
+          },
+          "address_line1": {
+            "description": "Billing address line 1.\n",
+            "type": "string"
+          },
+          "address_line2": {
+            "description": "Billing address line 2.\n",
+            "type": "string"
+          },
+          "address_postal_code": {
+            "description": "Billing address postal code.\n",
+            "type": "string"
+          },
+          "address_state": {
+            "description": "Billing address state or region.\n",
+            "type": "string"
+          },
+          "orb_portal_url": {
+            "description": "Orb user portal url\n",
+            "type": "string"
+          },
+          "tax_id": {
+            "description": "The tax identification number for the billing account, displayed on invoices.\n",
+            "type": "string"
+          },
+          "tax_id_type": {
+            "description": "The type of the tax identification number based on the country.\n",
+            "type": "string"
+          }
+        }
+      },
+      "BillingAccountState": {
+        "type": "string",
+        "description": "State of the billing account.\n",
+        "enum": [
+          "UNKNOWN",
+          "active",
+          "suspended",
+          "deactivated",
+          "deleted"
+        ]
+      },
+      "BillingSubscriptionType": {
+        "type": "string",
+        "description": "Type of subscription to Neon Cloud.\nNotice that for users without billing account this will be \"UNKNOWN\"\n",
+        "enum": [
+          "UNKNOWN",
+          "direct_sales",
+          "aws_marketplace",
+          "free_v2",
+          "launch",
+          "scale",
+          "business",
+          "vercel_pg_legacy"
+        ]
+      },
+      "BillingPaymentMethod": {
+        "type": "string",
+        "description": "Indicates whether and how an account makes payments.\n",
+        "enum": [
+          "UNKNOWN",
+          "none",
+          "stripe",
+          "direct_payment",
+          "aws_mp",
+          "azure_mp",
+          "vercel_mp",
+          "staff",
+          "trial",
+          "sponsorship"
+        ]
+      },
+      "Database": {
+        "type": "object",
+        "required": [
+          "id",
+          "branch_id",
+          "name",
+          "owner_name",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "id": {
+            "description": "The database ID\n",
+            "type": "integer",
+            "format": "int64"
+          },
+          "branch_id": {
+            "description": "The ID of the branch to which the database belongs\n",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "name": {
+            "description": "The database name\n",
+            "type": "string"
+          },
+          "owner_name": {
+            "description": "The name of role that owns the database\n",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "A timestamp indicating when the database was created\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "A timestamp indicating when the database was last updated\n",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "id": 834686,
+          "branch_id": "br-wispy-meadow-118737",
+          "name": "neondb",
+          "owner_name": "casey",
+          "created_at": "2022-11-30T18:25:15Z",
+          "updated_at": "2022-11-30T18:25:15Z"
+        }
+      },
+      "DatabaseCreateRequest": {
+        "type": "object",
+        "required": [
+          "database"
+        ],
+        "properties": {
+          "database": {
+            "type": "object",
+            "required": [
+              "name",
+              "owner_name"
+            ],
+            "properties": {
+              "name": {
+                "description": "The name of the database\n",
+                "type": "string"
+              },
+              "owner_name": {
+                "description": "The name of the role that owns the database\n",
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "DatabaseUpdateRequest": {
+        "type": "object",
+        "required": [
+          "database"
+        ],
+        "properties": {
+          "database": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "The name of the database\n",
+                "type": "string"
+              },
+              "owner_name": {
+                "description": "The name of the role that owns the database\n",
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "DatabaseResponse": {
+        "type": "object",
+        "required": [
+          "database"
+        ],
+        "properties": {
+          "database": {
+            "$ref": "#/components/schemas/Database"
+          }
+        }
+      },
+      "DatabasesResponse": {
+        "type": "object",
+        "required": [
+          "databases"
+        ],
+        "properties": {
+          "databases": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Database"
+            }
+          }
+        }
+      },
+      "Invitation": {
+        "type": "object",
+        "required": [
+          "id",
+          "email",
+          "org_id",
+          "invited_by",
+          "invited_at",
+          "role"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "description": "Email of the invited user",
+            "type": "string",
+            "format": "email"
+          },
+          "org_id": {
+            "description": "Organization id as it is stored in Neon",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "invited_by": {
+            "description": "UUID for the user_id who extended the invitation",
+            "type": "string",
+            "format": "uuid"
+          },
+          "invited_at": {
+            "description": "Timestamp when the invitation was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "role": {
+            "$ref": "#/components/schemas/MemberRole"
+          }
+        }
+      },
+      "MemberRole": {
+        "description": "The role of the organization member",
+        "type": "string",
+        "enum": [
+          "admin",
+          "member"
+        ]
+      },
+      "Member": {
+        "type": "object",
+        "required": [
+          "id",
+          "user_id",
+          "org_id",
+          "role"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "user_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "org_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "role": {
+            "$ref": "#/components/schemas/MemberRole"
+          },
+          "joined_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "MemberUserInfo": {
+        "type": "object",
+        "required": [
+          "email"
+        ],
+        "properties": {
+          "email": {
+            "type": "string"
+          }
+        }
+      },
+      "MemberWithUser": {
+        "type": "object",
+        "required": [
+          "member",
+          "user"
+        ],
+        "properties": {
+          "member": {
+            "$ref": "#/components/schemas/Member"
+          },
+          "user": {
+            "$ref": "#/components/schemas/MemberUserInfo"
+          }
+        }
+      },
+      "Organization": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "handle",
+          "plan",
+          "created_at",
+          "updated_at",
+          "managed_by"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "name": {
+            "type": "string"
+          },
+          "handle": {
+            "type": "string"
+          },
+          "plan": {
+            "type": "string"
+          },
+          "created_at": {
+            "description": "A timestamp indicting when the organization was created\n",
+            "type": "string",
+            "format": "date-time"
+          },
+          "managed_by": {
+            "description": "Organizations created via the Console or the API are managed by `console`.\nOrganizations created by other methods can't be deleted via the Console or the API.\n",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "A timestamp indicating when the organization was updated\n",
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "OrganizationsResponse": {
+        "type": "object",
+        "required": [
+          "organizations"
+        ],
+        "properties": {
+          "organizations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Organization"
+            }
+          }
+        }
+      },
+      "OrganizationsUpdateRequest": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 64
+          }
+        }
+      },
+      "OrganizationInvitationsResponse": {
+        "type": "object",
+        "required": [
+          "invitations"
+        ],
+        "properties": {
+          "invitations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Invitation"
+            }
+          }
+        }
+      },
+      "OrganizationInviteCreateRequest": {
+        "type": "object",
+        "required": [
+          "email",
+          "role"
+        ],
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "role": {
+            "$ref": "#/components/schemas/MemberRole"
+          }
+        }
+      },
+      "OrganizationInvitesCreateRequest": {
+        "type": "object",
+        "required": [
+          "invitations"
+        ],
+        "properties": {
+          "invitations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrganizationInviteCreateRequest"
+            }
+          }
+        }
+      },
+      "OrganizationInviteUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "role": {
+            "$ref": "#/components/schemas/MemberRole"
+          },
+          "resend": {
+            "type": "boolean"
+          }
+        }
+      },
+      "OrganizationGuestsResponse": {
+        "description": "A list of details for guests of an organization\n",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/OrganizationGuest"
+        }
+      },
+      "OrganizationGuest": {
+        "description": "Details of an organization guest, who is not directly a member of\nan organization but has been shared one of the projects it owns\n",
+        "type": "object",
+        "required": [
+          "permission_id",
+          "user_email",
+          "project_id",
+          "project_name"
+        ],
+        "properties": {
+          "permission_id": {
+            "type": "string"
+          },
+          "user_email": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "project_name": {
+            "type": "string"
+          }
+        }
+      },
+      "OrganizationMemberUpdateRequest": {
+        "type": "object",
+        "required": [
+          "role"
+        ],
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/MemberRole"
+          }
+        }
+      },
+      "OrganizationMembersResponse": {
+        "type": "object",
+        "required": [
+          "members"
+        ],
+        "properties": {
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MemberWithUser"
+            }
+          }
+        }
+      },
+      "InvitationCreateRequest": {
+        "type": "object",
+        "required": [
+          "email",
+          "role"
+        ],
+        "properties": {
+          "email": {
+            "description": "Email to invite",
+            "type": "string"
+          },
+          "role": {
+            "$ref": "#/components/schemas/MemberRole"
+          }
+        }
+      },
+      "OrganizationCreateRequest": {
+        "type": "object",
+        "required": [
+          "organization",
+          "subscription_type"
+        ],
+        "properties": {
+          "organization": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "The organization name",
+                "type": "string",
+                "maxLength": 64
+              },
+              "invitations": {
+                "description": "Emails with roles to invite to the organization",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/InvitationCreateRequest"
+                }
+              }
+            }
+          },
+          "subscription_type": {
+            "$ref": "#/components/schemas/BillingSubscriptionType"
+          }
+        }
+      },
+      "OrganizationLimits": {
+        "type": "object",
+        "required": [
+          "limits",
+          "features"
+        ],
+        "properties": {
+          "limits": {
+            "$ref": "#/components/schemas/Limits"
+          },
+          "features": {
+            "$ref": "#/components/schemas/Features"
+          }
+        }
+      },
+      "ActiveRegionsResponse": {
+        "type": "object",
+        "required": [
+          "regions"
+        ],
+        "properties": {
+          "regions": {
+            "type": "array",
+            "description": "The list of active regions",
+            "items": {
+              "$ref": "#/components/schemas/RegionResponse"
+            }
+          }
+        }
+      },
+      "RegionResponse": {
+        "type": "object",
+        "required": [
+          "region_id",
+          "name",
+          "default",
+          "geo_lat",
+          "geo_long"
+        ],
+        "properties": {
+          "region_id": {
+            "type": "string",
+            "description": "The region ID as used in other API endpoints"
+          },
+          "name": {
+            "type": "string",
+            "description": "A short description of the region."
+          },
+          "default": {
+            "type": "boolean",
+            "description": "Whether this region is used by default in new projects."
+          },
+          "geo_lat": {
+            "type": "string",
+            "description": "The geographical latitude (approximate) for the region. Empty if unknown."
+          },
+          "geo_long": {
+            "type": "string",
+            "description": "The geographical longitude (approximate) for the region. Empty if unknown."
+          }
+        }
+      },
+      "CurrentUserAuthAccount": {
+        "type": "object",
+        "required": [
+          "provider",
+          "email",
+          "name",
+          "login",
+          "image"
+        ],
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string"
+          },
+          "login": {
+            "type": "string",
+            "deprecated": true,
+            "description": "DEPRECATED. Use `email` field.\n"
+          },
+          "name": {
+            "type": "string"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/IdentityProviderId"
+          }
+        }
+      },
+      "LinkedAuthAccount": {
+        "type": "object",
+        "required": [
+          "provider",
+          "provider_display_name",
+          "username"
+        ],
+        "properties": {
+          "provider": {
+            "$ref": "#/components/schemas/IdentityProviderId"
+          },
+          "provider_display_name": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      },
+      "UpdateUserInfoRequest": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "image": {
+            "type": "string",
+            "deprecated": true,
+            "description": "DEPRECATED. This field is ignored.\n"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "new_password": {
+            "type": "string"
+          }
+        }
+      },
+      "CurrentUserInfoResponse": {
+        "type": "object",
+        "required": [
+          "active_seconds_limit",
+          "billing_account",
+          "id",
+          "email",
+          "login",
+          "name",
+          "last_name",
+          "image",
+          "projects_limit",
+          "branches_limit",
+          "max_autoscaling_limit",
+          "auth_accounts",
+          "plan"
+        ],
+        "properties": {
+          "active_seconds_limit": {
+            "description": "Control plane observes active endpoints of a user this amount of wall-clock time.\n",
+            "type": "integer",
+            "format": "int64"
+          },
+          "billing_account": {
+            "$ref": "#/components/schemas/BillingAccount"
+          },
+          "auth_accounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CurrentUserAuthAccount"
+            }
+          },
+          "email": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string"
+          },
+          "login": {
+            "type": "string",
+            "deprecated": true,
+            "description": "DEPRECATED. Use `email` field.\n"
+          },
+          "name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "projects_limit": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "branches_limit": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "max_autoscaling_limit": {
+            "$ref": "#/components/schemas/ComputeUnit"
+          },
+          "compute_seconds_limit": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "plan": {
+            "type": "string"
+          }
+        }
+      },
+      "ConvertUserToOrgRequest": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 64
+          }
+        }
+      },
+      "CurrentUserInfoAuthResponse": {
+        "type": "object",
+        "required": [
+          "password_stored",
+          "auth_accounts",
+          "linked_accounts",
+          "provider"
+        ],
+        "properties": {
+          "password_stored": {
+            "type": "boolean"
+          },
+          "auth_accounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CurrentUserAuthAccount"
+            }
+          },
+          "linked_accounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LinkedAuthAccount"
+            }
+          },
+          "provider": {
+            "type": "string"
+          }
+        }
+      },
+      "TransferProjectsToOrganizationRequest": {
+        "type": "object",
+        "required": [
+          "org_id",
+          "project_ids"
+        ],
+        "properties": {
+          "org_id": {
+            "description": "The source organization identifier",
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "project_ids": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 400,
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{1,60}$"
+            },
+            "description": "The list of projects ids to transfer. Maximum of 400 project ids"
+          }
+        }
+      },
+      "VerifyUserPasswordRequest": {
+        "type": "object",
+        "required": [
+          "password"
+        ],
+        "properties": {
+          "password": {
+            "type": "string"
+          }
+        }
+      },
+      "IdentityProviderId": {
+        "description": "Identity provider id from keycloak",
+        "type": "string",
+        "enum": [
+          "github",
+          "google",
+          "hasura",
+          "microsoft",
+          "microsoftv2",
+          "vercelmp",
+          "keycloak",
+          "test"
+        ]
+      },
+      "EndpointSettingsData": {
+        "type": "object",
+        "description": "A collection of settings for a compute endpoint",
+        "properties": {
+          "pg_settings": {
+            "$ref": "#/components/schemas/PgSettingsData"
+          },
+          "pgbouncer_settings": {
+            "$ref": "#/components/schemas/PgbouncerSettingsData"
+          }
+        }
+      },
+      "ProjectQuota": {
+        "type": "object",
+        "description": "Per-project consumption quota. If the quota is exceeded, all active computes\nare automatically suspended and it will not be possible to start them with\nan API method call or incoming proxy connections. The only exception is\n`logical_size_bytes`, which is applied on per-branch basis, i.e., only the\ncompute on the branch that exceeds the `logical_size` quota will be suspended.\n\nQuotas are enforced based on per-project consumption metrics with the same names,\nwhich are reset at the end of each billing period (the first day of the month).\nLogical size is also an exception in this case, as it represents the total size\nof data stored in a branch, so it is not reset.\n\nA zero or empty quota value means 'unlimited'.\n",
+        "properties": {
+          "active_time_seconds": {
+            "description": "The total amount of wall-clock time allowed to be spent by the project's compute endpoints.\n",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "compute_time_seconds": {
+            "description": "The total amount of CPU seconds allowed to be spent by the project's compute endpoints.\n",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "written_data_bytes": {
+            "description": "Total amount of data written to all of a project's branches.\n",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "data_transfer_bytes": {
+            "description": "Total amount of data transferred from all of a project's branches using the proxy.\n",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "logical_size_bytes": {
+            "description": "Limit on the logical size of every project's branch.\n",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
+      "DefaultEndpointSettings": {
+        "type": "object",
+        "description": "A collection of settings for a Neon endpoint",
+        "properties": {
+          "pg_settings": {
+            "$ref": "#/components/schemas/PgSettingsData"
+          },
+          "pgbouncer_settings": {
+            "$ref": "#/components/schemas/PgbouncerSettingsData"
+          },
+          "autoscaling_limit_min_cu": {
+            "description": "The minimum number of Compute Units. The minimum value is `0.25`.\nSee [Compute size and Autoscaling configuration](https://neon.tech/docs/manage/endpoints#compute-size-and-autoscaling-configuration)\nfor more information.\n",
+            "$ref": "#/components/schemas/ComputeUnit"
+          },
+          "autoscaling_limit_max_cu": {
+            "description": "The maximum number of Compute Units. See [Compute size and Autoscaling configuration](https://neon.tech/docs/manage/endpoints#compute-size-and-autoscaling-configuration)\nfor more information.\n",
+            "$ref": "#/components/schemas/ComputeUnit"
+          },
+          "suspend_timeout_seconds": {
+            "$ref": "#/components/schemas/SuspendTimeoutSeconds"
+          }
+        },
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "PgSettingsData": {
+        "description": "A raw representation of Postgres settings",
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "PgbouncerSettingsData": {
+        "description": "A raw representation of PgBouncer settings",
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "PgVersion": {
+        "description": "The major Postgres version number. Currently supported versions are `14`, `15`, `16`, and `17`.",
+        "type": "integer",
+        "minimum": 14,
+        "maximum": 17,
+        "default": 17
+      },
+      "HealthCheck": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "description": "Service status",
+            "type": "string"
+          }
+        },
+        "example": {
+          "status": "ok"
+        }
+      },
+      "ProjectOwnerData": {
+        "type": "object",
+        "required": [
+          "email",
+          "name",
+          "branches_limit",
+          "subscription_type"
+        ],
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "branches_limit": {
+            "type": "integer"
+          },
+          "subscription_type": {
+            "$ref": "#/components/schemas/BillingSubscriptionType"
+          }
+        }
+      },
+      "LimitsUnsatisfiedResponse": {
+        "type": "object",
+        "required": [
+          "limits"
+        ],
+        "properties": {
+          "limits": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "name",
+                "expected",
+                "actual"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "expected": {
+                  "type": "string"
+                },
+                "actual": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "example": {
+          "limits": [
+            {
+              "name": "projects_count",
+              "actual": "2",
+              "expected": "1"
+            },
+            {
+              "name": "subscription_type",
+              "actual": "launch",
+              "expected": "scale"
+            }
+          ]
+        }
+      },
+      "ProjectsWithIntegrationResponse": {
+        "type": "object",
+        "required": [
+          "projects"
+        ],
+        "properties": {
+          "projects": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "integration"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9-]{1,60}$"
+                },
+                "integration": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "example": {
+          "projects": [
+            {
+              "id": "round-frog-53611540",
+              "integration": "github"
+            },
+            {
+              "id": "long-leaf-72329067",
+              "integration": "vercel"
+            },
+            {
+              "id": "shrill-bush-06966719",
+              "integration": "outerbase"
+            }
+          ]
+        }
+      },
+      "UserDeletionConditionName": {
+        "type": "string",
+        "enum": [
+          "project_count",
+          "org_admin_membership_count",
+          "subscription_type"
+        ]
+      },
+      "OrgDeletionConditionName": {
+        "type": "string",
+        "enum": [
+          "project_count"
+        ]
+      },
+      "IdentitySupportedAuthProvider": {
+        "type": "string",
+        "enum": [
+          "mock",
+          "stack"
+        ]
+      },
+      "IdentityAuthProviderProjectOwnedBy": {
+        "type": "string",
+        "enum": [
+          "user",
+          "neon"
+        ]
+      },
+      "IdentityAuthProviderProjectTransferStatus": {
+        "type": "string",
+        "enum": [
+          "initiated",
+          "finished"
+        ]
+      },
+      "IdentityCreateIntegrationResponse": {
+        "type": "object",
+        "required": [
+          "auth_provider",
+          "auth_provider_project_id",
+          "pub_client_key",
+          "secret_server_key",
+          "jwks_url",
+          "schema_name",
+          "table_name"
+        ],
+        "properties": {
+          "auth_provider": {
+            "$ref": "#/components/schemas/IdentitySupportedAuthProvider"
+          },
+          "auth_provider_project_id": {
+            "type": "string"
+          },
+          "pub_client_key": {
+            "type": "string"
+          },
+          "secret_server_key": {
+            "type": "string"
+          },
+          "jwks_url": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "table_name": {
+            "type": "string"
+          }
+        }
+      },
+      "IdentityCreateAuthProviderSDKKeysRequest": {
+        "type": "object",
+        "required": [
+          "project_id",
+          "auth_provider"
+        ],
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "auth_provider": {
+            "$ref": "#/components/schemas/IdentitySupportedAuthProvider"
+          }
+        }
+      },
+      "ListProjectIdentityIntegrationsResponse": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IdentityIntegration"
+            }
+          }
+        }
+      },
+      "IdentityIntegration": {
+        "type": "object",
+        "required": [
+          "auth_provider",
+          "auth_provider_project_id",
+          "branch_id",
+          "db_name",
+          "created_at",
+          "owned_by",
+          "jwks_url"
+        ],
+        "properties": {
+          "auth_provider": {
+            "type": "string"
+          },
+          "auth_provider_project_id": {
+            "type": "string"
+          },
+          "branch_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]{1,60}$"
+          },
+          "db_name": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "owned_by": {
+            "$ref": "#/components/schemas/IdentityAuthProviderProjectOwnedBy"
+          },
+          "transfer_status": {
+            "$ref": "#/components/schemas/IdentityAuthProviderProjectTransferStatus"
+          },
+          "transferred_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "jwks_url": {
+            "type": "string"
+          }
+        }
+      },
+      "GeneralError": {
+        "type": "object",
+        "description": "General Error",
+        "required": [
+          "message",
+          "code"
+        ],
+        "properties": {
+          "request_id": {
+            "type": "string"
+          },
+          "code": {
+            "$ref": "#/components/schemas/ErrorCode"
+          },
+          "message": {
+            "description": "Error message",
+            "type": "string"
+          }
+        }
+      },
+      "ErrorCode": {
+        "type": "string"
+      },
+      "BranchOperations": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BranchResponse"
+          },
+          {
+            "$ref": "#/components/schemas/OperationsResponse"
+          }
+        ]
+      },
+      "EndpointOperations": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/EndpointResponse"
+          },
+          {
+            "$ref": "#/components/schemas/OperationsResponse"
+          }
+        ]
+      },
+      "DatabaseOperations": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DatabaseResponse"
+          },
+          {
+            "$ref": "#/components/schemas/OperationsResponse"
+          }
+        ]
+      },
+      "RoleOperations": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoleResponse"
+          },
+          {
+            "$ref": "#/components/schemas/OperationsResponse"
+          }
+        ]
+      },
+      "JWKSCreationOperation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/JWKSResponse"
+          },
+          {
+            "$ref": "#/components/schemas/OperationsResponse"
+          }
+        ]
+      },
+      "SupportTicketSeverity": {
+        "type": "string",
+        "enum": [
+          "low",
+          "normal",
+          "high",
+          "critical"
+        ]
+      },
+      "AnnotationData": {
+        "type": "object",
+        "x-tags": [
+          "Branch"
+        ],
+        "required": [
+          "object",
+          "value"
+        ],
+        "properties": {
+          "object": {
+            "$ref": "#/components/schemas/AnnotationObjectData"
+          },
+          "value": {
+            "$ref": "#/components/schemas/AnnotationValueData"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AnnotationValueData": {
+        "type": "object",
+        "description": "Annotation properties.",
+        "x-tags": [
+          "Branch"
+        ],
+        "maxProperties": 50,
+        "additionalProperties": {
+          "type": "string",
+          "example": {
+            "github-commit-ref": "github-branch-name"
+          }
+        }
+      },
+      "AnnotationObjectData": {
+        "type": "object",
+        "x-tags": [
+          "Branch"
+        ],
+        "required": [
+          "type",
+          "id"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          }
+        }
+      },
+      "AnnotationCreateValueRequest": {
+        "type": "object",
+        "x-tags": [
+          "Branch"
+        ],
+        "properties": {
+          "annotation_value": {
+            "$ref": "#/components/schemas/AnnotationValueData"
+          }
+        }
+      },
+      "AnnotationResponse": {
+        "type": "object",
+        "x-tags": [
+          "Branch"
+        ],
+        "required": [
+          "annotation"
+        ],
+        "properties": {
+          "annotation": {
+            "$ref": "#/components/schemas/AnnotationData"
+          }
+        }
+      },
+      "AnnotationsMapResponse": {
+        "type": "object",
+        "x-tags": [
+          "Branch"
+        ],
+        "required": [
+          "annotations"
+        ],
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AnnotationData"
+            }
+          }
+        }
+      },
+      "ProjectsApplicationsMapResponse": {
+        "type": "object",
+        "x-tags": [
+          "Project"
+        ],
+        "description": "A map where key is a project ID and a value is a list of installed applications.\n",
+        "required": [
+          "applications"
+        ],
+        "properties": {
+          "applications": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "vercel",
+                  "github",
+                  "datadog"
+                ]
+              }
+            }
+          }
+        },
+        "example": {
+          "winter-boat-259881": [
+            "vercel",
+            "github",
+            "datadog"
+          ]
+        }
+      },
+      "ProjectsIntegrationsMapResponse": {
+        "type": "object",
+        "x-tags": [
+          "Project"
+        ],
+        "description": "A map where key is a project ID and a value is a list of installed integrations.\n",
+        "required": [
+          "integrations"
+        ],
+        "properties": {
+          "integrations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "vercel",
+                  "github",
+                  "datadog"
+                ]
+              }
+            }
+          }
+        },
+        "example": {
+          "winter-boat-259881": [
+            "vercel",
+            "github",
+            "datadog"
+          ]
+        }
+      },
+      "CursorPaginationResponse": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "$ref": "#/components/schemas/CursorPagination"
+          }
+        }
+      },
+      "CursorPagination": {
+        "type": "object",
+        "description": "To paginate the response, issue an initial request with `limit` value. Then, add the value returned in the response `.pagination.next` attribute into the request under the `cursor` query parameter to the subsequent request to retrieve next page in pagination. The contents on cursor `next` are opaque, clients are not expected to make any assumptions on the format of the data inside the cursor.",
+        "properties": {
+          "next": {
+            "type": "string"
+          },
+          "sort_by": {
+            "type": "string"
+          },
+          "sort_order": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "parameters": {
+      "CursorParam": {
+        "name": "cursor",
+        "description": "A cursor to use in pagination. A cursor defines your place in the data list. Include `response.pagination.next` in subsequent API calls to fetch next page of the list.",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "LimitParam": {
+        "name": "limit",
+        "description": "The maximum number of records to be returned in the response",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10000
+        }
+      },
+      "SortOrderParam": {
+        "name": "sort_order",
+        "description": "Defines the sorting order of entities.",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "default": "desc",
+          "enum": [
+            "asc",
+            "desc"
+          ]
+        }
+      },
+      "TimeoutParam": {
+        "name": "timeout",
+        "in": "query",
+        "description": "Specify an explicit timeout in milliseconds to limit response delay.\nAfter timing out, the incomplete list of project data fetched so far will be returned.\nProjects still being fetched when the timeout occurred are listed in the \"unavailable\" attribute of the response.\nIf not specified, an implicit implementation defined timeout is chosen with the same behaviour as above\n",
+        "schema": {
+          "type": "integer",
+          "minimum": 100,
+          "maximum": 30000
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/schemas/user.json
+++ b/tests/fixtures/schemas/user.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string"
+    },
+    "createdAt": {
+      "type": "string"
+    },
+    "updatedAt": {
+      "type": "string"
+    }
+  }
+}

--- a/tests/singerlib/test_schema.py
+++ b/tests/singerlib/test_schema.py
@@ -30,6 +30,40 @@ OBJECT_DICT = {
 }
 
 
+def test_simple_schema():
+    simple_schema = {
+        "title": "Longitude and Latitude Values",
+        "description": "A geographical coordinate.",
+        "required": ["latitude", "longitude"],
+        "type": "object",
+        "properties": {
+            "latitude": {"type": "number", "minimum": -90, "maximum": 90},
+            "longitude": {"type": "number", "minimum": -180, "maximum": 180},
+        },
+    }
+
+    schema_plus = Schema.from_dict(simple_schema)
+    assert schema_plus.to_dict() == simple_schema
+    assert schema_plus.required == ["latitude", "longitude"]
+    assert isinstance(schema_plus.properties["latitude"], Schema)
+    latitude = schema_plus.properties["latitude"]
+    assert latitude.type == "number"
+
+
+def test_schema_with_items():
+    schema = {
+        "description": "A representation of a person, company, organization, or place",
+        "type": "object",
+        "properties": {"fruits": {"type": "array", "items": {"type": "string"}}},
+    }
+    schema_plus = Schema.from_dict(schema)
+    assert schema_plus.to_dict() == schema
+    assert isinstance(schema_plus.properties["fruits"], Schema)
+    fruits = schema_plus.properties["fruits"]
+    assert isinstance(fruits.items, Schema)
+    assert fruits.items.type == "string"
+
+
 @pytest.mark.parametrize(
     "schema,expected",
     [


### PR DESCRIPTION
## Summary by Sourcery

Introduce an extensible schema source API with local and OpenAPI backends and update the sample GitLab tap to use this unified mechanism for loading stream schemas.

New Features:
- Add BaseSchemaSource as an abstract API for fetching JSON schemas by reference
- Implement LocalSchemaSource for loading named schemas from local files
- Implement OpenAPISchemaSource for resolving and caching schemas from OpenAPI specs

Enhancements:
- Refactor the GitLab tap to replace static schema_filepath attributes with dynamic schema retrieval via LocalSchemaSource

Tests:
- Add unit tests for LocalSchemaSource and OpenAPISchemaSource behavior
- Relocate and preserve existing Schema.from_dict tests to validate schema dict round-trip

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2876.org.readthedocs.build/en/2876/

<!-- readthedocs-preview meltano-sdk end -->