### PR TITLE
fix(templates): Update Cookiecutter templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.8
+  rev: v0.11.11
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
@@ -39,7 +39,7 @@ repos:
   - id: mypy
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.7.2
+  rev: 0.7.8
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.8
+  rev: v0.11.11
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
@@ -45,7 +45,7 @@ repos:
     {%- endif %}
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.7.2
+  rev: 0.7.8
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.8
+  rev: v0.11.11
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
@@ -45,7 +45,7 @@ repos:
     {%- endif %}
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.7.2
+  rev: 0.7.8
   hooks:
   - id: uv-lock
   - id: uv-sync


### PR DESCRIPTION
## Summary by Sourcery

Update pre-commit hook versions in all cookiecutter templates

CI:
- Bump ruff from v0.11.8 to v0.11.11 in mapper, tap, and target templates
- Bump uv-pre-commit from 0.7.2 to 0.7.8 in mapper, tap, and target templates