### PR TITLE
fix: `AttributeError: object has no attribute '_requests_session'` when accessing public property during stream initialisation

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -48,7 +48,7 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
     """Abstract base class for HTTP streams."""
 
     _page_size: int = DEFAULT_PAGE_SIZE
-    _requests_session: requests.Session | None
+    _requests_session: requests.Session | None = None
 
     #: Response code reference for rate limit retries
     extra_retry_statuses: t.Sequence[int] = [HTTPStatus.TOO_MANY_REQUESTS]

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -97,11 +97,11 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
             path: URL path for this entity stream.
             http_method: HTTP method to use for requests.
         """
-        super().__init__(name=name, schema=schema, tap=tap)
         if path:
             self.path = path
-        self._http_headers: dict = {"User-Agent": self.user_agent}
         self._http_method = http_method
+        self._requests_session = requests.Session()
+        super().__init__(name=name, schema=schema, tap=tap)
 
     @staticmethod
     def _url_encode(val: str | datetime | bool | int | list[str]) -> str:  # noqa: FBT001
@@ -136,6 +136,20 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
         return url
 
     # HTTP Request functions
+
+    @property
+    def http_headers(self) -> dict:
+        """Return headers dict to be used for HTTP requests.
+
+        If an authenticator is also specified, the authenticator's headers will be
+        combined with `http_headers` when making HTTP requests.
+
+        Returns:
+            Dictionary of HTTP headers to use as a base for every request.
+        """
+        return {
+            "User-Agent": self.user_agent,
+        }
 
     @property
     def http_method(self) -> str:
@@ -577,18 +591,6 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
             next_page_token: Token, page number or any request argument to request the
                 next page of data.
         """
-
-    @property
-    def http_headers(self) -> dict:
-        """Return headers dict to be used for HTTP requests.
-
-        If an authenticator is also specified, the authenticator's headers will be
-        combined with `http_headers` when making HTTP requests.
-
-        Returns:
-            Dictionary of HTTP headers to use as a base for every request.
-        """
-        return self._http_headers
 
     @property
     def timeout(self) -> int:

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -48,7 +48,7 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
     """Abstract base class for HTTP streams."""
 
     _page_size: int = DEFAULT_PAGE_SIZE
-    _requests_session: requests.Session | None = None
+    _requests_session: requests.Session | None
 
     #: Response code reference for rate limit retries
     extra_retry_statuses: t.Sequence[int] = [HTTPStatus.TOO_MANY_REQUESTS]

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -102,7 +102,6 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
             self.path = path
         self._http_headers: dict = {"User-Agent": self.user_agent}
         self._http_method = http_method
-        self._requests_session = requests.Session()
 
     @staticmethod
     def _url_encode(val: str | datetime | bool | int | list[str]) -> str:  # noqa: FBT001


### PR DESCRIPTION
Resolves an issue when trying to initialise a stream with a dynamic schema that accesses `requests_session`:

```py
class DynamicStream(RESTStream):
    """Dynamic stream."""

    name = "dynamic"

    @override
    @cached_property
    def schema(self):
        response = self.requests_session.get(...)
        # ...

```

```
  File "/home/reuben/Documents/taps/tap-dynamic-stream-test/.venv/lib/python3.9/site-packages/singer_sdk/tap_base.py", line 381, in load_streams
    for stream in self.discover_streams():
  File "/home/reuben/Documents/taps/tap-dynamic-stream-test/tap_dynamic_stream_test/tap.py", line 55, in discover_streams
    streams.DynamicStream(self),
  File "/home/reuben/Documents/taps/tap-dynamic-stream-test/.venv/lib/python3.9/site-packages/singer_sdk/streams/rest.py", line 783, in __init__
    super().__init__(tap, name, schema, path, http_method=http_method)
  File "/home/reuben/Documents/taps/tap-dynamic-stream-test/.venv/lib/python3.9/site-packages/singer_sdk/streams/rest.py", line 100, in __init__
    super().__init__(name=name, schema=schema, tap=tap)
  File "/home/reuben/Documents/taps/tap-dynamic-stream-test/.venv/lib/python3.9/site-packages/singer_sdk/streams/core.py", line 182, in __init__
    if not self.schema:
  File "/home/linuxbrew/.linuxbrew/opt/python@3.9/lib/python3.9/functools.py", line 993, in __get__
    val = self.func(instance)
  File "/home/reuben/Documents/taps/tap-dynamic-stream-test/tap_dynamic_stream_test/streams.py", line 23, in schema
    response = self.requests_session.get(...)
  File "/home/reuben/Documents/taps/tap-dynamic-stream-test/.venv/lib/python3.9/site-packages/singer_sdk/streams/rest.py", line 173, in requests_session
    if not self._requests_session:
AttributeError: 'DynamicStream' object has no attribute '_requests_session'
```

https://github.com/meltano/sdk/blob/6a25f40bbab7156b335233737b0c6a39df38272b/singer_sdk/streams/rest.py#L173

---

`schema` is accessed during `Stream.__init__` https://github.com/meltano/sdk/blob/6a25f40bbab7156b335233737b0c6a39df38272b/singer_sdk/streams/core.py#L189

notably before `_requests_session` is itself initialised in `RESTStream.__init__` (i.e. after the `super().__init__` call)
https://github.com/meltano/sdk/blob/6a25f40bbab7156b335233737b0c6a39df38272b/singer_sdk/streams/rest.py#L100-L105

## Summary by Sourcery

Fix initialization of requests session in REST streams to prevent AttributeError during schema loading

Bug Fixes:
- Resolve an AttributeError that occurs when accessing `requests_session` during stream initialization by setting a default `None` value for `_requests_session`

Enhancements:
- Modify the initialization of `_requests_session` to ensure it is available before being accessed during stream setup

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2965.org.readthedocs.build/en/2965/

<!-- readthedocs-preview meltano-sdk end -->