### PR TITLE
ci: Exclude cookiecutter files from CodeQL analysis

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,6 @@
+paths:
+  - samples
+  - singer_sdk
+  - tests
+paths-ignore:
+  - cookiecutter

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,6 +47,7 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     - uses: github/codeql-action/init@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
       with:
+        config-file: .github/codeql-config.yml
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Excludes cookiecutter files from CodeQL analysis by adding a configuration file.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2912.org.readthedocs.build/en/2912/

<!-- readthedocs-preview meltano-sdk end -->