### PR TITLE
fix(targets): In SQL targets, use stream name as table name instead of splitting by hyphen if `default_target_schema` is speficied

### DIFF
--- a/tests/core/sinks/test_sql_sink.py
+++ b/tests/core/sinks/test_sql_sink.py
@@ -64,3 +64,75 @@ class TestDuckDBSink:
         assert str(stmt) == (
             'INSERT INTO foo (id, col_ts, "table") VALUES (:id, :col_ts, :table)'
         )
+
+    @pytest.mark.parametrize(
+        "stream_name, default_target_schema, expected_table_name, expected_schema_name",
+        [
+            pytest.param(
+                "foo",  # stream_name
+                None,  # default_target_schema
+                "foo",  # expected_table_name
+                None,  # expected_schema_name
+                id="no-default-schema",
+            ),
+            pytest.param(
+                "foo-bar",  # stream_name
+                None,  # default_target_schema
+                "bar",  # expected_table_name
+                "foo",  # expected_schema_name
+                id="no-default-schema-2-part",
+            ),
+            pytest.param(
+                "foo-bar-baz",  # stream_name
+                None,  # default_target_schema
+                "baz",  # expected_table_name
+                "bar",  # expected_schema_name
+                id="no-default-schema-3-part",
+            ),
+            pytest.param(
+                "foo",  # stream_name
+                "test",  # default_target_schema
+                "foo",  # expected_table_name
+                "test",  # expected_schema_name
+                id="default-schema",
+            ),
+            pytest.param(
+                "foo-bar",  # stream_name
+                "test",  # default_target_schema
+                "foo-bar",  # expected_table_name
+                "test",  # expected_schema_name
+                id="default-schema-2-part",
+            ),
+            pytest.param(
+                "foo-bar-baz",  # stream_name
+                "test",  # default_target_schema
+                "foo-bar-baz",  # expected_table_name
+                "test",  # expected_schema_name
+                id="default-schema-3-part",
+            ),
+        ],
+    )
+    def test_table_name(
+        self,
+        schema: dict,
+        stream_name: str,
+        default_target_schema: str | None,
+        expected_table_name: str,
+        expected_schema_name: str,
+    ):
+        target = DuckDBTarget(
+            config={
+                "sqlalchemy_url": "duckdb:///",
+                "default_target_schema": default_target_schema,
+            },
+        )
+
+        sink = DuckDBSink(
+            target,
+            stream_name=stream_name,
+            schema=schema,
+            key_properties=["id"],
+        )
+
+        assert sink.table_name == expected_table_name
+        assert sink.schema_name == expected_schema_name


### PR DESCRIPTION
## Related

- Closes #2909

cc @ReubenFrankel

## Summary by Sourcery

Modify SQL target table naming logic to use the full stream name when a default target schema is specified

New Features:
- Add new test cases to validate table and schema name generation for SQL targets

Bug Fixes:
- Fix table name generation to preserve full stream name when a default target schema is provided

Tests:
- Add comprehensive parametrized test cases for table name and schema name generation in different scenarios

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3020.org.readthedocs.build/en/3020/

<!-- readthedocs-preview meltano-sdk end -->