### PR TITLE
fix(templates): Fixed the S3 `BATCH` extra dependency in templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 
 [project.optional-dependencies]
 s3 = [
-    "fs-s3fs~=1.1.1",
+    "s3fs~=2025.5.0",
 ]
 
 [project.scripts]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 
 [project.optional-dependencies]
 s3 = [
-    "fs-s3fs~=1.1.1",
+    "s3fs~=2025.5.0",
 ]
 
 [project.scripts]

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 
 [project.optional-dependencies]
 s3 = [
-    "fs-s3fs~=1.1.1",
+    "s3fs~=2025.5.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Replace fs-s3fs~=1.1.1 with s3fs~=2025.5.0 in the S3 optional dependencies for mapper, tap, and target templates

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3055.org.readthedocs.build/en/3055/

<!-- readthedocs-preview meltano-sdk end -->