### PR TITLE
perf: Iterate only once over properties when pruning record

### DIFF
--- a/singer_sdk/helpers/_catalog.py
+++ b/singer_sdk/helpers/_catalog.py
@@ -86,7 +86,7 @@ def pop_deselected_record_properties(
     Walk through properties, starting at the index in breadcrumb, recursively
     updating in place.
     """
-    for property_name, val in list(record.items()):
+    for property_name, val in record.items():
         property_breadcrumb = (*breadcrumb, "properties", property_name)
         selected = mask[property_breadcrumb]
         if not selected:

--- a/singer_sdk/helpers/_catalog.py
+++ b/singer_sdk/helpers/_catalog.py
@@ -86,7 +86,7 @@ def pop_deselected_record_properties(
     Walk through properties, starting at the index in breadcrumb, recursively
     updating in place.
     """
-    for property_name, val in record.items():
+    for property_name, val in record.copy().items():
         property_breadcrumb = (*breadcrumb, "properties", property_name)
         selected = mask[property_breadcrumb]
         if not selected:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Improved the performance of the `pop_deselected_record_properties` function by iterating directly over the record's items instead of creating a list copy, which avoids unnecessary memory allocation and improves efficiency.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2887.org.readthedocs.build/en/2887/

<!-- readthedocs-preview meltano-sdk end -->