### PR TITLE
docs: Clarify that using `--discover` and `--catalog=<catalog file>` together is not supported

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -96,7 +96,7 @@ uv run tap-mysource --discover \
 
 ## Run in discovery mode with a passed catalog file
 
-```{note}
+```{warning}
 This pattern may not be supported by all connectors. By default and in general, the
 `--catalog` option is not used during discovery mode.
 ```


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3095.org.readthedocs.build/en/3095/

<!-- readthedocs-preview meltano-sdk end -->