### PR TITLE
chore: Use `nox.project.python_versions` to extract versions from trove classifiers

### DIFF
--- a/.github/workflows/cookiecutter-e2e.yml
+++ b/.github/workflows/cookiecutter-e2e.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Run Nox
       run: |
-        nox --session=test_cookiecutter
+        nox --session=templates
 
     - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     env:
-      NOXPYTHON: ${{ matrix.python-version }}
+      NOXFORCEPYTHON: ${{ matrix.python-version }}
       NOXSESSION: ${{ matrix.session }}
     permissions:
       contents: read

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,6 +37,10 @@ nox.options.sessions = [
 ]
 
 
+def _uv_python(session: nox.Session) -> str | None:
+    return str(session.python) if isinstance(session.python, str) else None
+
+
 @nox.session()
 def mypy(session: nox.Session) -> None:
     """Check types with mypy."""
@@ -58,7 +62,7 @@ def mypy(session: nox.Session) -> None:
         *(f"--extra={extra}" for extra in extras),
         env={
             "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
-            "UV_PYTHON": session.python,
+            "UV_PYTHON": _uv_python(session),
         },
     )
     session.run("mypy", *args)
@@ -85,7 +89,7 @@ def tests(session: nox.Session) -> None:
         *(f"--extra={extra}" for extra in extras),
         env={
             "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
-            "UV_PYTHON": session.python,
+            "UV_PYTHON": _uv_python(session),
         },
     )
 
@@ -125,7 +129,7 @@ def benches(session: nox.Session) -> None:
         *(f"--extra={extra}" for extra in extras),
         env={
             "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
-            "UV_PYTHON": session.python,
+            "UV_PYTHON": _uv_python(session),
         },
     )
     session.run(
@@ -159,7 +163,7 @@ def dependencies(session: nox.Session) -> None:
         *(f"--extra={extra}" for extra in extras),
         env={
             "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
-            "UV_PYTHON": session.python,
+            "UV_PYTHON": _uv_python(session),
         },
     )
     session.install("deptry")
@@ -188,7 +192,7 @@ def update_snapshots(session: nox.Session) -> None:
         *(f"--extra={extra}" for extra in extras),
         env={
             "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
-            "UV_PYTHON": session.python,
+            "UV_PYTHON": _uv_python(session),
         },
     )
 
@@ -213,7 +217,7 @@ def doctest(session: nox.Session) -> None:
         "--group=testing",
         env={
             "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
-            "UV_PYTHON": session.python,
+            "UV_PYTHON": _uv_python(session),
         },
     )
     session.run("pytest", "--xdoctest", *args)
@@ -232,7 +236,7 @@ def coverage(session: nox.Session) -> None:
         "--group=testing",
         env={
             "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
-            "UV_PYTHON": session.python,
+            "UV_PYTHON": _uv_python(session),
         },
     )
 
@@ -257,7 +261,7 @@ def docs(session: nox.Session) -> None:
         "--group=docs",
         env={
             "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
-            "UV_PYTHON": session.python,
+            "UV_PYTHON": _uv_python(session),
         },
     )
 
@@ -291,7 +295,7 @@ def docs_serve(session: nox.Session) -> None:
         "--group=docs",
         env={
             "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
-            "UV_PYTHON": session.python,
+            "UV_PYTHON": _uv_python(session),
         },
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -56,7 +56,10 @@ def mypy(session: nox.Session) -> None:
         "--no-dev",
         "--group=typing",
         *(f"--extra={extra}" for extra in extras),
-        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+        env={
+            "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
+            "UV_PYTHON": session.python,
+        },
     )
     session.run("mypy", *args)
     if not session.posargs:
@@ -80,7 +83,10 @@ def tests(session: nox.Session) -> None:
         "--no-dev",
         "--group=testing",
         *(f"--extra={extra}" for extra in extras),
-        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+        env={
+            "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
+            "UV_PYTHON": session.python,
+        },
     )
 
     env = {"COVERAGE_CORE": "sysmon"} if session.python == "3.12" else {}
@@ -117,7 +123,10 @@ def benches(session: nox.Session) -> None:
         "--no-dev",
         "--group=testing",
         *(f"--extra={extra}" for extra in extras),
-        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+        env={
+            "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
+            "UV_PYTHON": session.python,
+        },
     )
     session.run(
         "pytest",
@@ -148,7 +157,10 @@ def dependencies(session: nox.Session) -> None:
         "--inexact",
         "--no-dev",
         *(f"--extra={extra}" for extra in extras),
-        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+        env={
+            "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
+            "UV_PYTHON": session.python,
+        },
     )
     session.install("deptry")
     session.run("deptry", "singer_sdk", *session.posargs)
@@ -174,7 +186,10 @@ def update_snapshots(session: nox.Session) -> None:
         "--no-dev",
         "--group=testing",
         *(f"--extra={extra}" for extra in extras),
-        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+        env={
+            "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
+            "UV_PYTHON": session.python,
+        },
     )
 
     session.run("pytest", "--snapshot-update", *args)
@@ -196,7 +211,10 @@ def doctest(session: nox.Session) -> None:
         "--frozen",
         "--no-dev",
         "--group=testing",
-        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+        env={
+            "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
+            "UV_PYTHON": session.python,
+        },
     )
     session.run("pytest", "--xdoctest", *args)
 
@@ -212,7 +230,10 @@ def coverage(session: nox.Session) -> None:
         "--frozen",
         "--no-dev",
         "--group=testing",
-        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+        env={
+            "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
+            "UV_PYTHON": session.python,
+        },
     )
 
     if not session.posargs and any(Path().glob(".coverage.*")):
@@ -234,7 +255,10 @@ def docs(session: nox.Session) -> None:
         "--frozen",
         "--no-dev",
         "--group=docs",
-        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+        env={
+            "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
+            "UV_PYTHON": session.python,
+        },
     )
 
     build_dir = Path("build")
@@ -265,7 +289,10 @@ def docs_serve(session: nox.Session) -> None:
         "--inexact",
         "--no-dev",
         "--group=docs",
-        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+        env={
+            "UV_PROJECT_ENVIRONMENT": session.virtualenv.location,
+            "UV_PYTHON": session.python,
+        },
     )
 
     build_dir = Path("build")


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Nox configuration to dynamically extract Python versions from the pyproject.toml file and update CI workflows to use the new 'templates' session.

Enhancements:
- Refactor Nox sessions to dynamically extract Python versions from the project's pyproject.toml file using nox.project.python_versions.

CI:
- Update CI workflows to use the 'templates' session instead of 'test_cookiecutter' and adjust environment variable naming from NOXPYTHON to NOXFORCEPYTHON.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2914.org.readthedocs.build/en/2914/

<!-- readthedocs-preview meltano-sdk end -->