### PR TITLE
fix: Fix infinite recursion error when resolving JSON schemas with circular references

### DIFF
--- a/tests/singerlib/test_schema.py
+++ b/tests/singerlib/test_schema.py
@@ -365,6 +365,56 @@ def test_schema_from_dict(pydict, expected):
             },
             id="resolve_nested_one_of",
         ),
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {
+                    "filter": {
+                        "$ref": "components#/schemas/Filter",
+                    },
+                },
+            },
+            {
+                "components": {
+                    "schemas": {
+                        "Filter": {
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "title": "Name",
+                                },
+                                "clauses": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "components#/schemas/Filter",
+                                    },
+                                    "title": "Clauses",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "filter": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "title": "Name",
+                            },
+                            "clauses": {
+                                "type": "array",
+                                "items": {},
+                                "title": "Clauses",
+                            },
+                        },
+                    },
+                },
+            },
+            id="resolve_schema_references_with_circular_references",
+        ),
     ],
 )
 def test_resolve_schema_references(schema, refs, expected):


### PR DESCRIPTION
## Links

- https://json-schema.org/understanding-json-schema/structuring#recursion

## Summary by Sourcery

Enhance schema reference resolution to handle circular references in JSON schemas

Bug Fixes:
- Prevent infinite recursion when resolving schemas with circular references

Enhancements:
- Add support for tracking visited references during schema resolution

Tests:
- Add test case for resolving schemas with circular references

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3009.org.readthedocs.build/en/3009/

<!-- readthedocs-preview meltano-sdk end -->

## Summary by Sourcery

Enhance schema reference resolution to handle circular references in JSON schemas

Bug Fixes:
- Prevent infinite recursion when resolving schemas with circular references

Enhancements:
- Add support for tracking visited references during schema resolution

Tests:
- Add test case for resolving schemas with circular references