### PR TITLE
test: Add continuous benchmark for record data type conforming

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,10 +76,12 @@ jobs:
         allow-prereleases: true
 
     - uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
+      with:
+        version: ">=0.6,<0.7"
 
     - name: Install Nox
       run: |
-        uv tool install 'nox[uv]'
+        uv tool install nox
         nox --version
 
     - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -124,10 +126,12 @@ jobs:
         python-version: ${{ env.NOXPYTHON }}
 
     - uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
+      with:
+        version: ">=0.6,<0.7"
 
     - name: Install Nox
       run: |
-        uv tool install 'nox[uv]'
+        uv tool install nox
         nox --version
 
     - name: Run Nox
@@ -156,10 +160,12 @@ jobs:
         merge-multiple: true
 
     - uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
+      with:
+        version: ">=0.6,<0.7"
 
     - name: Install Nox
       run: |
-        uv tool install 'nox[uv]'
+        uv tool install nox
         nox --version
 
     - run: nox --install-only

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -438,7 +438,7 @@ def test_iterate_properties_list():
 
 def test_bench_conform_record_data_types(benchmark: BenchmarkFixture):
     """Run benchmark for conform_record_data_types method."""
-    number_of_runs = 10_000
+    number_of_runs = 1_000
     schema = {
         "type": "object",
         "properties": {

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import decimal
+import itertools
 import logging
 import typing as t
 
@@ -24,6 +25,9 @@ from singer_sdk.typing import (
     append_type,
     to_sql_type,
 )
+
+if t.TYPE_CHECKING:
+    from pytest_benchmark.fixture import BenchmarkFixture
 
 logger = logging.getLogger("log")
 
@@ -430,3 +434,53 @@ def test_iterate_properties_list():
     assert primitive_property in properties_list
     assert object_property in properties_list
     assert list_property in properties_list
+
+
+def test_bench_conform_record_data_types(benchmark: BenchmarkFixture):
+    """Run benchmark for conform_record_data_types method."""
+    number_of_runs = 10_000
+    schema = {
+        "type": "object",
+        "properties": {
+            "id": {"type": "integer"},
+            "created_at": {"type": "string", "format": "date-time"},
+            "count": {"type": "integer"},
+            "amount": {"type": "number"},
+            "is_active": {"type": "boolean"},
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "metadata": {
+                "type": "object",
+                "properties": {
+                    "key": {"type": "string"},
+                    "value": {"type": "string"},
+                },
+            },
+            "nested": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": True,
+            },
+        },
+    }
+    record = {
+        "id": 1,
+        "created_at": "2021-01-01T00:08:00-07:00",
+        "count": 10,
+        "amount": 100.0,
+        "is_active": True,
+        "tags": ["tag1", "tag2"],
+        "metadata": {"key": "value"},
+        "nested": {"key": "value", "deep": {"even_deeper": "value"}},
+    }
+
+    def run_conform_record_data_types():
+        for rec in itertools.repeat(record, number_of_runs):
+            conform_record_data_types(
+                "test_stream",
+                rec,
+                schema,
+                TypeConformanceLevel.RECURSIVE,
+                logger,
+            )
+
+    benchmark(run_conform_record_data_types)

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -460,17 +460,19 @@ def test_bench_conform_record_data_types(benchmark: BenchmarkFixture):
                 "properties": {},
                 "additionalProperties": True,
             },
+            "is_nan": {"type": "number"},
         },
     }
     record = {
         "id": 1,
-        "created_at": "2021-01-01T00:08:00-07:00",
+        "created_at": datetime.datetime(2021, 1, 1, tzinfo=datetime.timezone.utc),
         "count": 10,
         "amount": 100.0,
         "is_active": True,
         "tags": ["tag1", "tag2"],
         "metadata": {"key": "value"},
         "nested": {"key": "value", "deep": {"even_deeper": "value"}},
+        "is_nan": float("nan"),
     }
 
     def run_conform_record_data_types():


### PR DESCRIPTION
## Summary by Sourcery

Add a continuous benchmark test for the conform_record_data_types method to measure its performance with a complex record and schema

Tests:
- Added a benchmark test for conform_record_data_types method using pytest-benchmark
- Created a comprehensive test schema with various data types to stress test the conformance method

Chores:
- Imported type checking for BenchmarkFixture

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3007.org.readthedocs.build/en/3007/

<!-- readthedocs-preview meltano-sdk end -->