### PR TITLE
chore: Use the commitizen scm version provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ xfail_strict = false
 
 [tool.commitizen]
 name = "cz_version_bump"
-version = "0.44.3"
+version_provider = "scm"
 changelog_merge_prerelease = true
 prerelease_offset = 1
 tag_format = "v$major.$minor.$patch$prerelease"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Configure commitizen to use the scm version provider.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2892.org.readthedocs.build/en/2892/

<!-- readthedocs-preview meltano-sdk end -->