### PR TITLE
chore: Clean up deptry ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,9 +247,6 @@ PyJWT = "jwt"
 
 [tool.deptry.per_rule_ignores]
 DEP002 = [
-    # Transitive constraints
-    "numpy",
-    "urllib3",
     # Plugins
     "paramiko",
     "s3fs",


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove numpy and urllib3 from DEP002 per-rule ignores in pyproject.toml

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3089.org.readthedocs.build/en/3089/

<!-- readthedocs-preview meltano-sdk end -->