### PR TITLE
chore: Merge branch 'v0.46'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Singer SDK Version
       description: Version of the library you are using
-      placeholder: "0.46.3"
+      placeholder: "0.46.4"
     validations:
       required: true
   - type: checkboxes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.46.4 (2025-05-28)
+
+### 🐛 Fixes
+
+- [#3066](https://github.com/meltano/sdk/issues/3066) Revert table name splitting by `-` in SQL targets when `default_target_schema` is set, introduced in #3020
+
 ## v0.46.3 (2025-05-15)
 
 ### 🐛 Fixes

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -32,9 +32,9 @@ license-files = [ "LICENSE" ]
 requires-python = ">=3.9"
 dependencies = [
     {%- if cookiecutter.faker_extra %}
-    "singer-sdk[faker]~=0.46.3",
+    "singer-sdk[faker]~=0.46.4",
     {%- else %}
-    "singer-sdk~=0.46.3",
+    "singer-sdk~=0.46.4",
     {%- endif %}
 ]
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -35,9 +35,9 @@ license-files = [ "LICENSE" ]
 requires-python = ">=3.9"
 dependencies = [
     {%- if extras %}
-    "singer-sdk[{{ extras|join(',') }}]~=0.46.3",
+    "singer-sdk[{{ extras|join(',') }}]~=0.46.4",
     {%- else %}
-    "singer-sdk~=0.46.3",
+    "singer-sdk~=0.46.4",
     {%- endif %}
     {%- if cookiecutter.stream_type in ["REST", "GraphQL"] %}
     "requests~=2.32.3",

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -31,9 +31,9 @@ license-files = [ "LICENSE" ]
 requires-python = ">=3.9"
 dependencies = [
     {%- if cookiecutter.faker_extra %}
-    "singer-sdk[faker]~=0.46.3",
+    "singer-sdk[faker]~=0.46.4",
     {%- else %}
-    "singer-sdk~=0.46.3",
+    "singer-sdk~=0.46.4",
     {%- endif %}
     {%- if cookiecutter.serialization_method != "SQL" %}
     "requests~=2.32.3",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ copyright = f"{datetime.now().year}, Arch Data, Inc and Contributors"  # noqa: A
 author = "Meltano Core Team and Contributors"
 
 # The full version, including alpha/beta/rc tags
-release = "0.46.3"
+release = "0.46.4"
 
 
 # -- General configuration -------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ xfail_strict = false
 
 [tool.commitizen]
 name = "cz_version_bump"
-version = "0.46.3"
+version = "0.46.4"
 changelog_merge_prerelease = true
 prerelease_offset = 1
 tag_format = "v$major.$minor.$patch$prerelease"


### PR DESCRIPTION
## Summary by Sourcery

Release v0.46.4 with a fix for SQL target table naming and update version numbers and dependency references across the project

Bug Fixes:
- Revert table name splitting by '-' in SQL targets when default_target_schema is set

Enhancements:
- Update singer-sdk dependency pins in cookiecutter tap, target, and mapper templates to ~0.46.4

Build:
- Bump project version to 0.46.4 in pyproject.toml, docs/conf.py, changelog, and commitizen config

Documentation:
- Update ISSUE_TEMPLATE placeholder and documentation release version to 0.46.4

Chores:
- Publish v0.46.4 release

## Summary by Sourcery

Release v0.46.4 with a fix for SQL target table naming and update project version across metadata and templates

Bug Fixes:
- Revert table name splitting by '-' in SQL targets when default_target_schema is set

Chores:
- Bump release version to v0.46.4 and update singer-sdk dependency references in cookiecutter templates, changelog, docs, issue templates, and project metadata