### PR TITLE
fix: Revert table name splitting by `-` in SQL targets when `default_target_schema` is set, introduced in #3020

### DIFF
--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -90,9 +90,6 @@ class SQLSink(BatchSink, t.Generic[_C]):
         Returns:
             The target table name.
         """
-        if self.default_target_schema:
-            return self.stream_name
-
         parts = self.stream_name.split("-")
         table = self.stream_name if len(parts) == 1 else parts[-1]
         return self.conform_name(table, "table")

--- a/tests/core/sinks/test_sql_sink.py
+++ b/tests/core/sinks/test_sql_sink.py
@@ -99,14 +99,14 @@ class TestDuckDBSink:
             pytest.param(
                 "foo-bar",  # stream_name
                 "test",  # default_target_schema
-                "foo-bar",  # expected_table_name
+                "bar",  # expected_table_name
                 "test",  # expected_schema_name
                 id="default-schema-2-part",
             ),
             pytest.param(
                 "foo-bar-baz",  # stream_name
                 "test",  # default_target_schema
-                "foo-bar-baz",  # expected_table_name
+                "baz",  # expected_table_name
                 "test",  # expected_schema_name
                 id="default-schema-3-part",
             ),


### PR DESCRIPTION
Backport of https://github.com/meltano/sdk/pull/3065 for v0.46.

## Summary by Sourcery

Revert the bypass of hyphen-based table name splitting when default_target_schema is set in SQL sinks, restoring the original logic of splitting stream names on '-' and taking the last segment.

Bug Fixes:
- Restore table name splitting on hyphens for SQL targets when default_target_schema is configured.

Tests:
- Update SQL sink tests to expect the last segment of hyphenated stream names as table names when default_target_schema is set.

Chores:
- Backport the table name splitting revert from upstream to v0.46.