### PR TITLE
chore(templates): Add name to wheel and sdist build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ permissions: {}
 
 jobs:
   build:
-    name: Build artifacts
+    name: Build Wheel and SDist
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.baipp.outputs.package_version }}

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   build:
+    name: Build Wheel and SDist
     runs-on: ubuntu-latest
     outputs:
       name: {{ '${{ steps.baipp.outputs.package_name }}' }}

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   build:
+    name: Build Wheel and SDist
     runs-on: ubuntu-latest
     outputs:
       name: {{ '${{ steps.baipp.outputs.package_name }}' }}

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   build:
+    name: Build Wheel and SDist
     runs-on: ubuntu-latest
     outputs:
       name: {{ '${{ steps.baipp.outputs.package_name }}' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "singer-sdk"
 dynamic = [
-    "version"
+    "version",
 ]
 description = "A framework for building Singer taps"
 authors = [{ name = "Meltano Team and Contributors", email = "hello@meltano.com" }]


### PR DESCRIPTION
## Summary by Sourcery

Provide explicit names for Wheel and SDist build jobs in cookiecutter workflow templates and fix trailing comma in the dynamic version list

Build:
- Add trailing comma to the dynamic version list in pyproject.toml

CI:
- Add "Build Wheel and SDist" job name to mapper, tap, and target template build workflows

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3105.org.readthedocs.build/en/3105/

<!-- readthedocs-preview meltano-sdk end -->