### PR TITLE
revert: Revert "fix(targets): Avoid emitting message `"No schema for record field."` when "additionalProperties" is set to true in stream schema (#3031)"

### DIFF
--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -583,13 +583,12 @@ class Sink(metaclass=abc.ABCMeta):  # noqa: PLR0904
             treatment: TODO
         """
         for key, value in record.items():
-            additional_properties = schema.get("additionalProperties", False)
-            if key not in schema["properties"] and not additional_properties:
+            if key not in schema["properties"]:
                 if value is not None:
                     self.logger.warning("No schema for record field '%s'", key)
                 continue
-
-            if datelike_type := get_datelike_property_type(schema["properties"][key]):
+            datelike_type = get_datelike_property_type(schema["properties"][key])
+            if datelike_type:
                 date_val = value
                 try:
                     if value is not None:


### PR DESCRIPTION
This reverts commit f560e2920a38c1f6fe51496efc649d00d098054f.

## Summary by Sourcery

Revert the previous change that skipped warning for record fields missing in schema when additionalProperties was true, restoring the original behavior of always logging warnings for unknown fields and adjusting date parsing logic accordingly

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3042.org.readthedocs.build/en/3042/

<!-- readthedocs-preview meltano-sdk end -->