### PR TITLE
revert: Revert "fix: Ensure stream schema is overridden by the input catalog (#2932)"

### DIFF
--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -489,15 +489,6 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         """
         return self._schema
 
-    @schema.setter
-    def schema(self, new_value: dict) -> None:
-        """Set schema.
-
-        Args:
-            new_value: JSON Schema dictionary for this stream.
-        """
-        self._schema = new_value
-
     @property
     def primary_keys(self) -> t.Sequence[str] | None:
         """Get primary keys.
@@ -1314,8 +1305,6 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
             )
             if replication_method:
                 self.forced_replication_method = replication_method
-
-            self.schema = catalog_entry.schema.to_dict()
 
     def _get_state_partition_context(
         self,


### PR DESCRIPTION
This was causing problems for streams that declare `schema` property as read-only, that is without a `setter`:

```python
class MyStream(RESTStream):
    @property
    def schema(self): ...
```

I'm reverting until I come up with a better approach.

This reverts commit e5f4cdf7d597f61e99ac28f956c40752cdb426f4.

## Summary by Sourcery

Bug Fixes:
- Remove schema setter that was causing issues with read-only schema properties in stream classes

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2937.org.readthedocs.build/en/2937/

<!-- readthedocs-preview meltano-sdk end -->