### PR TITLE
refactor: Introduce basic `TypedDict` for tap state

### DIFF
--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -24,7 +24,7 @@ logger = logging.getLogger("singer_sdk")
 
 
 def get_state_if_exists(
-    tap_state: dict,
+    tap_state: types.TapState,
     tap_stream_id: str,
     state_partition_context: dict | None = None,
     key: str | None = None,
@@ -65,7 +65,10 @@ def get_state_if_exists(
     return matched_partition.get(key, None) if key else matched_partition
 
 
-def get_state_partitions_list(tap_state: dict, tap_stream_id: str) -> list[dict] | None:
+def get_state_partitions_list(
+    tap_state: types.TapState,
+    tap_stream_id: str,
+) -> list[dict] | None:
     """Return a list of partitions defined in the state, or None if not defined."""
     return (get_state_if_exists(tap_state, tap_stream_id) or {}).get("partitions", None)
 
@@ -99,7 +102,7 @@ def _create_in_partitions_list(
 
 
 def get_writeable_state_dict(
-    tap_state: dict,
+    tap_state: types.TapState,
     tap_stream_id: str,
     state_partition_context: types.Context | None = None,
 ) -> dict:
@@ -125,7 +128,7 @@ def get_writeable_state_dict(
         tap_state["bookmarks"] = {}
     if tap_stream_id not in tap_state["bookmarks"]:
         tap_state["bookmarks"][tap_stream_id] = {}
-    stream_state = t.cast("dict", tap_state["bookmarks"][tap_stream_id])
+    stream_state = tap_state["bookmarks"][tap_stream_id]
     if not state_partition_context:
         return stream_state
 
@@ -142,7 +145,7 @@ def get_writeable_state_dict(
 
 
 def write_stream_state(
-    tap_state: dict,
+    tap_state: types.TapState,
     tap_stream_id: str,
     key: str,
     val: t.Any,  # noqa: ANN401

--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -26,7 +26,7 @@ logger = logging.getLogger("singer_sdk")
 def get_state_if_exists(
     tap_state: types.TapState,
     tap_stream_id: str,
-    state_partition_context: dict | None = None,
+    state_partition_context: types.Context | None = None,
     key: str | None = None,
 ) -> t.Any | None:  # noqa: ANN401
     """Return the stream or partition state, creating a new one if it does not exist.
@@ -150,7 +150,7 @@ def write_stream_state(
     key: str,
     val: t.Any,  # noqa: ANN401
     *,
-    state_partition_context: dict | None = None,
+    state_partition_context: types.Context | None = None,
 ) -> None:
     """Write stream state."""
     state_dict = get_writeable_state_dict(

--- a/singer_sdk/helpers/types.py
+++ b/singer_sdk/helpers/types.py
@@ -22,3 +22,9 @@ __all__ = [
 Context: TypeAlias = Mapping[str, t.Any]
 Record: TypeAlias = dict[str, t.Any]
 Auth: TypeAlias = t.Callable[[requests.PreparedRequest], requests.PreparedRequest]
+
+
+class TapState(t.TypedDict, total=False):
+    """Tap state."""
+
+    bookmarks: dict[str, dict[str, t.Any]]

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -374,7 +374,7 @@ class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
     # Abstract methods:
 
     @property
-    def state(self) -> dict:
+    def state(self) -> t.Mapping[str, t.Any]:
         """Get state.
 
         Raises:

--- a/singer_sdk/singerlib/encoding/simple.py
+++ b/singer_sdk/singerlib/encoding/simple.py
@@ -6,6 +6,7 @@ import json
 import logging
 import sys
 import typing as t
+from collections.abc import Mapping  # noqa: TC003
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 
@@ -173,7 +174,7 @@ class SchemaMessage(Message):
 class StateMessage(Message):
     """Singer state message."""
 
-    value: dict[str, t.Any]
+    value: Mapping[str, t.Any]
     """The state value."""
 
     def __post_init__(self) -> None:

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -159,7 +159,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         self._mask: singer.SelectionMask | None = None
         self._schema: dict
         self._is_state_flushed: bool = True
-        self._last_emitted_state: dict | None = None
+        self._last_emitted_state: types.TapState | None = None
         self._sync_costs: dict[str, int] = {}
         self.child_streams: list[Stream] = []
         if schema:
@@ -705,7 +705,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
     # State properties:
 
     @property
-    def tap_state(self) -> dict:
+    def tap_state(self) -> types.TapState:
         """Return a writeable state dict for the entire tap.
 
         Note: This dictionary is shared (and writable) across all streams.

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -37,6 +37,7 @@ if t.TYPE_CHECKING:
     from pathlib import PurePath
 
     from singer_sdk.connectors import SQLConnector
+    from singer_sdk.helpers import types
     from singer_sdk.mapper import PluginMapper
     from singer_sdk.singerlib.encoding.base import GenericSingerWriter
     from singer_sdk.streams import SQLStream, Stream
@@ -103,7 +104,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         # Declare private members
         self._streams: dict[str, Stream] | None = None
         self._input_catalog: Catalog | None = None
-        self._state: dict[str, Stream] = {}
+        self._state: types.TapState = {}
         self._catalog: Catalog | None = None  # Tap's working catalog
 
         # Process input catalog
@@ -161,7 +162,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         return self._streams
 
     @property
-    def state(self) -> dict:
+    def state(self) -> types.TapState:
         """Get tap state.
 
         Returns:


### PR DESCRIPTION
## Summary by Sourcery

Introduce a TypedDict for tap state and update state-related APIs to use it for stronger type safety

Enhancements:
- Define a new TapState TypedDict to represent bookmarks in tap state
- Update state-handling functions and properties to use TapState instead of generic dicts
- Refine state value type hints to Mapping[str, Any] in encoding and plugin classes