### PR TITLE
chore: Rely on uv version from `required-version` uv setting in `pyproject.toml`

### DIFF
--- a/.github/workflows/api-changes.yml
+++ b/.github/workflows/api-changes.yml
@@ -15,7 +15,6 @@ concurrency:
 env:
   FORCE_COLOR: 1
   UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
-  UV_VERSION: 0.5.26
 
 permissions:  # added using https://github.com/step-security/secure-repo
   contents: read
@@ -39,8 +38,6 @@ jobs:
         python-version: 3.x
 
     - uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
-      with:
-        version: ${{ env.UV_VERSION }}
 
     - name: Install tools
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,6 @@ concurrency:
 env:
   FORCE_COLOR: "1"
   UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
-  UV_VERSION: 0.5.26
 
 permissions: {}
 
@@ -77,8 +76,6 @@ jobs:
         allow-prereleases: true
 
     - uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
-      with:
-        version: ${{ env.UV_VERSION }}
 
     - name: Install Nox
       run: |
@@ -127,8 +124,6 @@ jobs:
         python-version: ${{ env.NOXPYTHON }}
 
     - uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
-      with:
-        version: ${{ env.UV_VERSION }}
 
     - name: Install Nox
       run: |
@@ -161,8 +156,6 @@ jobs:
         merge-multiple: true
 
     - uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
-      with:
-        version: ${{ env.UV_VERSION }}
 
     - name: Install Nox
       run: |


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove explicit UV_VERSION environment variable from GitHub Actions workflows, allowing the uv version to be managed through project configuration

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2941.org.readthedocs.build/en/2941/

<!-- readthedocs-preview meltano-sdk end -->