### PR TITLE
chore: Fix template injection vulnerability reported by zizmor

### DIFF
--- a/.github/workflows/api-changes.yml
+++ b/.github/workflows/api-changes.yml
@@ -49,8 +49,10 @@ jobs:
     - name: Set REF
       id: set-ref
       if: always() && !startsWith(github.head_ref, 'release/')
+      env:
+        GIT_REF: ${{ github.event.pull_request.base.sha }}
       run: |
-        echo "ref=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+        echo "ref=${GIT_REF}" >> $GITHUB_OUTPUT
 
     # Check API against the latest commit on the base branch
     - name: Run Nox  # zizmor: ignore[template-injection]


### PR DESCRIPTION
## Summary by Sourcery

Fix template injection vulnerability in the api-changes GitHub Actions workflow by capturing the pull request’s base SHA in an environment variable and using it for the ref output.

CI:
- Introduce a GIT_REF environment variable to store github.event.pull_request.base.sha
- Use GIT_REF instead of direct event context when setting the ref output in the set-ref step