### PR TITLE
fix: Avoid aborting parent stream before child stream is finished in standard tap tests

### DIFF
--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -276,8 +276,9 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
             streams = self.streams.values()
 
         for stream in streams:
-            # Initialize streams' record limits before beginning the sync test.
-            stream.ABORT_AT_RECORD_COUNT = dry_run_record_limit
+            if not stream.child_streams:
+                # Initialize streams' record limits before beginning the sync test.
+                stream.ABORT_AT_RECORD_COUNT = dry_run_record_limit
 
             # Force selection of streams.
             stream.selected = True

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -276,7 +276,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
             streams = self.streams.values()
 
         for stream in streams:
-            if not stream.child_streams:
+            if not stream.child_streams:  # pragma: no branch
                 # Initialize streams' record limits before beginning the sync test.
                 stream.ABORT_AT_RECORD_COUNT = dry_run_record_limit
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Only apply the dry-run abort record limit to streams without child streams, ensuring parent streams complete properly.