### PR TITLE
fix: Let downstream packages import from deprecated `singer_sdk._singerlib.catalog`

### DIFF
--- a/singer_sdk/_singerlib/catalog.py
+++ b/singer_sdk/_singerlib/catalog.py
@@ -1,0 +1,21 @@
+"""Deprecated."""
+
+from __future__ import annotations
+
+import warnings
+
+from singer_sdk.helpers._compat import SingerSDKDeprecationWarning
+
+
+def __getattr__(name: str):  # noqa: ANN202
+    from singer_sdk.singerlib import catalog  # noqa: PLC0415
+
+    warnings.warn(
+        "The module `singer_sdk._singerlib.catalog` is deprecated and will be removed "
+        "by August 2025. "
+        "Please use `singer_sdk.singerlib.catalog` instead.",
+        SingerSDKDeprecationWarning,
+        stacklevel=2,
+    )
+
+    return getattr(catalog, name)


### PR DESCRIPTION
## Links

- Slack: https://meltano.slack.com/archives/C069CQNHDNF/p1743038808736009
- Linen: https://discuss.meltano.com/t/27134012/related-to-above-i-ve-started-to-see-this-error-when-running#86f51529-0f3e-44de-836a-6c095d6a4c46

## Summary by Sourcery

Add a deprecated module to maintain backwards compatibility for downstream packages importing from `singer_sdk._singerlib.catalog`

Bug Fixes:
- Provide a compatibility layer to prevent breaking changes for packages importing from the deprecated module path

Enhancements:
- Implement a deprecation warning mechanism to guide users to the new import path

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2925.org.readthedocs.build/en/2925/

<!-- readthedocs-preview meltano-sdk end -->