### PR TITLE
docs: Documented the `ignore_parent_replication_key` stream attribute

### DIFF
--- a/docs/parent_streams.md
+++ b/docs/parent_streams.md
@@ -17,8 +17,8 @@ from a parent record each time the child stream is invoked.
       [`generate_child_contexts`](singer_sdk.Stream.generate_child_contexts) to yield as many
       contexts as you need.
 3. If the parent stream's replication key won't get updated when child items are changed,
-   indicate this by adding `ignore_parent_replication_key = True` in the child stream
-   class declaration.
+   indicate this by adding [`ignore_parent_replication_key = True`](singer_sdk.Stream.ignore_parent_replication_key)
+   in the child stream class declaration.
 4. If the number of _parent_ items is very large (thousands or tens of thousands), you can
    optionally set [`state_partitioning_keys`](singer_sdk.Stream.state_partitioning_keys) on the child stream to specify a subset of context keys to use
    in state bookmarks. (When not set, the number of bookmarks will be equal to the number

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -106,6 +106,12 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
     """
 
     ignore_parent_replication_key: bool = False
+    """Set to `True` if the parent stream's replication key are not updated when child
+    items are changed.
+
+    This is used to indicate that a child stream should be synced regardless of the
+    parent stream's state.
+    """
 
     selected_by_default: bool = True
     """Whether this stream is selected by default in the catalog."""


### PR DESCRIPTION
## Updated docs

- https://meltano-sdk--2955.org.readthedocs.build/en/2955/parent_streams.html#if-you-do-want-to-utilize-parent-child-streams
- https://meltano-sdk--2955.org.readthedocs.build/en/2955/classes/singer_sdk.Stream.html#singer_sdk.Stream.ignore_parent_replication_key

## Summary by Sourcery

Document the purpose and usage of the `ignore_parent_replication_key` stream attribute in the Singer SDK

Enhancements:
- Added a docstring to the `ignore_parent_replication_key` attribute in the core Stream class to provide inline documentation

Documentation:
- Added documentation for the `ignore_parent_replication_key` attribute in the parent streams documentation, explaining its purpose in child stream synchronization

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2955.org.readthedocs.build/en/2955/

<!-- readthedocs-preview meltano-sdk end -->