### PR TITLE
feat: Honor `<APP_NAME>_LOGLEVEL` and `LOGLEVEL` environment variables across all default logging

### DIFF
--- a/singer_sdk/_logging.py
+++ b/singer_sdk/_logging.py
@@ -6,8 +6,6 @@ import sys
 import typing as t
 from pathlib import Path
 
-from singer_sdk.metrics import METRICS_LOGGER_NAME
-
 if t.TYPE_CHECKING:
     from singer_sdk.helpers._compat import Traversable
 
@@ -27,15 +25,15 @@ def _load_yaml_logging_config(path: Traversable | Path) -> t.Any:  # noqa: ANN40
         return yaml.safe_load(f)
 
 
-def _setup_console_logging() -> None:
+def _setup_console_logging(*, log_level: str | None = None) -> None:
     """Setup logging.
 
     Args:
-        package: The package name to get the logging configuration for.
-        config: A plugin configuration dictionary.
+        log_level: The log level to set.
     """
+    level = log_level or logging.INFO
     root = logging.getLogger()
-    root.setLevel(logging.INFO)
+    root.setLevel(level)
     root_formatter = logging.Formatter(
         "{asctime:23s} | {levelname:8s} | {name:20s} | {message}",
         style="{",
@@ -43,8 +41,6 @@ def _setup_console_logging() -> None:
     handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(root_formatter)
     root.addHandler(handler)
-    metrics_logger = logging.getLogger(METRICS_LOGGER_NAME)
-    metrics_logger.setLevel(logging.INFO)
 
     if "SINGER_SDK_LOG_CONFIG" in os.environ:  # pragma: no cover
         log_config_path = Path(os.environ["SINGER_SDK_LOG_CONFIG"])

--- a/singer_sdk/_logging.py
+++ b/singer_sdk/_logging.py
@@ -25,7 +25,7 @@ def _load_yaml_logging_config(path: Traversable | Path) -> t.Any:  # noqa: ANN40
         return yaml.safe_load(f)
 
 
-def _setup_console_logging(*, log_level: str | None = None) -> None:
+def _setup_console_logging(*, log_level: str | int | None = None) -> None:
     """Setup logging.
 
     Args:

--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -102,8 +102,8 @@ class SingerMetricsFormatter(logging.Formatter):
             **kwargs: Keyword arguments.
         """
         warnings.warn(
-            "SingerMetricsFormatter is deprecated and will be removed in a future "
-            "version. Use a different formatter.",
+            "SingerMetricsFormatter is deprecated and will be removed by September "
+            "2025. Use a different formatter.",
             SingerSDKDeprecationWarning,
             stacklevel=2,
         )

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -42,11 +42,6 @@ from singer_sdk.typing import (
     extend_validator_with_defaults,
 )
 
-if sys.version_info >= (3, 11):
-    _LOG_LEVELS_MAPPING = logging.getLevelNamesMapping()
-else:
-    _LOG_LEVELS_MAPPING = logging._nameToLevel  # noqa: SLF001
-
 if t.TYPE_CHECKING:
     from jsonschema import ValidationError
 

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -223,7 +223,7 @@ class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
             warnings.warn(
                 f"Using {metrics.METRICS_LOG_LEVEL_SETTING} to set metrics log level "
                 "is deprecated and will be removed by September 2025. "
-                "Please use the the logging level environment variables "
+                "Please use the logging level environment variables "
                 "or a custom logging configuration file.",
                 SingerSDKDeprecationWarning,
                 stacklevel=2,

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -56,6 +56,7 @@ if t.TYPE_CHECKING:
     )
 
 SDK_PACKAGE_NAME = "singer_sdk"
+DEFAULT_LOG_LEVEL = "INFO"
 
 JSONSchemaValidator = extend_validator_with_defaults(DEFAULT_JSONSCHEMA_VALIDATOR)
 
@@ -122,6 +123,20 @@ def _format_validation_error(error: ValidationError) -> str:
     return result
 
 
+def _plugin_log_level(*, plugin_name: str) -> str:
+    """Get the log level for a plugin.
+
+    Args:
+        plugin_name: The name of the plugin.
+
+    Returns:
+        The log level.
+    """
+    prefix = f"{plugin_name.upper().replace('-', '_')}_"
+    level = os.environ.get(f"{prefix}LOGLEVEL") or os.environ.get("LOGLEVEL")
+    return level.upper() if level is not None else DEFAULT_LOG_LEVEL
+
+
 class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
     """Abstract base class for taps."""
 
@@ -143,18 +158,7 @@ class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
         Returns:
             Plugin logger.
         """
-        # Get the level from <PLUGIN_NAME>_LOGLEVEL or LOGLEVEL environment variables
-        plugin_env_prefix = f"{cls.name.upper().replace('-', '_')}_"
-        log_level = os.environ.get(f"{plugin_env_prefix}LOGLEVEL") or os.environ.get(
-            "LOGLEVEL",
-        )
-
-        logger = logging.getLogger(cls.name)
-
-        if log_level is not None and log_level.upper() in _LOG_LEVELS_MAPPING:
-            logger.setLevel(log_level.upper())
-
-        return logger
+        return logging.getLogger(cls.name)
 
     # Constructor
 
@@ -213,9 +217,19 @@ class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
         self._config = config_dict
         self.metrics_logger = metrics.get_metrics_logger()
         if metrics_level := self.config.get(
-            metrics.METRICS_LOG_LEVEL_SETTING
+            metrics.METRICS_LOG_LEVEL_SETTING,
         ):  # pragma: no cover
             self.metrics_logger.setLevel(metrics_level)
+            warnings.warn(
+                f"Using {metrics.METRICS_LOG_LEVEL_SETTING} to set metrics log level "
+                "is deprecated and will be removed by September 2025. "
+                "Please use the the logging level environment variables "
+                "or a custom logging configuration file.",
+                SingerSDKDeprecationWarning,
+                stacklevel=2,
+            )
+        else:
+            self.metrics_logger.setLevel(_plugin_log_level(plugin_name=self.name))
 
         self._validate_config(raise_errors=validate_config)
         self._mapper: PluginMapper | None = None
@@ -677,7 +691,7 @@ class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
         Returns:
             A callable CLI object.
         """
-        _setup_console_logging()
+        _setup_console_logging(log_level=_plugin_log_level(plugin_name=cls.name))
         return cls.get_singer_command()
 
 


### PR DESCRIPTION
## Summary by Sourcery

Centralize logging configuration by supporting `<PLUGIN_NAME>_LOGLEVEL` and `LOGLEVEL` environment variables, refactor console logging setup to accept dynamic log levels, and deprecate the `metrics.METRICS_LOG_LEVEL_SETTING` in favor of environment-based configuration.

New Features:
- Honor `<PLUGIN_NAME>_LOGLEVEL` and `LOGLEVEL` environment variables to configure plugin and metrics logging

Enhancements:
- Introduce `DEFAULT_LOG_LEVEL` and centralize log level resolution in `_plugin_log_level`
- Refactor `_setup_console_logging` to accept a `log_level` parameter and apply it to the root logger, removing hardcoded metrics logger setup
- Replace manual logger level setting in `PluginBase.logger` and `cli` with the new `_plugin_log_level` mechanism