### PR TITLE
fix(targets): Avoid emitting an empty state from the target if the tap has not sent any state messages

### DIFF
--- a/samples/sample_tap_fake_people/__main__.py
+++ b/samples/sample_tap_fake_people/__main__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from samples.sample_tap_fake_people.tap import SampleTapFakePeople
+
+SampleTapFakePeople.cli()

--- a/samples/sample_tap_fake_people/tap.py
+++ b/samples/sample_tap_fake_people/tap.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import typing as t
+
+from faker import Faker
+
+from singer_sdk import Stream, Tap
+from singer_sdk import typing as th
+from singer_sdk.singerlib import Message, SingerMessageType
+
+if t.TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from singer_sdk.helpers.types import Record
+
+
+class FakePeopleStream(Stream):
+    name = "people"
+    primary_keys = ("id",)
+    schema = th.PropertiesList(
+        th.Property("id", th.IntegerType, required=True),
+        th.Property("name", th.StringType, required=True),
+        th.Property("email", th.StringType, required=True),
+        th.Property("phone", th.StringType, required=True),
+        th.Property("address", th.StringType, required=True),
+    ).to_dict()
+
+    def get_records(self, context: dict) -> Iterable[Record]:  # noqa: ARG002, PLR6301
+        faker = Faker()
+        for i in range(100):
+            yield {
+                "id": i,
+                "name": faker.name(),
+                "email": faker.email(),
+                "phone": faker.phone_number(),
+                "address": faker.address(),
+            }
+
+
+class SampleTapFakePeople(Tap):
+    name = "sample-tap-fake-people"
+
+    def write_message(self, message: Message) -> None:
+        if message.type == SingerMessageType.STATE:
+            return
+        super().write_message(message)
+
+    def discover_streams(self) -> Sequence[Stream]:
+        return [FakePeopleStream(self)]

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -32,6 +32,7 @@ from singer_sdk.io_base import SingerReader
 from singer_sdk.plugin_base import BaseSingerReader
 
 if t.TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import PurePath
 
     from singer_sdk.connectors import SQLConnector
@@ -89,7 +90,7 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
             message_reader=message_reader,
         )
 
-        self._latest_state: dict[str, dict] = {}
+        self._latest_state: dict[str, dict] | None = None
         self._drained_state: dict[str, dict] = {}
         self._sinks_active: dict[str, Sink] = {}
         self._sinks_to_clear: list[Sink] = []
@@ -479,17 +480,19 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
             is_endofpipe: This is called after the target instance has finished
                 listening to the stdin.
         """
-        state = copy.deepcopy(self._latest_state)
         self._drain_all(self._sinks_to_clear, 1)
         if is_endofpipe:
             for sink in self._sinks_to_clear:
                 sink.clean_up()
         self._sinks_to_clear = []
-        self._drain_all(list(self._sinks_active.values()), self.max_parallelism)
+        self._drain_all(self._sinks_active.values(), self.max_parallelism)
         if is_endofpipe:
             for sink in self._sinks_active.values():
                 sink.clean_up()
-        self._write_state_message(state)
+
+        if self._latest_state is not None:
+            self._write_state_message(self._latest_state)
+
         self._reset_max_record_age()
 
     @t.final
@@ -509,7 +512,7 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
             sink.process_batch(draining_status)
         sink.mark_drained()
 
-    def _drain_all(self, sink_list: list[Sink], parallelism: int) -> None:
+    def _drain_all(self, sink_list: Iterable[Sink], parallelism: int) -> None:
         if parallelism == 1:
             for sink in sink_list:
                 self.drain_one(sink)

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -491,7 +491,7 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
                 sink.clean_up()
 
         if self._latest_state is not None:
-            self._write_state_message(self._latest_state)
+            self._write_state_message(copy.deepcopy(self._latest_state))
 
         self._reset_max_record_age()
 

--- a/tests/samples/test_target_csv.py
+++ b/tests/samples/test_target_csv.py
@@ -16,6 +16,7 @@ from click.testing import CliRunner
 
 from samples.sample_mapper.mapper import StreamTransform
 from samples.sample_tap_countries.countries_tap import SampleTapCountries
+from samples.sample_tap_fake_people.tap import SampleTapFakePeople
 from samples.sample_target_csv.csv_target import SampleTargetCSV
 from singer_sdk.testing import (
     get_target_test_class,
@@ -67,6 +68,13 @@ def test_countries_to_csv_mapped(csv_config: dict):
     target = SampleTargetCSV(config=csv_config)
     mapper = StreamTransform(config=COUNTRIES_STREAM_MAPS_CONFIG)
     sync_end_to_end(tap, target, mapper)
+
+
+def test_fake_people_to_csv(csv_config: dict):
+    tap = SampleTapFakePeople()
+    target = SampleTargetCSV(config=csv_config)
+    _, _, target_stdout, _ = tap_to_target_sync_test(tap, target)
+    assert not target_stdout.read(), "Target should not emit any bookmarks"
 
 
 def test_target_batching():


### PR DESCRIPTION
## Summary by Sourcery

Prevent the target from emitting an empty state when the tap has not sent any state messages and add a corresponding test and sample tap for this scenario.

New Features:
- Introduce a SampleTapFakePeople demo tap that suppresses state messages to reproduce the no-state condition.

Bug Fixes:
- Skip writing a state message if no state has ever been received, avoiding emission of an empty state.

Enhancements:
- Change _latest_state to an optional type and accept generic Iterables in _drain_all for greater flexibility.

Tests:
- Add test_fake_people_to_csv to verify that no state/bookmark messages are emitted when the tap sends none.

Chores:
- Include a sample tap implementation under samples/sample_tap_fake_people to support the new test.