### PR TITLE
fix: Pass `auth` callable/tuple to each tap API request

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -423,6 +423,7 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
             "url": url,
             "params": params,
             "headers": headers,
+            "auth": self.authenticator,
         }
 
         if self.payload_as_json:


### PR DESCRIPTION
<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3054.org.readthedocs.build/en/3054/

<!-- readthedocs-preview meltano-sdk end -->

## Summary by Sourcery

Bug Fixes:
- Pass `auth` parameter when preparing REST requests to include the authenticator in each call.