### PR TITLE
fix: In the builtin tap tests, do not emit a warning for missing records on ignored streams

### DIFF
--- a/singer_sdk/testing/tap_tests.py
+++ b/singer_sdk/testing/tap_tests.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import typing as t
 import warnings
 
+import pytest
 from jsonschema import validators
 from jsonschema.exceptions import SchemaError
 
@@ -107,11 +108,13 @@ class StreamReturnsRecordTest(StreamTestTemplate):
             self.config.ignore_no_records
             or self.stream.name in self.config.ignore_no_records_for_streams
         ):
-            # only warn if this or all streams are set to ignore no records
-            warnings.warn(UserWarning(no_records_message), stacklevel=2)
-        else:
-            record_count = len(self.stream_records)
-            assert record_count > 0, no_records_message
+            pytest.skip(
+                "Skipping test because no records were returned in "
+                f"stream '{self.stream.name}'",
+            )
+
+        record_count = len(self.stream_records)
+        assert record_count > 0, no_records_message
 
 
 class StreamCatalogSchemaMatchesRecordTest(StreamTestTemplate):

--- a/tests/samples/test_tap_csv.py
+++ b/tests/samples/test_tap_csv.py
@@ -75,11 +75,14 @@ _TestCSVOneStreamPerFileIncremental = get_tap_test_class(
         "delimiter": "\t",
     },
     state=STATE,
-    suite_config=SuiteConfig(ignore_no_records=True),
 )
 
 
 class TestCSVOneStreamPerFileIncremental(_TestCSVOneStreamPerFileIncremental):
+    @pytest.mark.xfail(
+        reason="There are no records because the state is set to the future.",
+        strict=True,
+    )
     def test_tap_stream_returns_record(
         self,
         config: SuiteConfig,
@@ -87,8 +90,16 @@ class TestCSVOneStreamPerFileIncremental(_TestCSVOneStreamPerFileIncremental):
         runner: TapTestRunner,
         stream: CSVStream,
     ):
-        with pytest.warns(
-            UserWarning,
-            match="No records returned in stream",
-        ):
-            super().test_tap_stream_returns_record(config, resource, runner, stream)
+        super().test_tap_stream_returns_record(config, resource, runner, stream)
+
+
+TestCSVOneStreamPerFileIncrementalIgnoreNoRecords = get_tap_test_class(
+    tap_class=SampleTapCSV,
+    config={
+        "path": "fixtures/csv",
+        "read_mode": "one_stream_per_file",
+        "delimiter": "\t",
+    },
+    state=STATE,
+    suite_config=SuiteConfig(ignore_no_records=True),
+)


### PR DESCRIPTION
This will avoid emitting a warning if the test suite is configured to ignore if the stream returns no records.

It will skip the test altogether.

## Related

- Closes #2929

## Summary by Sourcery

Modify tap testing behavior to skip tests for streams with no records when configured to ignore no records, instead of emitting a warning

Bug Fixes:
- Improve handling of streams with no records in tap tests by skipping the test instead of generating a warning

Tests:
- Update test configuration to use pytest.skip() when no records are returned for an ignored stream

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2946.org.readthedocs.build/en/2946/

<!-- readthedocs-preview meltano-sdk end -->