### PR TITLE
chore: Update templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.5
+  rev: v0.11.6
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -32,9 +32,9 @@ license-files = [ "LICENSE" ]
 requires-python = ">=3.9"
 dependencies = [
     {%- if cookiecutter.faker_extra %}
-    "singer-sdk[faker]~=0.44.3",
+    "singer-sdk[faker]~=0.45.10",
     {%- else %}
-    "singer-sdk~=0.44.3",
+    "singer-sdk~=0.45.10",
     {%- endif %}
 ]
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.5
+  rev: v0.11.6
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -35,9 +35,9 @@ license-files = [ "LICENSE" ]
 requires-python = ">=3.9"
 dependencies = [
     {%- if extras %}
-    "singer-sdk[{{ extras|join(',') }}]~=0.44.3",
+    "singer-sdk[{{ extras|join(',') }}]~=0.45.10",
     {%- else %}
-    "singer-sdk~=0.44.3",
+    "singer-sdk~=0.45.10",
     {%- endif %}
     {%- if cookiecutter.stream_type in ["REST", "GraphQL"] %}
     "requests~=2.32.3",

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.5
+  rev: v0.11.6
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -31,9 +31,9 @@ license-files = [ "LICENSE" ]
 requires-python = ">=3.9"
 dependencies = [
     {%- if cookiecutter.faker_extra %}
-    "singer-sdk[faker]~=0.44.3",
+    "singer-sdk[faker]~=0.45.10",
     {%- else %}
-    "singer-sdk~=0.44.3",
+    "singer-sdk~=0.45.10",
     {%- endif %}
     {%- if cookiecutter.serialization_method != "SQL" %}
     "requests~=2.32.3",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ copyright = f"{datetime.now().year}, Arch Data, Inc and Contributors"  # noqa: A
 author = "Meltano Core Team and Contributors"
 
 # The full version, including alpha/beta/rc tags
-release = "0.44.3"
+release = "0.45.10"
 
 
 # -- General configuration -------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,9 +200,9 @@ prerelease_offset = 1
 tag_format = "v$major.$minor.$patch$prerelease"
 version_files = [
     "docs/conf.py:^release =",
-    "cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml:singer-sdk",
-    "cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml:singer-sdk",
-    "cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml:singer-sdk",
+    """cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml:^    "singer-sdk""",
+    """cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml:^    "singer-sdk""",
+    """cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml:^    "singer-sdk""",
     ".github/ISSUE_TEMPLATE/bug.yml:^      placeholder:",
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

Update project templates and configurations to use the latest versions of dependencies and tools, including singer-sdk 0.45.10 and ruff 0.11.6.

Enhancements:
- Update version references in pyproject.toml files to use singer-sdk version 0.45.10.

Chores:
- Update pre-commit configuration to use ruff version 0.11.6.

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--2985.org.readthedocs.build/en/2985/

<!-- readthedocs-preview meltano-sdk end -->