### PR TITLE
chore: Use walrus op to apply catalog

### DIFF
--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -1293,8 +1293,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         """
         self._tap_input_catalog = catalog
 
-        catalog_entry = catalog.get_stream(self.name)
-        if catalog_entry:
+        if catalog_entry := catalog.get_stream(self.name):
             stream_metadata: StreamMetadata | None
             if stream_metadata := catalog_entry.metadata.get(()):  # type: ignore[assignment]
                 table_key_properties = stream_metadata.table_key_properties


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Simplify the catalog stream retrieval logic by using the walrus operator (:=) to combine assignment and condition checking

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2933.org.readthedocs.build/en/2933/

<!-- readthedocs-preview meltano-sdk end -->