### PR TITLE
fix: Encode `nan`, `inf` and `-inf` values as `null` in Singer stream

### DIFF
--- a/singer_sdk/singerlib/json.py
+++ b/singer_sdk/singerlib/json.py
@@ -59,5 +59,6 @@ def serialize_json(obj: object, **kwargs: t.Any) -> str:
         use_decimal=True,
         default=_default_encoding,
         separators=(",", ":"),
+        ignore_nan=True,
         **kwargs,
     )

--- a/tests/singerlib/encoding/test_simple.py
+++ b/tests/singerlib/encoding/test_simple.py
@@ -106,11 +106,12 @@ def test_write_message():
     )
 
 
-def test_encode_nan_values():
+@pytest.mark.parametrize("float_value", [float("nan"), float("inf"), float("-inf")])
+def test_encode_nan_values(float_value):
     writer = SimpleSingerWriter()
     message = RecordMessage(
         stream="test",
-        record={"id": 1, "name": float("nan")},
+        record={"id": 1, "name": float_value},
     )
     with redirect_stdout(io.StringIO()) as out:
         writer.write_message(message)

--- a/tests/singerlib/encoding/test_simple.py
+++ b/tests/singerlib/encoding/test_simple.py
@@ -104,3 +104,17 @@ def test_write_message():
     assert out.getvalue() == (
         '{"type":"RECORD","stream":"test","record":{"id":1,"name":"test"}}\n'
     )
+
+
+def test_encode_nan_values():
+    writer = SimpleSingerWriter()
+    message = RecordMessage(
+        stream="test",
+        record={"id": 1, "name": float("nan")},
+    )
+    with redirect_stdout(io.StringIO()) as out:
+        writer.write_message(message)
+
+    assert out.getvalue() == (
+        '{"type":"RECORD","stream":"test","record":{"id":1,"name":null}}\n'
+    )


### PR DESCRIPTION
Changes the behavior of JSON serialization for Singer output to convert `nan`, `inf` and `-inf` values to `null` in compliance with the ECMA-262 specification.

## Implementation details

- `simplejson` supports this with the `ignore_nan=True`[^1] parameter.
- `msgspec` already does this by default[^2].

## Related

- Closes #2213

[^1]: https://simplejson.readthedocs.io/en/latest/#simplejson.dumps
[^2]: https://jcristharif.com/msgspec/supported-types.html#float

## Summary by Sourcery

Modify JSON serialization in Singer output to convert special float values (`nan`, `inf`, `-inf`) to `null`

Bug Fixes:
- Ensure proper handling of special float values in JSON serialization

Tests:
- Add test case to verify `nan` values are encoded as `null`

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3019.org.readthedocs.build/en/3019/

<!-- readthedocs-preview meltano-sdk end -->