### PR TITLE
fix: Add a date to the warning message for removal of `Faker` from stream maps contexts

### DIFF
--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -538,7 +538,9 @@ class CustomStreamMap(StreamMap):
                 )
                 if "Faker" in prop_def:
                     warnings.warn(
-                        "Class 'Faker' is deprecated in stream maps. Use instance methods, like 'fake.seed_instance.'",  # noqa: E501
+                        "Class 'Faker' is deprecated in stream maps and will be "
+                        "removed by August 2025. "
+                        "Use instance methods, like 'fake.seed_instance.'",
                         DeprecationWarning,
                         stacklevel=2,
                     )


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Enhance the deprecation warning for Faker by adding a specific removal date to provide clearer guidance to users