### PR TITLE
fix: Revert table name splitting by `-` in SQL targets when `default_target_schema` is set, introduced in #3020

### DIFF
--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -90,9 +90,6 @@ class SQLSink(BatchSink, t.Generic[_C]):
         Returns:
             The target table name.
         """
-        if self.default_target_schema:
-            return self.stream_name
-
         parts = self.stream_name.split("-")
         table = self.stream_name if len(parts) == 1 else parts[-1]
         return self.conform_name(table, "table")

--- a/tests/core/sinks/test_sql_sink.py
+++ b/tests/core/sinks/test_sql_sink.py
@@ -99,14 +99,14 @@ class TestDuckDBSink:
             pytest.param(
                 "foo-bar",  # stream_name
                 "test",  # default_target_schema
-                "foo-bar",  # expected_table_name
+                "bar",  # expected_table_name
                 "test",  # expected_schema_name
                 id="default-schema-2-part",
             ),
             pytest.param(
                 "foo-bar-baz",  # stream_name
                 "test",  # default_target_schema
-                "foo-bar-baz",  # expected_table_name
+                "baz",  # expected_table_name
                 "test",  # expected_schema_name
                 id="default-schema-3-part",
             ),


### PR DESCRIPTION
Reverts #3020.

## Summary by Sourcery

Revert the special case that disabled hyphen splitting for SQL table names when default_target_schema is set, restoring splitting behavior and updating tests.

Bug Fixes:
- Remove the conditional that prevented stream names from being split by hyphens when default_target_schema is provided

Tests:
- Adjust expected table names in SQL sink tests to reflect hyphen splitting for two- and three-part stream names