### PR TITLE
packaging: Remove license trove classifier and rely on PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ keywords = [
 ]
 classifiers = [
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Links

- https://peps.python.org/pep-0639/
- https://github.com/pypi/warehouse/issues/16620