### PR TITLE
fix: Ensure stream schema is overridden by the input catalog

### DIFF
--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -489,6 +489,15 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         """
         return self._schema
 
+    @schema.setter
+    def schema(self, new_value: dict) -> None:
+        """Set schema.
+
+        Args:
+            new_value: JSON Schema dictionary for this stream.
+        """
+        self._schema = new_value
+
     @property
     def primary_keys(self) -> t.Sequence[str] | None:
         """Get primary keys.
@@ -1306,6 +1315,8 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
             )
             if replication_method:
                 self.forced_replication_method = replication_method
+
+            self.schema = catalog_entry.schema.to_dict()
 
     def _get_state_partition_context(
         self,


### PR DESCRIPTION
## Summary by Sourcery

Add a schema setter method to allow overriding the stream schema from the input catalog

Bug Fixes:
- Ensure that the stream schema can be updated when applying a catalog entry

Enhancements:
- Introduced a schema setter method in the stream class to enable dynamic schema modification

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2932.org.readthedocs.build/en/2932/

<!-- readthedocs-preview meltano-sdk end -->