### PR TITLE
fix(templates): Added `uv` venv backend to Meltano project in templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/meltano.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/meltano.yml
@@ -2,6 +2,8 @@ version: 1
 send_anonymous_usage_stats: true
 project_id: "{{cookiecutter.mapper_id}}"
 default_environment: test
+venv:
+  backend: uv
 environments:
 - name: test
 plugins:

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/meltano.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/meltano.yml
@@ -2,6 +2,8 @@ version: 1
 send_anonymous_usage_stats: true
 project_id: "{{cookiecutter.tap_id}}"
 default_environment: test
+venv:
+  backend: uv
 environments:
 - name: test
 plugins:

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/meltano.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/meltano.yml
@@ -2,6 +2,8 @@ version: 1
 send_anonymous_usage_stats: true
 project_id: "{{cookiecutter.target_id}}"
 default_environment: test
+venv:
+  backend: uv
 environments:
 - name: test
 plugins:

--- a/noxfile.py
+++ b/noxfile.py
@@ -351,7 +351,7 @@ def templates(session: nox.Session, replay_file_path: Path) -> None:
     session.run("uvx", "twine", "check", "dist/*")
 
     session.run("git", "init", "-b", "main", external=True)
-    session.run("git", "add", ".", ".github", external=True)
+    session.run("git", "add", ".", external=True)
     session.run("uvx", "pre-commit", "run", "--all-files", external=True)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -351,7 +351,7 @@ def templates(session: nox.Session, replay_file_path: Path) -> None:
     session.run("uvx", "twine", "check", "dist/*")
 
     session.run("git", "init", "-b", "main", external=True)
-    session.run("git", "add", ".", external=True)
+    session.run("git", "add", ".", ".github", external=True)
     session.run("uvx", "pre-commit", "run", "--all-files", external=True)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Configure `uv` as the default virtual environment backend in mapper, tap, and target project templates

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2935.org.readthedocs.build/en/2935/

<!-- readthedocs-preview meltano-sdk end -->