### PR TITLE
fix(taps): Ensure state progress markers in child streams are finalized

### DIFF
--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -1110,14 +1110,14 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         Args:
             state: State object to promote progress markers with.
         """
-        if not self.selected:
-            return
-
         if state is None or state == {}:
             for child_stream in self.child_streams or []:
-                child_stream.finalize_state_progress_markers()
+                if child_stream.selected:
+                    child_stream.finalize_state_progress_markers()
 
-            context: types.Context | None
+            if not self.selected:
+                return
+
             for context in self.partitions or [{}]:
                 state = self.get_context_state(context or None)
                 self._finalize_state(state)

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -1193,7 +1193,6 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
                 timer.context = context_element
 
                 current_context = context_element or None
-                state = self.get_context_state(current_context)
                 state_partition_context = self._get_state_partition_context(
                     current_context,
                 )
@@ -1258,6 +1257,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
                 if current_context == state_partition_context:
                     # Finalize per-partition state only if 1:1 with context
+                    state = self.get_context_state(current_context)
                     self._finalize_state(state)
 
         if not context:

--- a/tests/core/snapshots/test_parent_child/test_child_deselected_parent/singer.jsonl
+++ b/tests/core/snapshots/test_parent_child/test_child_deselected_parent/singer.jsonl
@@ -14,3 +14,4 @@
 {"type":"RECORD","stream":"child","record":{"id":3,"pid":3},"time_extracted":"2022-01-01T00:00:00+00:00"}
 {"type":"STATE","value":{"bookmarks":{"parent":{"starting_replication_value":null},"child":{"partitions":[{"context":{"pid":1}},{"context":{"pid":2}},{"context":{"pid":3}}]}}}}
 {"type":"STATE","value":{"bookmarks":{"parent":{},"child":{"partitions":[{"context":{"pid":1}},{"context":{"pid":2}},{"context":{"pid":3}}]}}}}
+{"type":"STATE","value":{"bookmarks":{"parent":{},"child":{"partitions":[{"context":{"pid":1}},{"context":{"pid":2}},{"context":{"pid":3}}]}}}}


### PR DESCRIPTION
## Summary by Sourcery

Fix the state progress marker finalization flow to respect stream selection and correct state retrieval during record syncing

Bug Fixes:
- Only propagate and finalize state progress markers on selected child streams and defer parent skip until after child processing
- Reposition state retrieval inside the partition match branch in `_sync_records` to ensure per-partition state is properly defined

Tests:
- Update snapshot for parent-child deselection scenario

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3111.org.readthedocs.build/en/3111/

<!-- readthedocs-preview meltano-sdk end -->