### PR TITLE
docs: Auto-format markdown with `mdformat`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,3 +73,12 @@ repos:
   rev: v2.4.1
   hooks:
   - id: codespell
+
+- repo: https://github.com/executablebooks/mdformat
+  rev: 0.7.22
+  hooks:
+  - id: mdformat
+    exclude: tests/snapshots/about_format/markdown\.snap\.md
+    args: [--extensions, frontmatter]
+    additional_dependencies:
+    - mdformat-frontmatter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,7 +326,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 📦 Packaging changes
 
 - [#2694](https://github.com/meltano/sdk/issues/2694) Removed unused backport `importlib_resources` dependency in tap template
-- [#2664](https://github.com/meltano/sdk/issues/2664) Added a constraint on setuptools <= 70.3.0 to fix incompatibility with some dependencies
+- [#2664](https://github.com/meltano/sdk/issues/2664) Added a constraint on setuptools \<= 70.3.0 to fix incompatibility with some dependencies
 
 ## v0.40.0 (2024-09-02)
 
@@ -1125,11 +1125,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fix
 
-- Fix missing typing-extensions for Python<3.10 (#776)
+- Fix missing typing-extensions for Python\<3.10 (#776)
 
 ## 0.6.0 - (2022-06-30)
-
----
 
 ### New
 
@@ -1151,8 +1149,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.5.0 - (2022-05-19)
 
----
-
 ### New
 
 - Tap and Target SDK: The `--config=ENV` option now also considers environment variables from a
@@ -1172,8 +1168,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.4.9 - (2022-05-12)
 
----
-
 ### New
 
 - Tap SDK: Improved helpers for handling rate limits, backoff and retries ([#137](https://gitlab.com/meltano/sdk/-/issues/137), [#140](https://gitlab.com/meltano/sdk/-/issues/140), [!277](https://gitlab.com/meltano/sdk/-/merge_requests/277)) - _Thanks, **[Fred O'Loughlin](https://gitlab.com/fred-oloughlin-fl)**_!
@@ -1189,15 +1183,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.4.8 - (2022-05-05)
 
----
-
 ### Fixes
 
 - Target SDK: Use `maxLength` in SQL targets for string fields if the schema provides it ([#371](https://gitlab.com/meltano/sdk/-/issues/371), [!284](https://gitlab.com/meltano/sdk/-/merge_requests/284)) - _Thanks, **[Thomas Briggs](https://gitlab.com/tbriggs2)**_!
 
 ## 0.4.7 - (2022-04-28)
-
----
 
 ### Fixes
 
@@ -1208,16 +1198,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.4.6 - (2022-04-21)
 
----
-
 ### Fixes
 
 - Raise more descriptive exceptions when wrapped JSON typing classes needs to be instantiated ([#55](https://gitlab.com/meltano/sdk/-/issues/55), [#360](https://gitlab.com/meltano/sdk/-/issues/360), [!270](https://gitlab.com/meltano/sdk/-/merge_requests/270)).
 - Support JSONPath extensions in `records_jsonpath` and `next_page_token_jsonpath` ([#361](https://gitlab.com/meltano/sdk/-/issues/361), [!271](https://gitlab.com/meltano/sdk/-/merge_requests/271)).
 
 ## 0.4.5 - (2022-04-08)
-
----
 
 ### Fixes
 
@@ -1228,15 +1214,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.4.4 - (2022-03-03)
 
----
-
 ### New
 
 - Define all built-in JSON Schema string formats as separate types ([#336](https://gitlab.com/meltano/sdk/-/issues/336), [!250](https://gitlab.com/meltano/sdk/-/merge_requests/250)) - _Thanks, **[Reuben Frankel](https://gitlab.com/ReubenFrankel)**_!
 
 ## 0.4.3 - (2022-02-18)
-
----
 
 ### New
 
@@ -1248,8 +1230,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.4.2 - (2022-02-04)
 
----
-
 ### New
 
 - Add record and schema flattening in Stream Maps ([!236](https://gitlab.com/meltano/sdk/-/merge_requests/236)),
@@ -1260,16 +1240,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.4.1 - (2022-01-27)
 
----
-
 ### Changes
 
 - Always sync one record per stream when invoking with `--test` or `--test=all` ([#311](https://gitlab.com/meltano/sdk/-/issues/311), [!241](https://gitlab.com/meltano/sdk/-/merge_requests/241))
 - Add `--test=schema` option to emit tap SCHEMA messages only ([!218](https://gitlab.com/meltano/sdk/-/merge_requests/218)) - _Thanks, **[Laurent Savaëte](https://gitlab.com/LaurentS)**_!
 
 ## 0.4.0 - (2022-01-21)
-
----
 
 ### New
 
@@ -1278,8 +1254,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Licence tracking to SDK GitLab Project ([#166](https://gitlab.com/meltano/sdk/-/issues/166), [!237](https://gitlab.com/meltano/sdk/-/merge_requests/237))
 
 ## 0.3.18 - (2022-01-13)
-
----
 
 ### New
 
@@ -1293,8 +1267,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.3.17 - (2021-12-16)
 
----
-
 ### New
 
 - Tap SDK: Add configurable timeout for HTTP requests ([#287](https://gitlab.com/meltano/sdk/-/issues/287), [!217](https://gitlab.com/meltano/sdk/-/merge_requests/217), [!225](https://gitlab.com/meltano/sdk/-/merge_requests/225)) -- _Thanks, **[Josh Lloyd](https://gitlab.com/jlloyd3)**!_
@@ -1306,8 +1278,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.3.16 - (2021-12-09)
 
----
-
 ### Fixes
 
 - Tap SDK: Fix datelike type parsing bug with nested schemas ([#283](https://gitlab.com/meltano/sdk/-/issues/283), [!219](https://gitlab.com/meltano/sdk/-/merge_requests/219))
@@ -1315,16 +1285,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.3.15 - (2021-12-03)
 
----
-
 ### Fixes
 
 - Tap SDK: Fixed mapped `__key_properties__` not being passed to the emitted schema message ([#281](https://gitlab.com/meltano/sdk/-/issues/281), [!209](https://gitlab.com/meltano/sdk/-/merge_requests/209))
 - Tap SDK: Fixed missing schema during development causing sync to fail [#284](https://gitlab.com/meltano/sdk/-/issues/284), [!212](https://gitlab.com/meltano/sdk/-/merge_requests/212) -- _Thanks, **[Fred Reimer](https://gitlab.com/freimer)**!_
 
 ## 0.3.14 - (2021-11-18)
-
----
 
 ### New
 
@@ -1341,8 +1307,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.3.13 - (2021-10-28)
 
----
-
 ### New
 
 - Target SDK: CLI flag for targets to read messages from a file instead of stdin ([#249](https://gitlab.com/meltano/sdk/-/issues/249), [!190](https://gitlab.com/meltano/sdk/-/merge_requests/190)) -- _Thanks, **[Charles Julian Knight](https://gitlab.com/rabidaudio)**!_
@@ -1350,8 +1314,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tap and Target SDK: Create expanded list of capabilities ([#186](https://gitlab.com/meltano/sdk/-/issues/186), [!141](https://gitlab.com/meltano/sdk/-/merge_requests/141))
 
 ## 0.3.12 - (2021-10-21)
-
----
 
 ### Fixes
 
@@ -1361,8 +1323,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tap and Target SDK: Allows `--discover` and `--about` execution without requiring settings validation ([#235](https://gitlab.com/meltano/sdk/-/issues/235), [!188](https://gitlab.com/meltano/sdk/-/merge_requests/188))
 
 ## 0.3.11 - (2021-10-07)
-
----
 
 ### New
 
@@ -1380,15 +1340,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.3.10 - (2021-09-30)
 
----
-
 ### Changes
 
 - Tap and Target SDK: Prevents the leaking of sensitive configuration values when JSON schema validation fails ([!173](https://gitlab.com/meltano/sdk/-/merge_requests/173)) -- _Thanks, **[Kevin Mullins](https://gitlab.com/zyzil)**!_.
 
 ## 0.3.9 - (2021-09-23)
-
----
 
 ### New
 
@@ -1404,16 +1360,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.3.8 - (2021-09-16)
 
----
-
 ### Fixes
 
 - Tap and Target SDK: Resolves `2to3` compatibility issues when installed with `setuptools>=58.0`.
 - Resolve issue preventing repo from being cloned on Windows.
 
 ## 0.3.7 - (2021-09-09)
-
----
 
 ### New
 
@@ -1425,8 +1377,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tap SDK: Changed the signature of `Stream.apply_catalog` to reflect new catalog parsing flow ([#161](https://gitlab.com/meltano/sdk/-/issues/161), [!146](https://gitlab.com/meltano/sdk/-/merge_requests/146))
 
 ## 0.3.6 - (2021-08-26)
-
----
 
 ### New
 
@@ -1446,15 +1396,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.3.5 - (2021-08-17)
 
----
-
 ### Fixes
 
 - Tap SDK: Fixed a bug where not using a catalog file resulted in all streams being selected but all properties being removed from the schema and records (#190, !132)
 
 ## v0.3.4
-
----
 
 ### New
 
@@ -1470,8 +1416,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tap SDK: Fixed a bug where replication key signposts were not correctly applied for streams which defined them (#180, !129)
 
 ## v0.3.3
-
----
 
 ### New
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Taps and targets built on the SDK are automatically compliant with the
 de-facto open source standard for extract and load pipelines.
 </h3>
 
----
+______________________________________________________________________
 
 </br>
 
@@ -45,7 +45,7 @@ de-facto open source standard for extract and load pipelines.
   </a>
 </div>
 
----
+______________________________________________________________________
 
 ## Future-proof extractors and loaders, with less code
 
@@ -56,7 +56,7 @@ capabilities and bug fixes, simply by updating your SDK dependency to the latest
 
 ## Meltano
 
-*Not familiar with Meltano?*  [Meltano](https://docs.meltano.com/getting-started/meltano-at-a-glance) is your CLI for ELT+ that:
+*Not familiar with Meltano?* [Meltano](https://docs.meltano.com/getting-started/meltano-at-a-glance) is your CLI for ELT+ that:
 
 - **Starts simple**: Meltano is pip-installable and comes in a prepackaged docker container, you can have your first ELT pipeline running within minutes.
 - **Has DataOps out-of-the-box**: Meltano provides tools that make DataOps best practices easy to use in every project.
@@ -66,13 +66,14 @@ capabilities and bug fixes, simply by updating your SDK dependency to the latest
 - **Has first class ELT tooling built-in**: Extract data from any data source, load into any target, use inline maps to transform on data on the fly, and test the incoming data, all in one package.
 
 If you want to get started with Meltano, we suggest you:
+
 - head over to the [Installation](https://docs.meltano.com/getting-started/installation)
 - or if you have it installed, go through the [Meltano Tutorial](https://docs.meltano.com/getting-started/part1).
 
 ## Documentation
 
 - See our [online documentation](https://sdk.meltano.com) for instructions on how
-to get started with the SDK.
+  to get started with the SDK.
 
 ## Contributing back to the SDK
 

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/README.md
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/README.md
@@ -86,7 +86,7 @@ uv sync
 ### Create and Run Tests
 
 Create tests within the `tests` subfolder and
-  then run:
+then run:
 
 ```bash
 uv run pytest

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/README.md
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/README.md
@@ -87,7 +87,7 @@ uv sync
 ### Create and Run Tests
 
 Create tests within the `tests` subfolder and
-  then run:
+then run:
 
 ```bash
 uv run pytest

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/README.md
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/README.md
@@ -88,7 +88,7 @@ uv sync
 ### Create and Run Tests
 
 Create tests within the `tests` subfolder and
-  then run:
+then run:
 
 ```bash
 uv run pytest

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,27 +39,31 @@ uv sync --all-groups --all-extras
 First clone, then...
 
 1. Ensure you have the correct test library, formatters, and linters installed:
-    - `uv sync --all-groups --all-extras`
+
+   - `uv sync --all-groups --all-extras`
+
 1. The project has `pre-commit` hooks. Install them with:
-    - `pre-commit install`
+
+   - `pre-commit install`
+
 1. Most development tasks you might need should be covered by `nox` sessions. You can use `nox -l` to list all available tasks.
-For example:
+   For example:
 
-    - Run unit tests: `nox -r`.
+   - Run unit tests: `nox -r`.
 
-      We use `coverage` for code coverage metrics.
+     We use `coverage` for code coverage metrics.
 
-    - Run pre-commit hooks: `pre-commit run --all`.
+   - Run pre-commit hooks: `pre-commit run --all`.
 
-      We use [Ruff](https://github.com/charliermarsh/ruff),
-      [black](https://black.readthedocs.io/en/stable/index.html),
-      [flake8](https://flake8.pycqa.org/en/latest/) and
-      [mypy](https://mypy.readthedocs.io/en/stable/).
-      The project-wide max line length is `88`.
+     We use [Ruff](https://github.com/charliermarsh/ruff),
+     [black](https://black.readthedocs.io/en/stable/index.html),
+     [flake8](https://flake8.pycqa.org/en/latest/) and
+     [mypy](https://mypy.readthedocs.io/en/stable/).
+     The project-wide max line length is `88`.
 
-    - Build documentation: `nox -rs docs`
+   - Build documentation: `nox -rs docs`
 
-      We use `sphinx` to build documentation.
+     We use `sphinx` to build documentation.
 
 ### If you are using VSCode
 
@@ -67,7 +71,7 @@ For example:
 1. Set interpreter to match uv's managed virtualenv: run
    `Python: Select interpreter` and select the interpreter.
 1. The [pre-commit extension](https://marketplace.visualstudio.com/items?itemName=MarkLarah.pre-commit-vscode)
-will allow to run pre-commit hooks on the current file from the VSCode command palette.
+   will allow to run pre-commit hooks on the current file from the VSCode command palette.
 
 ## Testing Locally
 
@@ -182,11 +186,12 @@ In general, PR titles should follow the format `<type>: <desc>`, where type is a
 
 Optionally, you may use the expanded syntax to specify a scope in the form `<type>(<scope>): <desc>`. Currently scopes are:
 
- scopes:
-  - `taps`       # tap SDK only
-  - `targets`    # target SDK only
-  - `mappers`    # mappers only
-  - `templates`  # cookiecutters
+scopes:
+
+- `taps` # tap SDK only
+- `targets` # target SDK only
+- `mappers` # mappers only
+- `templates` # cookiecutters
 
 More advanced rules and settings can be found within the file [`.github/semantic.yml`](https://github.com/meltano/sdk/blob/main/.github/semantic.yml).
 
@@ -195,7 +200,7 @@ More advanced rules and settings can be found within the file [`.github/semantic
 ### Universal Code Formatting
 
 - From the [Black](https://black.readthedocs.io) website:
-    > By using Black, you agree to cede control over minutiae of hand-formatting. In return, Black gives you speed, determinism, and freedom from pycodestyle nagging about formatting. You will save time and mental energy for more important matters. **Black makes code review faster by producing the smallest diffs possible.** Blackened code looks the same regardless of the project you’re reading. **Formatting becomes transparent after a while and you can focus on the content instead.**
+  > By using Black, you agree to cede control over minutiae of hand-formatting. In return, Black gives you speed, determinism, and freedom from pycodestyle nagging about formatting. You will save time and mental energy for more important matters. **Black makes code review faster by producing the smallest diffs possible.** Blackened code looks the same regardless of the project you’re reading. **Formatting becomes transparent after a while and you can focus on the content instead.**
 
 ### Pervasive Python Type Hints
 

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -19,6 +19,7 @@ Currently only a local filesystem or AWS S3 are supported, but other filesystems
 ## The `BATCH` Message
 
 Local
+
 ```json
 {
   "type": "BATCH",
@@ -35,6 +36,7 @@ Local
 ```
 
 AWS S3
+
 ```json
 {
   "type": "BATCH",
@@ -63,7 +65,6 @@ The `manifest` field is used to specify the paths to the batch files. The paths 
 When local storage is used, targets do no require special configuration to process `BATCH` messages. Use of AWS S3 assumes S3/AWS credentials are already discoverable via the underlying S3 libraries (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_DEFAULT_REGION`)
 
 Taps may be configured to specify a root storage `root` directory, file path `prefix`, and `encoding` for batch files using a configuration like the below:
-
 
 In `config.json`:
 
@@ -114,6 +115,6 @@ class MySink(Sink):
 ## Known Limitations of `BATCH`
 
 1. Currently the built-in `BATCH` implementation does not support incremental bookmarks or `STATE` tracking. This work is tracked in [Issue #976](https://github.com/meltano/sdk/issues/976).
-2. The `BATCH` implementation is not currently compatible with [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html). This is certainly possible to implement in theory, but it would also introduce some performance penalties. This limitation is tracked in [Issue 1117#](https://github.com/meltano/sdk/issues/1117).
+1. The `BATCH` implementation is not currently compatible with [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html). This is certainly possible to implement in theory, but it would also introduce some performance penalties. This limitation is tracked in [Issue 1117#](https://github.com/meltano/sdk/issues/1117).
 
 If you are interested in contributing to one or both of these features, please add a comment in the respective issue.

--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -7,21 +7,21 @@ prefix `poetry run`.
 
 - Note: CLI mapping is performed in `pyproject.toml` and shims are recreated during `poetry install`:
 
-    ````{tab} Poetry
-    ```toml
-    ...
-    [tool.poetry.scripts]
-    tap-mysource = 'singer_sdk.tests.sample_tap_parquet.parquet_tap:cli'
-    ```
-    ````
+  ````{tab} Poetry
+  ```toml
+  ...
+  [tool.poetry.scripts]
+  tap-mysource = 'singer_sdk.tests.sample_tap_parquet.parquet_tap:cli'
+  ```
+  ````
 
-    ````{tab} uv
-    ```toml
-    ...
-    [project.scripts]
-    tap-mysource = 'singer_sdk.tests.sample_tap_parquet.parquet_tap:cli'
-    ```
-    ````
+  ````{tab} uv
+  ```toml
+  ...
+  [project.scripts]
+  tap-mysource = 'singer_sdk.tests.sample_tap_parquet.parquet_tap:cli'
+  ```
+  ````
 
 The CLI commands defined here will be configured automatically when the python library is installed by a user.
 
@@ -293,12 +293,12 @@ plugins:
 
 ### Comparison
 
-|                     | native/shell/`poetry`/`uv`                                                                  |                          `meltano`                                   |
+| | native/shell/`poetry`/`uv` | `meltano` |
 | ------------------- | :-----------------------------------------------------------------------------------------: | :------------------------------------------------------------------: |
 | Configuration store | Config JSON file (`--config=path/to/config.json`) or environment variables (`--config=ENV`) | `meltano.yml`, `.env`, environment variables, or Meltano's system db |
-| Simple invocation   | `my-tap --config=...`                                                                       | `meltano invoke my-tap`                                              |
-| Other CLI options   | `my-tap --about --format=json`                                                              | `meltano invoke my-tap --about --format=json`                        |
-| ELT                 | `my-tap --config=... \| path/to/target-jsonl --config=...`                                  | `meltano run my-tap target-jsonl`                                    |
+| Simple invocation | `my-tap --config=...` | `meltano invoke my-tap` |
+| Other CLI options | `my-tap --about --format=json` | `meltano invoke my-tap --about --format=json` |
+| ELT | `my-tap --config=... \| path/to/target-jsonl --config=...` | `meltano run my-tap target-jsonl` |
 
-[Meltano]: https://www.meltano.com
 [declare settings]: https://docs.meltano.com/reference/command-line-interface#how-to-use-2
+[meltano]: https://www.meltano.com

--- a/docs/code_samples.md
+++ b/docs/code_samples.md
@@ -325,6 +325,7 @@ class CustomResponseValidationStream(RESTStream):
 ```
 
 ### Custom Backoff
+
 Custom backoff and retry behaviour can be added by overriding the methods:
 
 - [`backoff_wait_generator`](singer_sdk.RESTStream.backoff_wait_generator)
@@ -333,6 +334,7 @@ Custom backoff and retry behaviour can be added by overriding the methods:
 - [`backoff_jitter`](singer_sdk.RESTStream.backoff_jitter)
 
 For example, to use a constant retry:
+
 ```
 def backoff_wait_generator() -> Callable[..., Generator[int, Any, None]]:
     return backoff.constant(interval=10)
@@ -342,7 +344,7 @@ To utilise a response header as a wait value you can use [`backoff_runtime`](sin
 
 **Note**: By default jitter makes this function wait a bit longer than the value provided.
 To disable jitter override [`backoff_jitter`](singer_sdk.RESTStream.backoff_jitter).
-In sdk versions <=0.21.0 the default jitter function will make the function below not work as you would expect without disabling jitter,
+In sdk versions \<=0.21.0 the default jitter function will make the function below not work as you would expect without disabling jitter,
 ([here](https://github.com/meltano/sdk/issues/1477) for more information) to disable jitter override the `request_decorator` and pass `jitter=None` to the `backoff.on_exception` function.
 
 ```

--- a/docs/context_object.md
+++ b/docs/context_object.md
@@ -9,9 +9,9 @@ partition or parent stream.
 - The context object MUST NOT contain any sensitive information, such as API keys or secrets.
   This is because the context is<br><br>
 
-  1) sent to the target,
-  2) stored in the state file and
-  3) logged to the console as a tag in metrics and logs.<br><br>
+  1. sent to the target,
+  1. stored in the state file and
+  1. logged to the console as a tag in metrics and logs.<br><br>
 
 - The context object SHOULD NOT be mutated during the stream's lifecycle. This is because the
   context is stored in the state file, and mutating it will cause the state file to be

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -6,13 +6,13 @@ Create taps with the SDK requires overriding just two or three classes:
 
 1. The `Tap` class. This class governs configuration, validation,
    and stream discovery.
-2. The stream class. You have different options for your base class depending on the type
+1. The stream class. You have different options for your base class depending on the type
    of data source you are working with:
    - `Stream` - The **generic** base class for streams.
    - `RESTStream` - The base class for **REST**-type streams.
    - `GraphQLStream` - The base class for **GraphQL**-type streams. This class inherits
      from `RESTStream`, since GraphQL is built upon REST.
-3. An optional authenticator class. You can omit this class entirely if you do not require authentication or if you prefer to write custom authentication logic. The supported authenticator classes are:
+1. An optional authenticator class. You can omit this class entirely if you do not require authentication or if you prefer to write custom authentication logic. The supported authenticator classes are:
    - `SimpleAuthenticator` - This class is functionally equivalent to overriding
      `http_headers` property in the stream class.
    - `OAuthAuthenticator` - This class performs an OAuth 2.0 authentication flow.
@@ -25,7 +25,7 @@ Create targets with the SDK requires overriding just two classes:
 
 1. The `Target` class. This class governs configuration, validation,
    and stream discovery.
-2. The `Sink` class. You have two different options depending on whether your target
+1. The `Sink` class. You have two different options depending on whether your target
    prefers writing one record at a time versus writing in batches:
    - `RecordSink` writes one record at a time, via the `process_record()`
      method.
@@ -218,7 +218,6 @@ Also using breakpoints is a great way to become familiar with the internals of t
 Ensure the interpreter you're using in VSCode is set to use the one in the project's virtual environment (usually `.venv` in the project root).
 You can change this by using the command palette to go to interpreter settings.
 Doing this will also help with autocompletion.
-
 
 In order to launch your plugin via it's CLI with the built-in debugger, VSCode requires a [Launch configuration](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations).
 An example launch configuration, added to your `launch.json`, might be as follows:

--- a/docs/guides/porting.md
+++ b/docs/guides/porting.md
@@ -19,7 +19,7 @@ When porting over an existing tap, most developers find it easier to start from 
 Next, we'll copy over the settings and readme from the old project to the new one.
 
 1. Open `archive/README.md` and copy-paste the old file into the new `README.md`. Generally, the best place to insert it is in the settings section, then move things around as needed. Commit the result when you're happy with the new file.
-2. Open the `README.md` in side-by-side mode with `tap.py` and copy paste each setting and it's description into an appropriate type helper class (prefixed with `th.*`).
+1. Open the `README.md` in side-by-side mode with `tap.py` and copy paste each setting and it's description into an appropriate type helper class (prefixed with `th.*`).
    - If settings are not defined in your README.md, you can try searching the `archived/**.py` files for references to `config.get(` or `config[`, and/or check any other available reference for the expected input settings.
 
 ## If you are building a SQL tap
@@ -33,21 +33,21 @@ Continue until just before you reach the "Pagination" section, at which point yo
 ## Authentication
 
 1. Open the `auth.py` or `client.py` file (depending on auth method) and locate the authentication logic.
-2. In your archived files, open `client.py` or whichever file pertains to authentication. (You'll use this for reference in the next step.)
-3. Update the authenticator methods by applying the logic and config values as demonstrated in the archived python code.
+1. In your archived files, open `client.py` or whichever file pertains to authentication. (You'll use this for reference in the next step.)
+1. Update the authenticator methods by applying the logic and config values as demonstrated in the archived python code.
 
 ## Define your first stream
 
 Before you begin this section, please select a stream you would like to port as your first stream. This should be a simple stream without complex logic. If your tap has nested structure, start with a top level stream rather than a child stream.
 
 1. Open `streams.py` and modify one of the samples to fit your first stream's name.
-2. Make sure you set `primary_keys`, `replication_key` first.
-3. If you have a schema file for each stream:
+1. Make sure you set `primary_keys`, `replication_key` first.
+1. If you have a schema file for each stream:
    1. Move the entire `schemas` folder out of the `archive` directory.
-   2. Set `schema_filepath` property to be equal to the schema file for this stream.
-4. If you are declaring schemas directly (without an existing JSON schema file):
+   1. Set `schema_filepath` property to be equal to the schema file for this stream.
+1. If you are declaring schemas directly (without an existing JSON schema file):
    1. Using the typing helpers (`th.*`) to define just the `primary_key`, `replication_key`, and 3-5 additional fields.
-   2. Don't worry about defining all properties up front. Instead, come back to this step _after_ you finish a successful stream test.
+   1. Don't worry about defining all properties up front. Instead, come back to this step _after_ you finish a successful stream test.
 
 Once you have a single stream defined, with 3-6 properties, you're ready to continue to the next step.
 
@@ -84,7 +84,7 @@ Once you have the necessary dependencies added, run `poetry install`/`uv sync` t
 ## Perform `TODO` items in `tap.py` and `client.py`
 
 1. Open `tap.py` and search for TODO items. Depending on the type of tap you are porting, you will likely have to provide your new stream's class names so that the tap class knows to invoke them.
-2. Open `client.py` and search for TODO items. If your API type requires a `url_base`, go ahead and input it now.
+1. Open `client.py` and search for TODO items. If your API type requires a `url_base`, go ahead and input it now.
    - You can postpone the other TODOs for now. Pagination will be addressed in the steps below.
 
 Note: You _do not_ have to resolve TODOs everywhere in the project, but if there are any sections you can obviously resolve, you can go ahead and do so now.
@@ -97,27 +97,27 @@ If you have not already done so, run `poetry install`/`uv` to make sure your pro
 
 Repeat the following steps until you see a help message:
 
-````{tab} Poetry
+```{tab} Poetry
 1. Run `poetry run tap-mysource --help` to confirm the program can run.
 2. Find and fix any errors that occur.
-````
+```
 
-````{tab} uv
+```{tab} uv
 1. Run `uv run tap-mysource --help` to confirm the program can run.
 2. Find and fix any errors that occur.
-````
+```
 
 Now, repeat the following steps until you get data coming through your tap:
 
-````{tab} Poetry
+```{tab} Poetry
 1. Run `poetry run tap-mysource` to attempt your first data sync.
 2. Find and fix any errors that occur.
-````
+```
 
-````{tab} uv
+```{tab} uv
 1. Run `uv run tap-mysource` to attempt your first data sync.
 2. Find and fix any errors that occur.
-````
+```
 
 If you run into error, go back and debug, and especially double check your authentication process and input credentials.
 
@@ -251,8 +251,8 @@ uv run pytest
 ````
 
 1. If pytest is successful, add properties missing from your prior iteration.
-2. Run pytest again.
-3. Continue adding properties and testing until all streams are fully defined.
+1. Run pytest again.
+1. Continue adding properties and testing until all streams are fully defined.
 
 ## Optional Next Steps
 

--- a/docs/guides/sql-tap.md
+++ b/docs/guides/sql-tap.md
@@ -65,7 +65,6 @@ class MyConnector(SQLConnector):
 
 ### Adapting the type mapping based on user configuration
 
-
 If your type mapping depends on some user-defined configuration, you can also override the `from_config` method to pass the configuration to your custom type mapping:
 
 ```python
@@ -80,7 +79,6 @@ class ConfiguredSQLToJSONSchema(SQLToJSONSchema):
 ```
 
 Then, you can use your custom type mapping in your connector as in the previous example.
-
 
 ### SQL tap support for Singer Decimal string format
 

--- a/docs/implementation/cli.md
+++ b/docs/implementation/cli.md
@@ -3,7 +3,6 @@ myst:
   heading_anchors: 4
 ---
 
-
 # Command Line Reference
 
 This page describes how SDK-based taps and targets can be invoked via the command line interface, or "CLI".
@@ -56,7 +55,7 @@ The SDK supports one or more `--config` inputs when run from the CLI.
 
 - If one of the supplied inputs is `--config ENV` (or `--config=ENV` according to the user's preference), the environment variable parsing rules will be applied to ingest config values from environment variables.
 - One or more files can also be sent to `--config`. If multiple files are sent, they will be processed in sequential order.
-If one or more files conflict for a given setting, the latter provided files will override earlier provided files.
+  If one or more files conflict for a given setting, the latter provided files will override earlier provided files.
   - This behavior allows to you easily inject environment overrides by adding `--config=path/to/overrides.json` at the end of the CLI command text.
 - If `--config=ENV` is set and one or more files conflict with an environment variable setting, the environment variable setting will always have precedence, regardless of ordering.
 - One benefit of this approach is that credentials and other secrets can be stored completely separately from general settings: either by having two distinct `config.json` files or by using environment variables for secure settings and `config.json` files for the rest.
@@ -81,7 +80,6 @@ The following value types are automatically cast to the appropriate Python type:
 - JSON arrays (e.g. `TAP_MY_EXAMPLE_ARRAY='["a", "b", "c"]'`)
 - JSON objects (e.g. `TAP_MY_EXAMPLE_OBJECT='{"key": "value"}'`)
 
-
 ## Tap-Specific CLI Options
 
 ### `--state`
@@ -100,8 +98,8 @@ The SDK automatically applies selection logic as described by the
 Selection rules are applied at three levels:
 
 1. **Streams** are filtered out if they are deselected or omitted in the input catalog.
-2. **RECORD messages** are filtered based upon selection rules in the input catalog.
-3. **SCHEMA messages** are filtered based upon selection rules in the input catalog.
+1. **RECORD messages** are filtered based upon selection rules in the input catalog.
+1. **SCHEMA messages** are filtered based upon selection rules in the input catalog.
 
 ### `--test`
 

--- a/docs/implementation/discovery.md
+++ b/docs/implementation/discovery.md
@@ -9,14 +9,14 @@ importantly:
 
 - `Tap.discover_streams()` - Should return a list of available "discovered" streams.
 - `Stream.schema` or `Stream.schema_filepath` - The JSON Schema definition of each stream,
-provided either directly as a Python `dict` or indirectly as a `.json` filepath.
+  provided either directly as a Python `dict` or indirectly as a `.json` filepath.
 - `Stream.primary_keys` - a list of strings indicating the primary key(s) of the stream.
 - `Stream.replication_key` - a single string indicating the name of the stream's replication
-key (if applicable).
+  key (if applicable).
 
 ## Additional Discovery Mode References
 
 - See the [Dev Guide](../dev_guide.md) and [Code Samples](../code_samples.md) for more
-information on working with dynamic stream schemas.
+  information on working with dynamic stream schemas.
 - [Singer Spec: Discovery (meltano.com)](https://hub.meltano.com/singer/spec#discovery-mode)
 - [Singer Spec: Discovery (singer-io)](https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md)

--- a/docs/implementation/state.md
+++ b/docs/implementation/state.md
@@ -33,8 +33,8 @@ Within each stream definition, the following are considered the minimal effectiv
 implementation within the SDK:
 
 1. `replication_key` and `replication_key_value` - These two keys together should designate
-the incremental replication key (if applicable) and the highest value yet seen for this
-property.
+   the incremental replication key (if applicable) and the highest value yet seen for this
+   property.
 
 ## State Message Frequency
 

--- a/docs/incremental_replication.md
+++ b/docs/incremental_replication.md
@@ -34,9 +34,9 @@ class CommentsStream(RESTStream):
 
 1. First we inform the SDK of the `replication_key`, which automatically triggers incremental import mode.
 
-2. Second, optionally, set `is_sorted` to true if the records are monotonically increasing (i.e. newer records always come later). With this setting, the sync will be resumable if it's interrupted at any point and the state file will reflect this. Otherwise, the tap has to run to completion so the state can safely reflect the largest replication value seen.
+1. Second, optionally, set `is_sorted` to true if the records are monotonically increasing (i.e. newer records always come later). With this setting, the sync will be resumable if it's interrupted at any point and the state file will reflect this. Otherwise, the tap has to run to completion so the state can safely reflect the largest replication value seen.
 
-3. Last, we have to adapt the query to the remote system, in this example by adding a query parameter with the ISO timestamp.
+1. Last, we have to adapt the query to the remote system, in this example by adding a query parameter with the ISO timestamp.
 
    The [`get_starting_timestamp`](singer_sdk.Stream.get_starting_timestamp) method and the related [`get_starting_replication_key_value`](singer_sdk.Stream.get_starting_replication_key_value) method, are provided by the SDK and return the last replication key value seen in the previous run. If the tap is run for the first time and the value for the `start_date` setting is null, the method will return `None`.
 

--- a/docs/parent_streams.md
+++ b/docs/parent_streams.md
@@ -7,19 +7,19 @@ from a parent record each time the child stream is invoked.
 ## If you do want to utilize parent-child streams
 
 1. Set `parent_stream_type` in the child-stream's class to the class of the parent.
-2. Implement one of the below methods to pass context from the parent to the child:
+1. Implement one of the below methods to pass context from the parent to the child:
    1. If using [`get_records`](singer_sdk.Stream.get_child_context) you can simply return a tuple instead of a `record`
       dictionary. A tuple return value will be interpreted by the SDK as
       `(record: dict, child_context: dict)`.
-   2. Override [`get_child_context`](singer_sdk.Stream.get_child_context) to return a new
+   1. Override [`get_child_context`](singer_sdk.Stream.get_child_context) to return a new
       child context object based on records and any existing context from the parent stream.
-   3. If you need to sync more than one child stream per parent record, you can override
+   1. If you need to sync more than one child stream per parent record, you can override
       [`generate_child_contexts`](singer_sdk.Stream.generate_child_contexts) to yield as many
       contexts as you need.
-3. If the parent stream's replication key won't get updated when child items are changed,
+1. If the parent stream's replication key won't get updated when child items are changed,
    indicate this by adding [`ignore_parent_replication_key = True`](singer_sdk.Stream.ignore_parent_replication_key)
    in the child stream class declaration.
-4. If the number of _parent_ items is very large (thousands or tens of thousands), you can
+1. If the number of _parent_ items is very large (thousands or tens of thousands), you can
    optionally set [`state_partitioning_keys`](singer_sdk.Stream.state_partitioning_keys) on the child stream to specify a subset of context keys to use
    in state bookmarks. (When not set, the number of bookmarks will be equal to the number
    of parent items.) If you do not wish to store any state bookmarks for the child stream, set[`state_partitioning_keys`](singer_sdk.Stream.state_partitioning_keys) to `[]`.

--- a/docs/python_tips.md
+++ b/docs/python_tips.md
@@ -89,16 +89,16 @@ Note that the first static example was more concise while this second example is
 ### In summary
 
 - Use the static syntax whenever you are dealing with stream properties that won't change
-and use dynamic syntax whenever you need to calculate the stream's properties or discover them dynamically.
+  and use dynamic syntax whenever you need to calculate the stream's properties or discover them dynamically.
 - For those new to Python, note that the dynamic syntax is identical to declaring a function or method, with
-the one difference of having the `@property` decorator directly above the method definition. This one change
-tells Python that you want to be able to access the method as a property (as in `pk = stream.primary_key`)
-instead of as a callable function (as in `pk = stream.primary_key()`).
+  the one difference of having the `@property` decorator directly above the method definition. This one change
+  tells Python that you want to be able to access the method as a property (as in `pk = stream.primary_key`)
+  instead of as a callable function (as in `pk = stream.primary_key()`).
 
 ### Troubleshooting
 
 - If you are working on a SDK tap/target that uses a `poetry-core` version before v1.0.8 in the `build-system` table of `pyproject.toml` you may have trouble specifying a `pip_url` in Meltano with "editable mode" (`-e path/to/package`) enabled
-(as per [#238](https://gitlab.com/meltano/sdk/-/issues/238)). This can be resolved by upgrading
-the version of `poetry-core>=1.0.8`.
+  (as per [#238](https://gitlab.com/meltano/sdk/-/issues/238)). This can be resolved by upgrading
+  the version of `poetry-core>=1.0.8`.
 
 For more examples, please see the [Code Samples](./code_samples.md) page.

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -14,9 +14,9 @@ The Singer SDK currently follows roughly a [ZeroVer versioning scheme](https://0
 The following steps are required to create a stable release:
 
 1. Trigger the `.github/workflows/version_bump.yml` workflow from the GitHub Actions tab, or from the CLI with `gh workflow run version_bump.yml`.
-2. Wait for the workflow to complete. It will create a new PR with the version bump, and also a draft release.
-3. Review the PR for any errors in the changelog and version bumps, then merge it.
-4. Publish the draft release from the GitHub Releases tab.
+1. Wait for the workflow to complete. It will create a new PR with the version bump, and also a draft release.
+1. Review the PR for any errors in the changelog and version bumps, then merge it.
+1. Publish the draft release from the GitHub Releases tab.
 
 #### Feature releases
 

--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -25,7 +25,7 @@ In all examples below where `null` is used as a value, the special string `"__NU
 
 ### Schema Flattening Applications
 
-- ***Flatten nested properties:** separates large complex properties into multiple distinct fields.
+- **Flatten nested properties:** separates large complex properties into multiple distinct fields.
 
 For instance, a complex `user` property may look like this:
 
@@ -94,11 +94,11 @@ The following behaviors are implemented by the SDK automatically:
    - Because this process happens automatically after all other tap logic is executed, the
      tap developer does not have to write any custom handling logic.
    - The tap development process is fully insulated from this 'out-of-box' functionality.
-2. Similarly for targets, the received streams are processed by the `stream_maps` config
+1. Similarly for targets, the received streams are processed by the `stream_maps` config
    setting _prior_ to any Sink processing functions.
    - This means that the target developer can assume that all streams and records are
      transformed, aliased, filtered, etc. _before_ any custom target code is executed.
-3. The standalone mapper plugin [`meltano-map-transformer`](https://hub.meltano.com/mappers/meltano-map-transformer/) is a hybrid tap/target which
+1. The standalone mapper plugin [`meltano-map-transformer`](https://hub.meltano.com/mappers/meltano-map-transformer/) is a hybrid tap/target which
    simply receives input from a tap, transforms all stream and schema messages via the
    `stream_maps` config option, and then emits the resulting stream(s) to a downstream
    target.
@@ -230,12 +230,12 @@ can be referenced directly by mapping expressions.
 
 The following functions and namespaces are available for use in mapping expressions:
 
-| Function                                             | Description                                                                                                                                                                                                                                                                  |
+| Function | Description |
 | :--------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`md5()`](inv:python:py:function:#hashlib.md5)       | Returns an inline MD5 hash of any string, outputting the string representation of the hash's hex digest. This is defined by the SDK internally with native python: [`hashlib.md5(<input>.encode("utf-8")).hexdigest()`](inv:python:py:method:#hashlib.hash.hexdigest).       |
+| [`md5()`](inv:python:py:function:#hashlib.md5) | Returns an inline MD5 hash of any string, outputting the string representation of the hash's hex digest. This is defined by the SDK internally with native python: [`hashlib.md5(<input>.encode("utf-8")).hexdigest()`](inv:python:py:method:#hashlib.hash.hexdigest). |
 | [`sha256()`](inv:python:py:function:#hashlib.sha256) | Returns an inline SHA256 hash of any string, outputting the string representation of the hash's hex digest. This is defined by the SDK internally with native python: [`hashlib.sha256(<input>.encode("utf-8")).hexdigest()`](inv:python:py:method:#hashlib.hash.hexdigest). |
-| [`datetime`](inv:python:py:module:#datetime)         | This is the datetime module object from the Python standard library. You can access [`datetime.datetime`](inv:python:py:class:#datetime.datetime), [`datetime.timedelta`](inv:python:py:class:#datetime.timedelta), etc.                                                     |
-| [`json`](inv:python:py:module:#json)                 | This is the json module object from the Python standard library. Primarily used for calling [`json.dumps()`](inv:python:py:function:#json.dumps) and [`json.loads()`](inv:python:py:function:#json.loads).                                                                   |
+| [`datetime`](inv:python:py:module:#datetime) | This is the datetime module object from the Python standard library. You can access [`datetime.datetime`](inv:python:py:class:#datetime.datetime), [`datetime.timedelta`](inv:python:py:class:#datetime.timedelta), etc. |
+| [`json`](inv:python:py:module:#json) | This is the json module object from the Python standard library. Primarily used for calling [`json.dumps()`](inv:python:py:function:#json.dumps) and [`json.loads()`](inv:python:py:function:#json.loads). |
 
 ```{tip}
 With `json.dumps()`, you might want to pass the `default` argument. For example, `json.dumps(obj, default=str)` will call `str()` on
@@ -246,18 +246,18 @@ an object if it is otherwise not serializable. This is useful for serializing da
 
 The following variables are available in the context of a mapping expression:
 
-| Variable          | Description                                                                                                                                                                                       |
+| Variable | Description |
 | :---------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `config`          | A dictionary with the `stream_map_config` values from settings. This can be used to provide a secret hash seed, for instance.                                                                     |
-| `record`          | An alias for the record values dictionary in the current stream.                                                                                                                                  |
-| `_`               | Same as `record` but shorter to type.                                                                                                                                                             |
-| `self`            | The existing property value if the property already exists.                                                                                                                                       |
-| `fake`            | A [`Faker`](inv:faker:std:doc#index) instance, configurable via `faker_config` (see previous example) - see the built-in [standard providers](inv:faker:std:doc#providers) for available methods. |
-| `__stream_name__` | The name of the stream. Useful when [applying the same transformation to multiple streams](#applying-a-mapping-across-two-or-more-streams).                                                       |
+| `config` | A dictionary with the `stream_map_config` values from settings. This can be used to provide a secret hash seed, for instance. |
+| `record` | An alias for the record values dictionary in the current stream. |
+| `_` | Same as `record` but shorter to type. |
+| `self` | The existing property value if the property already exists. |
+| `fake` | A [`Faker`](inv:faker:std:doc#index) instance, configurable via `faker_config` (see previous example) - see the built-in [standard providers](inv:faker:std:doc#providers) for available methods. |
+| `__stream_name__` | The name of the stream. Useful when [applying the same transformation to multiple streams](#applying-a-mapping-across-two-or-more-streams). |
 
-  ```{tip}
-  To use the `fake` object, the `faker` library must be installed.
-  ```
+```{tip}
+To use the `fake` object, the `faker` library must be installed.
+```
 
 :::{versionadded} 0.35.0
 The `faker` object.
@@ -279,7 +279,7 @@ The `__stream_name__` variable.
 
 The following variables are available in the context of the `__alias__` expression:
 
-| Variable          | Description              |
+| Variable | Description |
 | :---------------- | :----------------------- |
 | `__stream_name__` | The existing stream name |
 
@@ -297,9 +297,9 @@ The following logic is applied in determining the SCHEMA of the transformed stre
 
 1. Calculations which begin with the text `str(`, `float(`, `int(` will be
    assumed to be belonging to the specified type.
-2. Otherwise, if the property already existed in the original stream, it will be assumed
+1. Otherwise, if the property already existed in the original stream, it will be assumed
    to have the same data type as the original stream.
-3. Otherwise, if no type is detected using the above rules, any new stream properties will
+1. Otherwise, if no type is detected using the above rules, any new stream properties will
    be assumed to be of type `str` .
 
 ## Customized `stream_map` Behaviors
@@ -488,7 +488,7 @@ faker_config:
 
 Be sure to checkout the [`faker` documentation](https://faker.readthedocs.io/en/master/) for all the fake data generation possibilities.
 
-Note that in the example above, `faker` will generate a new random value each time the `first_name()` function is invoked. This means if 3 records have a `first_name` value of `Mike`, then they will each have a different name after being mapped (for example, `Alistair`, `Debra`, `Scooby`).  This can actually lead to issues when developing in the lower environments.
+Note that in the example above, `faker` will generate a new random value each time the `first_name()` function is invoked. This means if 3 records have a `first_name` value of `Mike`, then they will each have a different name after being mapped (for example, `Alistair`, `Debra`, `Scooby`). This can actually lead to issues when developing in the lower environments.
 
 Some users require consistent masking (for example, the first name `Mike` is always masked as `Debra`). Consistent masking preserves the relationship between tables and rows, while still hiding the real value. When a random mask is generated every time, relationships between tables/rows are effectively lost, making it impossible to test things like sql `JOIN`s. This can cause highly unpredictable behavior when running the same code in lower environments vs production.
 
@@ -784,7 +784,6 @@ the `key_properties` in an extract-load pipeline. For instance, it is common to 
 "append-only" loading behavior in certain targets, as may be required for historical reporting. This does not change the
 underlying nature of the `primary_key` configuration in the upstream source data, only how it will be landed or deduped
 in the downstream source.
-
 
 ### Q: How do I use Meltano environment variables to configure stream maps?
 

--- a/samples/sample_tap_dummy_json/README.md
+++ b/samples/sample_tap_dummy_json/README.md
@@ -82,7 +82,7 @@ uv sync
 ### Create and Run Tests
 
 Create tests within the `tests` subfolder and
-  then run:
+then run:
 
 ```bash
 uv run pytest


### PR DESCRIPTION
## Summary by Sourcery

Auto-format markdown files using `mdformat` to improve consistency and readability of documentation

Documentation:
- Added `mdformat` pre-commit hook to automatically format markdown files
- Cleaned up markdown formatting across multiple documentation files

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3026.org.readthedocs.build/en/3026/

<!-- readthedocs-preview meltano-sdk end -->