### PR TITLE
chore: Enable dependabot updates for uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
## Related

- https://github.com/dependabot/dependabot-core/issues/10478#issuecomment-2691330949

## Summary by Sourcery

Chores:
- Enable dependabot updates for the uv ecosystem.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2890.org.readthedocs.build/en/2890/

<!-- readthedocs-preview meltano-sdk end -->