### PR TITLE
test: Test unmapped properties warning still shows when no additional properties specified

### DIFF
--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -14,6 +14,7 @@ import sqlalchemy as sa
 from singer_sdk.helpers._typing import (
     TypeConformanceLevel,
     _conform_primitive_property,
+    _warn_unmapped_properties,
     conform_record_data_types,
 )
 from singer_sdk.typing import (
@@ -30,6 +31,12 @@ if t.TYPE_CHECKING:
     from pytest_benchmark.fixture import BenchmarkFixture
 
 logger = logging.getLogger("log")
+
+
+@pytest.fixture(autouse=True)
+def reset__warn_unmapped_properties_log_cache():
+    yield
+    _warn_unmapped_properties.cache_clear()
 
 
 def test_simple_schema_conforms_types():
@@ -291,6 +298,37 @@ def test_conform_object_additional_properties(caplog: pytest.LogCaptureFixture):
 
         assert actual_output == expected_output
         assert not caplog.records
+
+
+@pytest.mark.parametrize("additional_properties", [False, None])
+def test_conform_object_no_additional_properties(
+    caplog: pytest.LogCaptureFixture,
+    additional_properties: bool | None,
+):
+    schema = PropertiesList(
+        Property(
+            "object",
+            PropertiesList(additional_properties=additional_properties),
+        ),
+    ).to_dict()
+
+    record = {"object": {"extra": "value"}}
+    expected_output = {"object": {}}
+
+    with caplog.at_level(logging.WARNING):
+        actual_output = conform_record_data_types(
+            "test_stream",
+            record,
+            schema,
+            TypeConformanceLevel.RECURSIVE,
+            logger,
+        )
+
+        assert actual_output == expected_output
+        assert caplog.records[0].message == (
+            "Properties ('object.extra',) were present in the 'test_stream' stream but "
+            "not found in catalog schema. Ignoring."
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follow-up #3108

## Summary by Sourcery

Add an autouse fixture to clear the unmapped-properties warning cache between tests and add a parametrized test to ensure that `conform_record_data_types` emits a warning and filters out extra fields when `additional_properties` is set to `False` or `None`.

Tests:
- Introduce an autouse pytest fixture to reset the `_warn_unmapped_properties` cache after each test.
- Add a parametrized test verifying that unmapped object properties trigger a warning and are dropped when `additional_properties` is `False` or `None`.