### PR TITLE
fix: Update cookiecutter templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/dependabot.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/dependabot.yml
@@ -20,16 +20,6 @@ updates:
         update-types:
           - "patch"
     versioning-strategy: increase-if-necessary
-  - package-ecosystem: pip
-    directory: "/.github/workflows"
-    schedule:
-      interval: weekly
-    commit-message:
-      prefix: "ci: "
-    groups:
-      ci:
-        patterns:
-          - "*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
@@ -20,14 +20,14 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.32.1
+  rev: 0.33.0
   hooks:
   - id: check-dependabot
   - id: check-github-workflows
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.2
+  rev: v0.11.5
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
@@ -39,7 +39,7 @@ repos:
   - id: mypy
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.6.10
+  rev: 0.6.14
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/dependabot.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/dependabot.yml
@@ -20,16 +20,6 @@ updates:
         update-types:
           - "patch"
     versioning-strategy: increase-if-necessary
-  - package-ecosystem: pip
-    directory: "/.github/workflows"
-    schedule:
-      interval: weekly
-    commit-message:
-      prefix: "ci: "
-    groups:
-      ci:
-        patterns:
-          - "*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
@@ -20,14 +20,14 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.32.1
+  rev: 0.33.0
   hooks:
   - id: check-dependabot
   - id: check-github-workflows
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.2
+  rev: v0.11.5
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
@@ -45,7 +45,7 @@ repos:
     {%- endif %}
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.6.10
+  rev: 0.6.14
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/dependabot.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/dependabot.yml
@@ -20,16 +20,6 @@ updates:
         update-types:
           - "patch"
     versioning-strategy: increase-if-necessary
-  - package-ecosystem: pip
-    directory: "/.github/workflows"
-    schedule:
-      interval: weekly
-    commit-message:
-      prefix: "ci: "
-    groups:
-      ci:
-        patterns:
-          - "*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
@@ -20,14 +20,14 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.32.1
+  rev: 0.33.0
   hooks:
   - id: check-dependabot
   - id: check-github-workflows
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.2
+  rev: v0.11.5
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
@@ -45,7 +45,7 @@ repos:
     {%- endif %}
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.6.10
+  rev: 0.6.14
   hooks:
   - id: uv-lock
   - id: uv-sync


### PR DESCRIPTION
## Summary by Sourcery

Update pre-commit configuration and Dependabot settings in cookiecutter templates

Enhancements:
- Update pre-commit hook versions for check-jsonschema, ruff, and uv-pre-commit across mapper, tap, and target templates

CI:
- Remove pip-based workflow updates from Dependabot configuration in mapper, tap, and target templates