### PR TITLE
fix(targets): Ensure fields with an array of JSON schema types are properly handled by SQL targets

### DIFF
--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -479,7 +479,7 @@ class JSONSchemaToSQL:
 
                 # If we have multiple non-null types, use VARCHAR
                 if len(non_null_types) > 1:
-                    self.handle_multiple_types(non_null_types)
+                    return self.handle_multiple_types(non_null_types)
 
                 # If we have exactly one non-null type, use its handler
                 if len(non_null_types) == 1 and non_null_types[0] in self._type_mapping:

--- a/tests/core/test_connector_sql.py
+++ b/tests/core/test_connector_sql.py
@@ -671,6 +671,11 @@ class TestJSONSchemaToSQL:  # noqa: PLR0904
         "jsonschema_type,expected_type",
         [
             pytest.param(
+                {"type": ["unknown", "null"]},
+                sa.types.VARCHAR,
+                id="unknown",
+            ),
+            pytest.param(
                 {"type": ["array", "object", "boolean", "null"]},
                 sa.types.VARCHAR,
                 id="array-first",

--- a/tests/core/test_connector_sql.py
+++ b/tests/core/test_connector_sql.py
@@ -645,6 +645,24 @@ class TestJSONSchemaToSQL:  # noqa: PLR0904
         result = json_schema_to_sql.to_sql_type(jsonschema_type)
         assert isinstance(result, sa.types.INTEGER)
 
+    def test_anyof_json(self):
+        json_schema_to_sql = JSONSchemaToSQL()
+        json_schema_to_sql.register_type_handler("object", sa.types.JSON)
+        jsonschema_type = {
+            "anyOf": [
+                {"type": "null"},
+                {"type": "object"},
+            ],
+        }
+        result = json_schema_to_sql.to_sql_type(jsonschema_type)
+        assert isinstance(result, sa.types.JSON)
+
+        jsonschema_type = {
+            "type": ["object", "null", "null"],
+        }
+        result = json_schema_to_sql.to_sql_type(jsonschema_type)
+        assert isinstance(result, sa.types.JSON)
+
     def test_anyof_unknown(self, json_schema_to_sql: JSONSchemaToSQL):
         jsonschema_type = {
             "anyOf": [
@@ -670,7 +688,7 @@ class TestJSONSchemaToSQL:  # noqa: PLR0904
             ),
         ],
     )
-    def test_complex(
+    def test_multiple_types(
         self,
         json_schema_to_sql: JSONSchemaToSQL,
         jsonschema_type: dict,
@@ -678,6 +696,22 @@ class TestJSONSchemaToSQL:  # noqa: PLR0904
     ):
         result = json_schema_to_sql.to_sql_type(jsonschema_type)
         assert isinstance(result, expected_type)
+
+    def test_multiple_types_custom_handler(self):
+        class CustomJSONSchemaToSQL(JSONSchemaToSQL):
+            def handle_multiple_types(self, types: list[str]) -> sa.types.TypeEngine:
+                if "object" in types or "array" in types:
+                    return sa.types.JSON()
+                return super().handle_multiple_types(types)
+
+        json_schema_to_sql = CustomJSONSchemaToSQL()
+        jsonschema_type = {"type": ["object", "array", "string", "null"]}
+        result = json_schema_to_sql.to_sql_type(jsonschema_type)
+        assert isinstance(result, sa.types.JSON)
+
+        jsonschema_type = {"type": ["string", "number", "null"]}
+        result = json_schema_to_sql.to_sql_type(jsonschema_type)
+        assert isinstance(result, sa.types.VARCHAR)
 
     def test_unknown_type(self, json_schema_to_sql: JSONSchemaToSQL):
         jsonschema_type = {"cannot": "compute"}

--- a/tests/core/test_connector_sql.py
+++ b/tests/core/test_connector_sql.py
@@ -657,12 +657,6 @@ class TestJSONSchemaToSQL:  # noqa: PLR0904
         result = json_schema_to_sql.to_sql_type(jsonschema_type)
         assert isinstance(result, sa.types.JSON)
 
-        jsonschema_type = {
-            "type": ["object", "null", "null"],
-        }
-        result = json_schema_to_sql.to_sql_type(jsonschema_type)
-        assert isinstance(result, sa.types.JSON)
-
     def test_anyof_unknown(self, json_schema_to_sql: JSONSchemaToSQL):
         jsonschema_type = {
             "anyOf": [


### PR DESCRIPTION
…operly handled by SQL targets

## Summary by Sourcery

Fix SQL type mapping for JSON schemas defining multiple types for a field.

Bug Fixes:
- Ensure the result of the `handle_multiple_types` method is returned when mapping JSON schema types to SQL, correctly handling cases like `type: ["object", "null"]` or `anyOf` definitions.

Tests:
- Add tests to verify correct SQL type mapping (e.g., to JSON) for fields with `anyOf` or an array of types specified in the JSON schema.
- Rename `test_complex` to `test_multiple_types` for clarity.