### PR TITLE
fix: Correctly resolve JSON schema references when mulitple properties use the same reference

### DIFF
--- a/tests/singerlib/test_schema.py
+++ b/tests/singerlib/test_schema.py
@@ -415,6 +415,30 @@ def test_schema_from_dict(pydict, expected):
             },
             id="resolve_schema_references_with_circular_references",
         ),
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {
+                    "min_compute_units": {"$ref": "components#/schemas/ComputeUnit"},
+                    "max_compute_units": {"$ref": "components#/schemas/ComputeUnit"},
+                },
+            },
+            {
+                "components": {
+                    "schemas": {
+                        "ComputeUnit": {"type": "number"},
+                    },
+                },
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "min_compute_units": {"type": "number"},
+                    "max_compute_units": {"type": "number"},
+                },
+            },
+            id="resolve_schema_multiple_properties_with_same_reference",
+        ),
     ],
 )
 def test_resolve_schema_references(schema, refs, expected):


### PR DESCRIPTION
## Related

- Closes #3090
- Introduced by #3009

## Summary by Sourcery

Ensure JSON schema references are correctly dereferenced when multiple properties refer to the identical component to prevent shared-state issues

Bug Fixes:
- Correct JSON schema resolution when multiple properties reference the same schema component

Tests:
- Add a test case for resolving multiple properties using the same JSON schema reference

## Summary by Sourcery

Fix JSON schema reference resolution to correctly dereference identical components for multiple properties without shared-state issues

Bug Fixes:
- Ensure separate resolution of identical schema references used by multiple properties to prevent state leakage

Enhancements:
- Switch visited_refs from a mutable set to an immutable tuple to accurately track recursion depth

Tests:
- Add a test case for resolving multiple properties referencing the same JSON schema component