### PR TITLE
fix: Formalize setting any _falsy_ replication key as a way to force full-table replication

### DIFF
--- a/tests/core/test_streams.py
+++ b/tests/core/test_streams.py
@@ -80,7 +80,11 @@ def stream(tap):
     return tap.load_streams()[0]
 
 
-def test_stream_apply_catalog(stream: Stream):
+@pytest.mark.parametrize("no_replication_key", [None, "", False])
+def test_stream_apply_catalog(
+    stream: Stream,
+    no_replication_key: t.Literal[None, "", False],
+):
     """Applying a catalog to a stream should overwrite fields."""
     assert stream.primary_keys == []
     assert stream.replication_key == "updatedAt"
@@ -98,7 +102,7 @@ def test_stream_apply_catalog(stream: Stream):
                         "stream": stream.name,
                         "schema": stream.schema,
                         "replication_method": REPLICATION_FULL_TABLE,
-                        "replication_key": None,
+                        "replication_key": no_replication_key,
                     },
                 ],
             },


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Parametrize the `test_stream_apply_catalog` test with `None`, empty string, and `False` to assert that all falsy replication_key values trigger full-table replication.