### PR TITLE
fix: Do not log a warning if `null` cannot be appended to schema types

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/{{cookiecutter.library_name}}/mapper.py
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/{{cookiecutter.library_name}}/mapper.py
@@ -22,7 +22,7 @@ class {{ cookiecutter.name }}Mapper(InlineMapper):
         # TODO: Replace or remove this example config based on your needs
         th.Property(
             "example_config",
-            th.StringType,
+            th.StringType(nullable=False),
             title="Example Configuration",
             description="An example config, replace or remove based on your needs.",
         ),

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/tap.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/tap.py
@@ -28,7 +28,7 @@ class Tap{{ cookiecutter.source_name }}({{ 'SQL' if cookiecutter.stream_type == 
     config_jsonschema = th.PropertiesList(
         th.Property(
             "auth_token",
-            th.StringType,
+            th.StringType(nullable=False),
             required=True,
             secret=True,  # Flag config as protected.
             title="Auth Token",
@@ -36,19 +36,19 @@ class Tap{{ cookiecutter.source_name }}({{ 'SQL' if cookiecutter.stream_type == 
         ),
         th.Property(
             "project_ids",
-            th.ArrayType(th.StringType),
+            th.ArrayType(th.StringType(nullable=False), nullable=False),
             required=True,
             title="Project IDs",
             description="Project IDs to replicate",
         ),
         th.Property(
             "start_date",
-            th.DateTimeType,
+            th.DateTimeType(nullable=True),
             description="The earliest record date to sync",
         ),
         th.Property(
             "api_url",
-            th.StringType,
+            th.StringType(nullable=False),
             title="API URL",
             default="https://api.mysample.com",
             description="The url for the API service",
@@ -56,7 +56,7 @@ class Tap{{ cookiecutter.source_name }}({{ 'SQL' if cookiecutter.stream_type == 
         {%- if cookiecutter.stream_type in ("GraphQL", "REST") %}
         th.Property(
             "user_agent",
-            th.StringType,
+            th.StringType(nullable=True),
             description=(
                 "A custom User-Agent header to send with each request. Default is "
                 "'<tap_name>/<tap_version>'"

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/target.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/target.py
@@ -21,7 +21,7 @@ class Target{{ cookiecutter.destination_name }}({{ target_class }}):
         {%- if cookiecutter.serialization_method == "SQL" %}
         th.Property(
             "sqlalchemy_url",
-            th.StringType,
+            th.StringType(nullable=False),
             secret=True,  # Flag config as protected.
             title="SQLAlchemy URL",
             description="SQLAlchemy connection string",
@@ -29,20 +29,21 @@ class Target{{ cookiecutter.destination_name }}({{ target_class }}):
         {%- else %}
         th.Property(
             "filepath",
-            th.StringType,
+            th.StringType(nullable=False),
             title="Output File Path",
             description="The path to the target output file",
         ),
         th.Property(
             "file_naming_scheme",
-            th.StringType,
+            th.StringType(nullable=False),
             title="File Naming Scheme",
             description="The scheme with which output files will be named",
         ),
         th.Property(
             "auth_token",
-            th.StringType,
+            th.StringType(nullable=False),
             secret=True,  # Flag config as protected.
+            required=True,
             title="Auth Token",
             description="The path to the target output file",
         ),

--- a/docs/code_samples.md
+++ b/docs/code_samples.md
@@ -131,7 +131,7 @@ class ParquetStream(Stream):
         properties: List[th.Property] = []
         for header in FAKECSV.split("\n")[0].split(","):
             # Assume string type for all fields
-            properties.append(th.Property(header, th.StringType()))
+            properties.append(th.Property(header, th.StringType(nullable=True)))
         return th.PropertiesList(*properties).to_dict()
 ```
 

--- a/docs/guides/config-schema.md
+++ b/docs/guides/config-schema.md
@@ -15,9 +15,9 @@ class MyTap(Tap):
     name = "my-tap"
 
     config_jsonschema = th.PropertiesList(
-        th.Property("api_key", th.StringType, required=True, title="API Key"),
-        th.Property("base_url", th.StringType, default="https://api.example.com", title="Base URL"),
-        th.Property("start_date", th.DateTimeType, title="Start Date"),
+        th.Property("api_key", th.StringType(nullable=False), required=True, title="API Key"),
+        th.Property("base_url", th.StringType(nullable=True), default="https://api.example.com", title="Base URL"),
+        th.Property("start_date", th.DateTimeType(nullable=True), title="Start Date"),
     ).to_dict()
 ```
 

--- a/docs/incremental_replication.md
+++ b/docs/incremental_replication.md
@@ -15,7 +15,7 @@ class CommentsStream(RESTStream):
     is_sorted = True
 
     schema = th.PropertiesList(
-        th.Property("date_gmt", th.DateTimeType, description="date"),
+        th.Property("date_gmt", th.DateTimeType(nullable=True), description="date"),
     ).to_dict()
 
     def get_url_params(self, context, next_page_token):

--- a/docs/incremental_replication.md
+++ b/docs/incremental_replication.md
@@ -15,7 +15,7 @@ class CommentsStream(RESTStream):
     is_sorted = True
 
     schema = th.PropertiesList(
-        th.Property("date_gmt", th.DateTimeType(nullable=True), description="date"),
+        th.Property("date_gmt", th.DateTimeType(nullable=True), description="Date"),
     ).to_dict()
 
     def get_url_params(self, context, next_page_token):

--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -72,11 +72,6 @@ def append_type(type_dict: dict, new_type: str) -> dict:
             result["type"] = [*type_array, new_type]
         return result
 
-    logger.warning(
-        "Could not append type because the JSON schema for the dictionary "
-        "`%s` appears to be invalid.",
-        type_dict,
-    )
     return result
 
 

--- a/tests/core/test_jsonschema_helpers.py
+++ b/tests/core/test_jsonschema_helpers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 import typing as t
-from logging import WARNING
 from textwrap import dedent
 
 import pytest
@@ -167,25 +166,19 @@ def test_to_json():
     )
 
 
-def test_any_type(caplog: pytest.LogCaptureFixture):
+def test_any_type():
     schema = PropertiesList(
         Property("any_type", AnyType, description="Can be anything"),
     )
-    with caplog.at_level(WARNING):
-        assert schema.to_dict() == {
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "type": "object",
-            "properties": {
-                "any_type": {
-                    "description": "Can be anything",
-                },
+    assert schema.to_dict() == {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "any_type": {
+                "description": "Can be anything",
             },
-        }
-        assert caplog.records[0].levelname == "WARNING"
-        assert caplog.records[0].message == (
-            "Could not append type because the JSON schema for the dictionary `{}` "
-            "appears to be invalid."
-        )
+        },
+    }
 
 
 def test_nested_complex_objects():


### PR DESCRIPTION
## Related

- Closes https://github.com/meltano/sdk/issues/2519
- https://github.com/meltano/sdk/pull/2488

## Summary by Sourcery

Remove warning log when `null` cannot be appended to schema types and update type definitions to explicitly handle nullability

Bug Fixes:
- Eliminate unnecessary warning log when processing JSON schema types that cannot have `null` appended

Enhancements:
- Update type definitions to explicitly specify nullability for various configuration and schema properties

Tests:
- Modify test case for `any_type` to remove warning log capture