### PR TITLE
fix: Don't warn about catalog schema not matching records if there are no records available to test against

### DIFF
--- a/singer_sdk/testing/runners.py
+++ b/singer_sdk/testing/runners.py
@@ -16,6 +16,7 @@ if t.TYPE_CHECKING:
 
     from singer_sdk import Tap, Target
     from singer_sdk.helpers._compat import Traversable
+    from singer_sdk.helpers.types import Record
 
 
 class SingerTestRunner(metaclass=abc.ABCMeta):
@@ -46,7 +47,7 @@ class SingerTestRunner(metaclass=abc.ABCMeta):
         self.schema_messages: list[dict] = []
         self.record_messages: list[dict] = []
         self.state_messages: list[dict] = []
-        self.records: defaultdict = defaultdict(list)
+        self.records: defaultdict[str, list[Record]] = defaultdict(list)
 
     @staticmethod
     def _clean_sync_output(raw_records: str) -> list[dict]:

--- a/singer_sdk/testing/tap_tests.py
+++ b/singer_sdk/testing/tap_tests.py
@@ -121,12 +121,17 @@ class StreamCatalogSchemaMatchesRecordTest(StreamTestTemplate):
 
     def test(self) -> None:
         """Run test."""
-        stream_transformed_keys = set(
+        if not self.stream_records:
+            return
+
+        stream_transformed_keys: set[str] = set(
             self.stream.stream_maps[-1].transformed_schema["properties"].keys(),
         )
-        stream_record_keys = set().union(*(d.keys() for d in self.stream_records))
+        stream_record_keys: set[str] = set().union(
+            *(d.keys() for d in self.stream_records)
+        )
         diff = stream_transformed_keys - stream_record_keys
-        if stream_record_keys and diff:
+        if diff:
             warnings.warn(
                 UserWarning(
                     f"Fields in transformed catalog but not in records: ({diff})",

--- a/singer_sdk/testing/tap_tests.py
+++ b/singer_sdk/testing/tap_tests.py
@@ -126,7 +126,7 @@ class StreamCatalogSchemaMatchesRecordTest(StreamTestTemplate):
         )
         stream_record_keys = set().union(*(d.keys() for d in self.stream_records))
         diff = stream_transformed_keys - stream_record_keys
-        if diff:
+        if stream_record_keys and diff:
             warnings.warn(
                 UserWarning(
                     f"Fields in transformed catalog but not in records: ({diff})",

--- a/singer_sdk/testing/templates.py
+++ b/singer_sdk/testing/templates.py
@@ -8,16 +8,19 @@ import typing as t
 import warnings
 
 from singer_sdk.testing import target_test_streams
+from singer_sdk.testing.runners import SingerTestRunner, TapTestRunner, TargetTestRunner
 
 if t.TYPE_CHECKING:
     from singer_sdk.helpers._compat import Traversable
     from singer_sdk.streams import Stream
 
     from .config import SuiteConfig
-    from .runners import TapTestRunner, TargetTestRunner
 
 
-class TestTemplate:
+_T = t.TypeVar("_T", bound=SingerTestRunner)
+
+
+class TestTemplate(t.Generic[_T]):
     """Each Test class requires one or more of the following arguments.
 
     Args:
@@ -91,7 +94,7 @@ class TestTemplate:
         self,
         config: SuiteConfig,
         resource: t.Any,
-        runner: TapTestRunner | TargetTestRunner,
+        runner: _T,
     ) -> None:
         """Test main run method.
 
@@ -138,7 +141,7 @@ class TapTestTemplate(TestTemplate):
         """
         return f"tap__{self.name}"
 
-    def run(  # type: ignore[override]
+    def run(
         self,
         config: SuiteConfig,
         resource: t.Any,
@@ -190,7 +193,7 @@ class StreamTestTemplate(TestTemplate):
         super().run(config, resource, runner)
 
 
-class AttributeTestTemplate(TestTemplate):
+class AttributeTestTemplate(TestTemplate[TapTestRunner]):
     """Base Tap Stream Attribute template."""
 
     plugin_type = "attribute"
@@ -270,12 +273,12 @@ class AttributeTestTemplate(TestTemplate):
         raise NotImplementedError(msg)
 
 
-class TargetTestTemplate(TestTemplate):
+class TargetTestTemplate(TestTemplate[TargetTestRunner]):
     """Base Target test template."""
 
     plugin_type = "target"
 
-    def run(  # type: ignore[override]
+    def run(
         self,
         config: SuiteConfig,
         resource: t.Any,
@@ -307,7 +310,7 @@ class TargetFileTestTemplate(TargetTestTemplate):
     Use this when sourcing Target test input from a .singer file.
     """
 
-    def run(  # type: ignore[override]
+    def run(
         self,
         config: SuiteConfig,
         resource: t.Any,

--- a/tests/samples/test_tap_csv.py
+++ b/tests/samples/test_tap_csv.py
@@ -80,24 +80,6 @@ _TestCSVOneStreamPerFileIncremental = get_tap_test_class(
 
 
 class TestCSVOneStreamPerFileIncremental(_TestCSVOneStreamPerFileIncremental):
-    def test_tap_stream_transformed_catalog_schema_matches_record(
-        self,
-        config: SuiteConfig,
-        resource: t.Any,
-        runner: TapTestRunner,
-        stream: CSVStream,
-    ):
-        with pytest.warns(
-            UserWarning,
-            match="Fields in transformed catalog but not in records",
-        ):
-            super().test_tap_stream_transformed_catalog_schema_matches_record(
-                config,
-                resource,
-                runner,
-                stream,
-            )
-
     def test_tap_stream_returns_record(
         self,
         config: SuiteConfig,


### PR DESCRIPTION
https://github.com/ReubenFrankel/tap-f1/actions/runs/13897716477/job/38882050908?pr=111#step:7:21

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where a warning was raised about catalog schema mismatches even when no records were available to test against.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2903.org.readthedocs.build/en/2903/

<!-- readthedocs-preview meltano-sdk end -->