### PR TITLE
docs: Fixed the dynamic schema example

### DIFF
--- a/docs/code_samples.md
+++ b/docs/code_samples.md
@@ -121,8 +121,9 @@ val1,val2,val3
 val1,val2,val3
 """
 
-@property
 class ParquetStream(Stream):
+
+    @property
     def schema(self):
         """Dynamically detect the json schema for the stream.
         This is evaluated prior to any records being retrieved.


### PR DESCRIPTION
Updated docs: https://meltano-sdk--2938.org.readthedocs.build/en/2938/code_samples.html#dynamically-discovering-schema-for-a-stream.

## Summary by Sourcery

Documentation:
- Corrected the code sample for the ParquetStream class by adjusting the @property decorator placement

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2938.org.readthedocs.build/en/2938/

<!-- readthedocs-preview meltano-sdk end -->