### PR TITLE
fix: Restore private `_http_headers` attribute of REST streams

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -99,6 +99,7 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
         """
         if path:
             self.path = path
+        self._http_headers: dict[str, str] = {}
         self._http_method = http_method
         self._requests_session = requests.Session()
         super().__init__(name=name, schema=schema, tap=tap)
@@ -149,6 +150,7 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
         """
         return {
             "User-Agent": self.user_agent,
+            **self._http_headers,
         }
 
     @property


### PR DESCRIPTION
## Related

- https://github.com/meltano/sdk/pull/2965
- https://github.com/MeltanoLabs/tap-github/issues/391
- https://github.com/MeltanoLabs/tap-github/pull/393

## Summary by Sourcery

Bug Fixes:
- Reintroduced the `_http_headers` attribute in the REST stream initialization to enable custom header configuration