### PR TITLE
packaging: Add a `fallback-version` for hatch vcs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ benchmark = [
 ]
 
 [tool.hatch.version]
+fallback-version = "0.0.0"
 source = "vcs"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Configure a fallback version of '0.0.0' in the project's pyproject.toml to ensure version resolution when VCS information is unavailable

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2966.org.readthedocs.build/en/2966/

<!-- readthedocs-preview meltano-sdk end -->