### PR TITLE
refactor: Make the filesystem tap and stream logs less noisy

### DIFF
--- a/singer_sdk/contrib/filesystem/stream.py
+++ b/singer_sdk/contrib/filesystem/stream.py
@@ -124,7 +124,7 @@ class FileStream(Stream, metaclass=abc.ABCMeta):
             and mtime is not None
             and mtime < previous_bookmark
         ):
-            self.logger.info("File has not been modified since last read, skipping")
+            self.logger.debug("File has not been modified since last read, skipping")
             return
 
         for record in self.read_file(path):

--- a/singer_sdk/contrib/filesystem/tap.py
+++ b/singer_sdk/contrib/filesystem/tap.py
@@ -165,7 +165,7 @@ class FolderTap(Tap, t.Generic[_T]):
                 msg,
                 errors=[f"Missing configuration for filesystem {protocol}"],
             )
-        logger.info("Instantiating filesystem interface: '%s'", protocol)
+        logger.debug("Instantiating filesystem interface: '%s'", protocol)
 
         return fsspec.implementations.dirfs.DirFileSystem(
             path=self.path,


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Downgrade two filesystem logging statements from INFO to DEBUG to reduce verbosity

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3039.org.readthedocs.build/en/3039/

<!-- readthedocs-preview meltano-sdk end -->