### PR TITLE
fix(taps): Suppress unmapped warning for additional properties

### DIFF
--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -450,7 +450,8 @@ def _conform_record_data_types(
         if property_name not in schema["properties"]:
             if schema.get("additionalProperties"):
                 output_object[property_name] = elem
-            unmapped_properties.append(property_path)
+            else:
+                unmapped_properties.append(property_path)
             continue
 
         property_schema = schema["properties"][property_name]

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -290,10 +290,7 @@ def test_conform_object_additional_properties(caplog: pytest.LogCaptureFixture):
         )
 
         assert actual_output == expected_output
-        assert caplog.records[0].message == (
-            "Properties ('object.extra',) were present in the 'test_stream' stream but "
-            "not found in catalog schema. Ignoring."
-        )
+        assert not caplog.records
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Similar fix to #3031/#3048 for taps.

## Summary by Sourcery

Suppress warnings for unmapped properties when additionalProperties is enabled and update tests to verify no warnings are emitted for additional properties

Bug Fixes:
- Only track unmapped properties when additionalProperties is disabled in _conform_record_data_types

Tests:
- Wrap the conformity call in caplog and assert no warnings are logged for additionalProperties