### PR TITLE
chore: Use `--locked` flag instead of `--frozen` of `uv sync` in Nox sessions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,8 +91,6 @@ jobs:
         key: http_cache-${{ runner.os }}-${{ matrix.python-version }}
 
     - name: Run Nox
-      env:
-        UV_PRERELEASE: allow
       run: |
         nox --verbose
 
@@ -135,8 +133,6 @@ jobs:
         nox --version
 
     - name: Run Nox
-      env:
-        UV_PRERELEASE: allow
       run: |
         nox -- -m "external"
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -70,7 +70,7 @@ def mypy(session: nox.Session) -> None:
     session.run_install(
         "uv",
         "sync",
-        "--frozen",
+        "--locked",
         "--no-dev",
         "--group=typing",
         *(f"--extra={extra}" for extra in extras),
@@ -94,7 +94,7 @@ def tests(session: nox.Session) -> None:
     session.run_install(
         "uv",
         "sync",
-        "--frozen",
+        "--locked",
         "--no-dev",
         "--group=testing",
         *(f"--extra={extra}" for extra in extras),
@@ -128,7 +128,7 @@ def coverage(session: nox.Session) -> None:
     session.run_install(
         "uv",
         "sync",
-        "--frozen",
+        "--locked",
         "--no-dev",
         "--group=testing",
         env=_install_env(session),
@@ -151,7 +151,7 @@ def benches(session: nox.Session) -> None:
     session.run_install(
         "uv",
         "sync",
-        "--frozen",
+        "--locked",
         "--no-dev",
         "--group=testing",
         *(f"--extra={extra}" for extra in extras),
@@ -182,7 +182,7 @@ def dependencies(session: nox.Session) -> None:
     session.run_install(
         "uv",
         "sync",
-        "--frozen",
+        "--locked",
         "--inexact",
         "--no-dev",
         *(f"--extra={extra}" for extra in extras),
@@ -208,7 +208,7 @@ def update_snapshots(session: nox.Session) -> None:
     session.run_install(
         "uv",
         "sync",
-        "--frozen",
+        "--locked",
         "--no-dev",
         "--group=testing",
         *(f"--extra={extra}" for extra in extras),
@@ -231,7 +231,7 @@ def doctest(session: nox.Session) -> None:
     session.run_install(
         "uv",
         "sync",
-        "--frozen",
+        "--locked",
         "--no-dev",
         "--group=testing",
         env=_install_env(session),
@@ -249,7 +249,7 @@ def docs(session: nox.Session) -> None:
     session.run_install(
         "uv",
         "sync",
-        "--frozen",
+        "--locked",
         "--no-dev",
         "--group=docs",
         env=_install_env(session),
@@ -279,7 +279,7 @@ def docs_serve(session: nox.Session) -> None:
     session.run_install(
         "uv",
         "sync",
-        "--frozen",
+        "--locked",
         "--inexact",
         "--no-dev",
         "--group=docs",


### PR DESCRIPTION
## Links

- https://github.com/wntrblm/nox/pull/972
- https://github.com/astral-sh/uv/pull/12818
- https://github.com/astral-sh/uv/pull/12819
- https://hynek.me/articles/docker-uv/

## Summary by Sourcery

Build:
- Replace all uv sync --frozen flags with --locked in the Nox session definitions

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3035.org.readthedocs.build/en/3035/

<!-- readthedocs-preview meltano-sdk end -->