### PR TITLE
fix: Additionally suppress `No records were available to test` warning when no records are ignored for all streams

### DIFF
--- a/singer_sdk/testing/templates.py
+++ b/singer_sdk/testing/templates.py
@@ -243,10 +243,13 @@ class AttributeTestTemplate(TestTemplate[TapTestRunner]):
             for r in self.stream_records
             if r.get(self.attribute_name) is not None
         ]
-        if (
-            not values
-            and self.stream.name not in self.config.ignore_no_records_for_streams
-        ):
+
+        ignore_no_records = (
+            self.config.ignore_no_records
+            or self.stream.name in self.config.ignore_no_records_for_streams
+        )
+
+        if not values and not ignore_no_records:
             warnings.warn(
                 UserWarning("No records were available to test."),
                 stacklevel=2,


### PR DESCRIPTION
Follow up to https://github.com/meltano/sdk/pull/2906#discussion_r2002142717

## Summary by Sourcery

Bug Fixes:
- Suppress `No records were available to test` warning when no records are ignored for all streams.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2907.org.readthedocs.build/en/2907/

<!-- readthedocs-preview meltano-sdk end -->