### PR TITLE
test: Add a default output folder to CSV target sample

### DIFF
--- a/samples/sample_target_csv/csv_target.py
+++ b/samples/sample_target_csv/csv_target.py
@@ -13,7 +13,11 @@ class SampleTargetCSV(Target):
     name = "target-csv"
     config_jsonschema = th.PropertiesList(
         th.Property(
-            "target_folder", th.StringType, required=True, title="Target Folder"
+            "target_folder",
+            th.StringType,
+            default="output",
+            required=False,  # Default value will be used if not provided
+            title="Target Folder",
         ),
         th.Property("file_naming_scheme", th.StringType, title="File Naming Scheme"),
     ).to_dict()


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Make the target_folder property optional in the CSV target sample and set its default to 'output'.