### PR TITLE
fix: Consider `oneOf` schemas when checking for `date` and `datetime` types

### DIFF
--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -148,6 +148,8 @@ def is_datetime_type(type_dict: dict) -> bool:
         return any(is_datetime_type(type_dict) for type_dict in type_dict["anyOf"])
     if "allOf" in type_dict:
         return all(is_datetime_type(type_dict) for type_dict in type_dict["allOf"])
+    if "oneOf" in type_dict:
+        return any(is_datetime_type(option) for option in type_dict["oneOf"])
     if "type" in type_dict:
         return type_dict.get("format") == "date-time"
     msg = f"Could not detect type of replication key using schema '{type_dict}'"
@@ -175,6 +177,8 @@ def is_date_or_datetime_type(type_dict: dict) -> bool:
         return all(
             is_date_or_datetime_type(type_dict) for type_dict in type_dict["allOf"]
         )
+    if "oneOf" in type_dict:
+        return any(is_date_or_datetime_type(option) for option in type_dict["oneOf"])
 
     if "type" in type_dict:
         return type_dict.get("format") in {"date", "date-time"}

--- a/tests/core/test_jsonschema_helpers.py
+++ b/tests/core/test_jsonschema_helpers.py
@@ -1061,6 +1061,11 @@ def test_schema_dependencies():
             True,
             id="oneof_datetime",
         ),
+        pytest.param(
+            {"oneOf": [{"type": "string"}, {"type": "null"}]},
+            False,
+            id="oneof_string_or_null",
+        ),
     ],
 )
 def test_is_datetime_type(schema, expected):

--- a/tests/core/test_jsonschema_helpers.py
+++ b/tests/core/test_jsonschema_helpers.py
@@ -1023,33 +1023,107 @@ def test_schema_dependencies():
     )
 
 
-def test_is_datetime_type():
-    assert is_datetime_type({"type": "string", "format": "date-time"})
-    assert not is_datetime_type({"type": "string"})
+@pytest.mark.parametrize(
+    "schema,expected",
+    [
+        pytest.param(
+            {"type": "string", "format": "date-time"},
+            True,
+            id="datetime_type",
+        ),
+        pytest.param(
+            {"type": "string"},
+            False,
+            id="plain_string_type",
+        ),
+        pytest.param(
+            {"anyOf": [{"type": "string", "format": "date-time"}]},
+            True,
+            id="anyof_datetime",
+        ),
+        pytest.param(
+            {"anyOf": [{"type": "string"}]},
+            False,
+            id="anyof_string",
+        ),
+        pytest.param(
+            {"allOf": [{"type": "string", "format": "date-time"}]},
+            True,
+            id="allof_datetime",
+        ),
+        pytest.param(
+            {"allOf": [{"type": "string"}]},
+            False,
+            id="allof_string",
+        ),
+        pytest.param(
+            {"oneOf": [{"type": "string", "format": "date-time"}, {"type": "null"}]},
+            True,
+            id="oneof_datetime",
+        ),
+    ],
+)
+def test_is_datetime_type(schema, expected):
+    assert is_datetime_type(schema) == expected
 
-    assert is_datetime_type({"anyOf": [{"type": "string", "format": "date-time"}]})
-    assert not is_datetime_type({"anyOf": [{"type": "string"}]})
 
-    assert is_datetime_type({"allOf": [{"type": "string", "format": "date-time"}]})
-    assert not is_datetime_type({"allOf": [{"type": "string"}]})
-
-
-def test_is_date_or_datetime_type():
-    assert is_date_or_datetime_type({"type": "string", "format": "date"})
-    assert is_date_or_datetime_type({"type": "string", "format": "date-time"})
-    assert not is_date_or_datetime_type({"type": "string"})
-
-    assert is_date_or_datetime_type(
-        {"anyOf": [{"type": "string", "format": "date-time"}]},
-    )
-    assert is_date_or_datetime_type({"anyOf": [{"type": "string", "format": "date"}]})
-    assert not is_date_or_datetime_type({"anyOf": [{"type": "string"}]})
-
-    assert is_date_or_datetime_type(
-        {"allOf": [{"type": "string", "format": "date-time"}]},
-    )
-    assert is_date_or_datetime_type({"allOf": [{"type": "string", "format": "date"}]})
-    assert not is_date_or_datetime_type({"allOf": [{"type": "string"}]})
+@pytest.mark.parametrize(
+    "schema,expected",
+    [
+        pytest.param(
+            {"type": "string", "format": "date"},
+            True,
+            id="date_type",
+        ),
+        pytest.param(
+            {"type": "string", "format": "date-time"},
+            True,
+            id="datetime_type",
+        ),
+        pytest.param(
+            {"type": "string"},
+            False,
+            id="plain_string_type",
+        ),
+        pytest.param(
+            {"anyOf": [{"type": "string", "format": "date-time"}]},
+            True,
+            id="anyof_datetime",
+        ),
+        pytest.param(
+            {"anyOf": [{"type": "string", "format": "date"}]},
+            True,
+            id="anyof_date",
+        ),
+        pytest.param(
+            {"anyOf": [{"type": "string"}]},
+            False,
+            id="anyof_string",
+        ),
+        pytest.param(
+            {"allOf": [{"type": "string", "format": "date-time"}]},
+            True,
+            id="allof_datetime",
+        ),
+        pytest.param(
+            {"allOf": [{"type": "string", "format": "date"}]},
+            True,
+            id="allof_date",
+        ),
+        pytest.param(
+            {"allOf": [{"type": "string"}]},
+            False,
+            id="allof_string",
+        ),
+        pytest.param(
+            {"oneOf": [{"type": "string", "format": "date-time"}, {"type": "null"}]},
+            True,
+            id="oneof_datetime",
+        ),
+    ],
+)
+def test_is_date_or_datetime_type(schema, expected):
+    assert is_date_or_datetime_type(schema) == expected
 
 
 def test_is_string_array_type():


### PR DESCRIPTION
## Summary by Sourcery

Enhance type checking for date and datetime schemas to support `oneOf` schema compositions

Bug Fixes:
- Improve type detection for complex JSON schemas that use `oneOf` composition, ensuring correct identification of date and datetime types

Enhancements:
- Extend type checking functions to handle `oneOf` schema compositions
- Improve type detection robustness for complex schema definitions

Tests:
- Refactor tests for `is_datetime_type` and `is_date_or_datetime_type` to use parametrized testing with comprehensive test cases
- Add test cases for `oneOf` schema compositions to verify type detection

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2970.org.readthedocs.build/en/2970/

<!-- readthedocs-preview meltano-sdk end -->