### PR TITLE
refactor: `ignore_no_records` as an instance property in built-in tests

### DIFF
--- a/singer_sdk/testing/tap_tests.py
+++ b/singer_sdk/testing/tap_tests.py
@@ -103,18 +103,14 @@ class StreamReturnsRecordTest(StreamTestTemplate):
 
     def test(self) -> None:
         """Run test."""
-        no_records_message = f"No records returned in stream '{self.stream.name}'."
-        if (
-            self.config.ignore_no_records
-            or self.stream.name in self.config.ignore_no_records_for_streams
-        ):
+        if self.ignore_no_records:
             pytest.skip(
                 "Skipping test because no records were returned in "
                 f"stream '{self.stream.name}'",
             )
 
         record_count = len(self.stream_records)
-        assert record_count > 0, no_records_message
+        assert record_count > 0, f"No records returned in stream '{self.stream.name}'."
 
 
 class StreamCatalogSchemaMatchesRecordTest(StreamTestTemplate):

--- a/singer_sdk/testing/templates.py
+++ b/singer_sdk/testing/templates.py
@@ -174,6 +174,13 @@ class StreamTestTemplate(TestTemplate):
         """
         return f"{self.stream.name}__{self.name}"
 
+    @property
+    def ignore_no_records(self) -> bool:
+        return (
+            self.config.ignore_no_records
+            or self.stream.name in self.config.ignore_no_records_for_streams
+        )
+
     def run(  # type: ignore[override]
         self,
         config: SuiteConfig,
@@ -194,7 +201,7 @@ class StreamTestTemplate(TestTemplate):
         super().run(config, resource, runner)
 
 
-class AttributeTestTemplate(TestTemplate[TapTestRunner]):
+class AttributeTestTemplate(StreamTestTemplate):
     """Base Tap Stream Attribute template."""
 
     plugin_type = "attribute"
@@ -226,10 +233,8 @@ class AttributeTestTemplate(TestTemplate[TapTestRunner]):
                 to use with this test.
             attribute_name: The name of the attribute to test.
         """
-        self.stream = stream
-        self.stream_records = runner.records[stream.name]
         self.attribute_name = attribute_name
-        super().run(config, resource, runner)
+        super().run(config, resource, runner, stream)
 
     @cached_property
     def non_null_attribute_values(self) -> list[t.Any]:
@@ -244,12 +249,7 @@ class AttributeTestTemplate(TestTemplate[TapTestRunner]):
             if r.get(self.attribute_name) is not None
         ]
 
-        ignore_no_records = (
-            self.config.ignore_no_records
-            or self.stream.name in self.config.ignore_no_records_for_streams
-        )
-
-        if not values and not ignore_no_records:
+        if not values and not self.ignore_no_records:
             warnings.warn(
                 UserWarning("No records were available to test."),
                 stacklevel=2,

--- a/singer_sdk/testing/templates.py
+++ b/singer_sdk/testing/templates.py
@@ -176,6 +176,7 @@ class StreamTestTemplate(TestTemplate):
 
     @property
     def ignore_no_records(self) -> bool:
+        """Whether or not the stream should be ignored if no records are returned."""
         return (
             self.config.ignore_no_records
             or self.stream.name in self.config.ignore_no_records_for_streams


### PR DESCRIPTION
Follow-up to https://github.com/meltano/sdk/issues/2929#issuecomment-2770650894

## Summary by Sourcery

Refactor the `ignore_no_records` logic to be an instance property in the StreamTestTemplate class, simplifying record testing logic across multiple test classes.

Enhancements:
- Move the `ignore_no_records` logic to a property method in the StreamTestTemplate base class, reducing code duplication and improving reusability of the testing logic

Tests:
- Modify the AttributeTestTemplate to inherit from StreamTestTemplate and use the new `ignore_no_records` property
- Update record testing methods to use the centralized `ignore_no_records` property