### PR TITLE
refactor: use dict instead of `OrderedDict`

### DIFF
--- a/singer_sdk/about.py
+++ b/singer_sdk/about.py
@@ -6,7 +6,6 @@ import abc
 import dataclasses
 import json
 import typing as t
-from collections import OrderedDict
 from textwrap import dedent
 
 from packaging.specifiers import SpecifierSet
@@ -164,17 +163,15 @@ class JSONFormatter(AboutFormatter, format_name="json"):
         Returns:
             A formatted string.
         """
-        data = OrderedDict(
-            [
-                ("name", about_info.name),
-                ("description", about_info.description),
-                ("version", about_info.version),
-                ("sdk_version", about_info.sdk_version),
-                ("supported_python_versions", about_info.supported_python_versions),
-                ("capabilities", [c.value for c in about_info.capabilities]),
-                ("settings", about_info.settings),
-            ],
-        )
+        data = {
+            "name": about_info.name,
+            "description": about_info.description,
+            "version": about_info.version,
+            "sdk_version": about_info.sdk_version,
+            "supported_python_versions": about_info.supported_python_versions,
+            "capabilities": [c.value for c in about_info.capabilities],
+            "settings": about_info.settings,
+        }
         return json.dumps(data, indent=self.indent, default=self.default)
 
 


### PR DESCRIPTION
Starting [with Python 3.7](https://docs.python.org/3.7/whatsnew/3.7.html), "insertion-order preservation nature of [dict](https://docs.python.org/3.7/library/stdtypes.html#typesmapping) objects [has been declared](https://mail.python.org/pipermail/python-dev/2017-December/151283.html) to be an official part of the Python language spec".

## Summary by Sourcery

Enhancements:
- Simplified dictionary creation by using standard dict syntax

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3010.org.readthedocs.build/en/3010/

<!-- readthedocs-preview meltano-sdk end -->

## Summary by Sourcery

Enhancements:
- Simplified dictionary creation by using standard dict syntax