### PR TITLE
chore: Add `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# chore: Enforce `import typing as t` by configuring `ICN003`
+54222bb2dc1903c0816347952c6a77c30267f30f


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Create .git-blame-ignore-revs file to improve code attribution

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3025.org.readthedocs.build/en/3025/

<!-- readthedocs-preview meltano-sdk end -->