### PR TITLE
fix: Bump standard tap tests max records limit from 25 to 150

### DIFF
--- a/singer_sdk/testing/config.py
+++ b/singer_sdk/testing/config.py
@@ -17,6 +17,6 @@ class SuiteConfig:
              no records, for named streams.
     """
 
-    max_records_limit: int | None = 25
+    max_records_limit: int | None = 150
     ignore_no_records: bool = False
     ignore_no_records_for_streams: list[str] = field(default_factory=list)


### PR DESCRIPTION
## Related

- https://github.com/meltano/sdk/issues/3029

## Summary by Sourcery

Bug Fixes:
- Increase the default max_records_limit for test suites from 25 to 150 to prevent test failures due to low record caps