### PR TITLE
fix: Recognize `oneOf` fields in Singer schema helpers

### DIFF
--- a/singer_sdk/singerlib/schema.py
+++ b/singer_sdk/singerlib/schema.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import typing as t
-from dataclasses import KW_ONLY, dataclass
+from dataclasses import dataclass
 
 from referencing import Registry
 from referencing.jsonschema import DRAFT202012
@@ -90,10 +90,11 @@ class Schema:
     # JSON Schema extensions
     x_sql_datatype: str | None = None
 
-    _: KW_ONLY
-
     deprecated: bool | None = None
     oneOf: t.Any | None = None  # noqa: N815
+
+    # TODO: Use dataclass.KW_ONLY when Python 3.9 support is dropped
+    # _: KW_ONLY  # noqa: ERA001
 
     def to_dict(self) -> dict[str, t.Any]:
         """Return the raw JSON Schema as a (possibly nested) dict.

--- a/singer_sdk/singerlib/schema.py
+++ b/singer_sdk/singerlib/schema.py
@@ -36,12 +36,14 @@ STANDARD_KEYS = [
     "pattern",
     "contentMediaType",
     "contentEncoding",
+    "deprecated",
     # These are NOT simple keys (they can contain schemas themselves). We could
     # consider adding extra handling to them.
     "additionalProperties",
     "anyOf",
     "patternProperties",
     "allOf",
+    "oneOf",
     # JSON Schema extensions
     "x-sql-datatype",
 ]
@@ -76,6 +78,7 @@ class Schema:
     minLength: int | None = None  # noqa: N815
     anyOf: t.Any | None = None  # noqa: N815
     allOf: t.Any | None = None  # noqa: N815
+    oneOf: t.Any | None = None  # noqa: N815
     format: str | None = None
     additionalProperties: t.Any | None = None  # noqa: N815
     patternProperties: t.Any | None = None  # noqa: N815
@@ -85,7 +88,7 @@ class Schema:
     pattern: str | None = None
     contentMediaType: str | None = None  # noqa: N815
     contentEncoding: str | None = None  # noqa: N815
-
+    deprecated: bool | None = None
     # JSON Schema extensions
     x_sql_datatype: str | None = None
 
@@ -151,10 +154,22 @@ class Schema:
             ...             "minimum": 0,
             ...             "x-sql-datatype": "smallint",
             ...         },
+            ...         "deprecatedField": {
+            ...             "type": "string",
+            ...             "deprecated": True,
+            ...         },
+            ...         "price": {
+            ...             "oneOf": [
+            ...                 {"type": "number", "deprecated": True},
+            ...                 {"type": "null"},
+            ...             ],
+            ...         },
             ...     },
             ...     "required": ["firstName", "lastName"],
             ... }
             >>> schema = Schema.from_dict(data)
+            >>> schema.schema
+            'http://json-schema.org/draft/2020-12/schema'
             >>> schema.title
             'Person'
             >>> schema.properties["firstName"].description
@@ -163,8 +178,10 @@ class Schema:
             0
             >>> schema.properties["age"].x_sql_datatype
             'smallint'
-            >>> schema.schema
-            'http://json-schema.org/draft/2020-12/schema'
+            >>> schema.properties["deprecatedField"].deprecated
+            True
+            >>> schema.properties["price"].oneOf[0]["deprecated"]
+            True
         """  # noqa: E501
         kwargs = schema_defaults.copy()
         properties = data.get("properties")

--- a/singer_sdk/singerlib/schema.py
+++ b/singer_sdk/singerlib/schema.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import typing as t
-from dataclasses import dataclass
+from dataclasses import KW_ONLY, dataclass
 
 from referencing import Registry
 from referencing.jsonschema import DRAFT202012
@@ -78,7 +78,6 @@ class Schema:
     minLength: int | None = None  # noqa: N815
     anyOf: t.Any | None = None  # noqa: N815
     allOf: t.Any | None = None  # noqa: N815
-    oneOf: t.Any | None = None  # noqa: N815
     format: str | None = None
     additionalProperties: t.Any | None = None  # noqa: N815
     patternProperties: t.Any | None = None  # noqa: N815
@@ -88,9 +87,13 @@ class Schema:
     pattern: str | None = None
     contentMediaType: str | None = None  # noqa: N815
     contentEncoding: str | None = None  # noqa: N815
-    deprecated: bool | None = None
     # JSON Schema extensions
     x_sql_datatype: str | None = None
+
+    _: KW_ONLY
+
+    deprecated: bool | None = None
+    oneOf: t.Any | None = None  # noqa: N815
 
     def to_dict(self) -> dict[str, t.Any]:
         """Return the raw JSON Schema as a (possibly nested) dict.

--- a/singer_sdk/testing/tap_tests.py
+++ b/singer_sdk/testing/tap_tests.py
@@ -243,7 +243,7 @@ class AttributeIsDateTimeTest(AttributeTestTemplate):
         Returns:
             True if this test is applicable, False if not.
         """
-        return bool(th.is_date_or_datetime_type(property_schema))
+        return th.is_date_or_datetime_type(property_schema)
 
 
 class AttributeIsBooleanTest(AttributeTestTemplate):

--- a/tests/core/test_jsonschema_helpers.py
+++ b/tests/core/test_jsonschema_helpers.py
@@ -1125,6 +1125,21 @@ def test_is_datetime_type(schema, expected):
             True,
             id="oneof_datetime",
         ),
+        pytest.param(
+            {
+                "oneOf": [
+                    {"type": "null"},
+                    {
+                        "oneOf": [
+                            {"type": "string", "format": "date-time"},
+                            {"type": "string"},
+                        ],
+                    },
+                ],
+            },
+            True,
+            id="nested_oneof_datetime",
+        ),
     ],
 )
 def test_is_date_or_datetime_type(schema, expected):

--- a/tests/core/test_mapper.py
+++ b/tests/core/test_mapper.py
@@ -22,7 +22,6 @@ from singer_sdk.tap_base import Tap
 from singer_sdk.typing import (
     ArrayType,
     BooleanType,
-    CustomType,
     DateTimeType,
     IntegerType,
     NumberType,
@@ -422,7 +421,7 @@ def wildcard_schemas():
                 ArrayType(
                     ObjectType(
                         Property("id", IntegerType),
-                        Property("value", CustomType({})),
+                        Property("value", OneOf(StringType, IntegerType, BooleanType)),
                     ),
                 ),
             ),

--- a/tests/singerlib/test_schema.py
+++ b/tests/singerlib/test_schema.py
@@ -269,22 +269,101 @@ def test_schema_from_dict(pydict, expected):
                     {"$ref": "references.json#/definitions/first_type"},
                     {"$ref": "references.json#/definitions/second_type"},
                 ],
+                "title": "A Title",
             },
             {
                 "references.json": {
                     "definitions": {
-                        "first_type": {"type": "string"},
-                        "second_type": {"type": "integer"},
+                        "first_type": {"type": "string", "title": "First Type"},
+                        "second_type": {"type": "integer", "title": "Second Type"},
                     }
                 },
             },
             {
                 "oneOf": [
-                    {"type": "string"},
-                    {"type": "integer"},
-                ]
+                    {"type": "string", "title": "First Type"},
+                    {"type": "integer", "title": "Second Type"},
+                ],
+                "title": "A Title",
             },
             id="resolve_schema_one_of",
+        ),
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {
+                    "product_price": {
+                        "oneOf": [
+                            {"$ref": "components#/schemas/LegacyProductPrice"},
+                            {"$ref": "components#/schemas/ProductPrice"},
+                        ],
+                        "title": "Product Price",
+                    },
+                },
+            },
+            {
+                "components": {
+                    "schemas": {
+                        "LegacyProductPrice": {
+                            "type": "object",
+                            "properties": {"price": {"type": "number"}},
+                            "title": "Legacy Product Price",
+                        },
+                        "ProductPrice": {
+                            "oneOf": [
+                                {
+                                    "$ref": "components#/schemas/ProductPriceFixed",
+                                },
+                                {
+                                    "$ref": "components#/schemas/ProductPriceFree",
+                                },
+                            ],
+                        },
+                        "ProductPriceFixed": {
+                            "type": "object",
+                            "properties": {"price": {"type": "number"}},
+                            "title": "Product Price Fixed",
+                        },
+                        "ProductPriceFree": {
+                            "type": "object",
+                            "properties": {"price": {"type": "number", "const": 0}},
+                            "title": "Product Price Free",
+                        },
+                    }
+                },
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "product_price": {
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "properties": {"price": {"type": "number"}},
+                                "title": "Legacy Product Price",
+                            },
+                            {
+                                "oneOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {"price": {"type": "number"}},
+                                        "title": "Product Price Fixed",
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "price": {"type": "number", "const": 0}
+                                        },
+                                        "title": "Product Price Free",
+                                    },
+                                ],
+                            },
+                        ],
+                        "title": "Product Price",
+                    },
+                },
+            },
+            id="resolve_nested_one_of",
         ),
     ],
 )


### PR DESCRIPTION
## Summary by Sourcery

Enhance Singer schema helpers to recognize and handle `oneOf` fields more comprehensively, including support for nested `oneOf` schemas and additional schema properties.

New Features:
- Add support for nested `oneOf` schemas in JSON schema validation and type checking
- Introduce handling of `oneOf` fields in schema resolution and type detection

Enhancements:
- Extend schema parsing to support additional JSON schema properties like `deprecated`
- Improve schema reference resolution for complex `oneOf` schemas

Tests:
- Add test cases for resolving complex `oneOf` schemas with nested references
- Expand test coverage for date and datetime type detection with nested `oneOf` schemas