### PR TITLE
chore: Split ignored warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,8 +171,12 @@ filterwarnings = [
     "ignore:No records were available to test:UserWarning",
     # https://github.com/meltano/sdk/issues/1354
     "ignore:The function singer_sdk.testing.get_standard_tap_tests is deprecated:DeprecationWarning",
+    "once:.*singer_sdk._singerlib.*:singer_sdk.helpers._compat.SingerSDKDeprecationWarning",
     # https://github.com/meltano/sdk/issues/2744
-    "default::singer_sdk.helpers._compat.SingerSDKDeprecationWarning",
+    "default:Passing a config file path is deprecated:singer_sdk.helpers._compat.SingerSDKDeprecationWarning",
+    "default:Passing a list of config file paths is deprecated:singer_sdk.helpers._compat.SingerSDKDeprecationWarning",
+    "default:Passing a catalog file path is deprecated:singer_sdk.helpers._compat.SingerSDKDeprecationWarning",
+    "default:Passing a state file path is deprecated:singer_sdk.helpers._compat.SingerSDKDeprecationWarning",
     # TODO: Address this SQLite warning in Python 3.13+
     "ignore::ResourceWarning",
 ]


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Modify warning filter settings to provide more granular control over deprecation warnings in the project

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2963.org.readthedocs.build/en/2963/

<!-- readthedocs-preview meltano-sdk end -->