### PR TITLE
fix: Only finalize state for selected streams

### DIFF
--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -1084,6 +1084,9 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         Args:
             state: State object to promote progress markers with.
         """
+        if not self.selected:
+            return
+
         if state is None or state == {}:
             for child_stream in self.child_streams or []:
                 child_stream.finalize_state_progress_markers()

--- a/tests/core/snapshots/test_parent_child/test_child_deselected_parent/singer.jsonl
+++ b/tests/core/snapshots/test_parent_child/test_child_deselected_parent/singer.jsonl
@@ -14,4 +14,3 @@
 {"type":"RECORD","stream":"child","record":{"id":3,"pid":3},"time_extracted":"2022-01-01T00:00:00+00:00"}
 {"type":"STATE","value":{"bookmarks":{"parent":{"starting_replication_value":null},"child":{"partitions":[{"context":{"pid":1}},{"context":{"pid":2}},{"context":{"pid":3}}]}}}}
 {"type":"STATE","value":{"bookmarks":{"parent":{},"child":{"partitions":[{"context":{"pid":1}},{"context":{"pid":2}},{"context":{"pid":3}}]}}}}
-{"type":"STATE","value":{"bookmarks":{"parent":{},"child":{"partitions":[{"context":{"pid":1}},{"context":{"pid":2}},{"context":{"pid":3}}]}}}}

--- a/tests/core/snapshots/test_parent_child/test_deselected_child/singer.jsonl
+++ b/tests/core/snapshots/test_parent_child/test_deselected_child/singer.jsonl
@@ -3,5 +3,3 @@
 {"type":"RECORD","stream":"parent","record":{"id":2},"time_extracted":"2022-01-01T00:00:00+00:00"}
 {"type":"RECORD","stream":"parent","record":{"id":3},"time_extracted":"2022-01-01T00:00:00+00:00"}
 {"type":"STATE","value":{"bookmarks":{"parent":{}}}}
-{"type":"STATE","value":{"bookmarks":{"parent":{},"child":{}}}}
-{"type":"STATE","value":{"bookmarks":{"parent":{},"child":{}}}}

--- a/tests/core/snapshots/test_parent_child/test_deselected_child/singer.jsonl
+++ b/tests/core/snapshots/test_parent_child/test_deselected_child/singer.jsonl
@@ -1,0 +1,7 @@
+{"type":"SCHEMA","stream":"parent","schema":{"properties":{"id":{"type":"integer"}},"type":"object"},"key_properties":[]}
+{"type":"RECORD","stream":"parent","record":{"id":1},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"parent","record":{"id":2},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"RECORD","stream":"parent","record":{"id":3},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"STATE","value":{"bookmarks":{"parent":{}}}}
+{"type":"STATE","value":{"bookmarks":{"parent":{},"child":{}}}}
+{"type":"STATE","value":{"bookmarks":{"parent":{},"child":{}}}}

--- a/tests/core/snapshots/test_parent_child/test_deselected_child/stderr.log
+++ b/tests/core/snapshots/test_parent_child/test_deselected_child/stderr.log
@@ -1,0 +1,2 @@
+INFO my-tap Skipping deselected stream 'child'.
+INFO my-tap.parent Beginning full_table sync of 'parent'

--- a/tests/core/test_parent_child.py
+++ b/tests/core/test_parent_child.py
@@ -86,16 +86,17 @@ def tap():
 @pytest.fixture
 def tap_with_deselected_parent(tap: MyTap):
     """A tap with a parent stream deselected."""
-    original = tap.catalog["parent"].metadata[()].selected
-    tap.catalog["parent"].metadata[()].selected = False
+    stream_metadata = tap.catalog["parent"].metadata.root
+    original = stream_metadata.selected
+    stream_metadata.selected = False
     yield tap
-    tap.catalog["parent"].metadata[()].selected = original
+    stream_metadata.selected = original
 
 
 @pytest.fixture
 def tap_with_deselected_child(tap: MyTap):
     """A tap with a child stream deselected."""
-    stream_metadata = tap.catalog["child"].metadata[()]
+    stream_metadata = tap.catalog["child"].metadata.root
     original = stream_metadata.selected
     stream_metadata.selected = False
     yield tap

--- a/tests/core/test_parent_child.py
+++ b/tests/core/test_parent_child.py
@@ -169,7 +169,7 @@ def test_deselected_child(
     caplog: pytest.LogCaptureFixture,
     snapshot: Snapshot,
 ):
-    """Test tap output with parent stream deselected."""
+    """Test tap output when a child stream is deselected."""
     child_stream = tap_with_deselected_child.streams["child"]
 
     assert not child_stream.selected


### PR DESCRIPTION
Closes #2350

## Summary by Sourcery

Add support for testing deselected child streams by introducing a fixture and snapshot-based test.

Tests:
- Introduce a pytest fixture to deselect a child stream for test scenarios
- Add a snapshot test to validate output and logs when a child stream is deselected

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3077.org.readthedocs.build/en/3077/

<!-- readthedocs-preview meltano-sdk end -->

## Summary by Sourcery

Skip finalizing state markers for deselected streams and add snapshot-based tests for deselected child streams.

Bug Fixes:
- Only finalize state progress markers for streams with selected set to True.

Tests:
- Refactor tap_with_deselected_parent fixture to use metadata.root and add tap_with_deselected_child fixture.
- Add a snapshot test to validate sync output and logs when a child stream is deselected.