### PR TITLE
fix(templates): Remove redundant `tool.ruff.target-version` from tap template

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -88,9 +88,6 @@ warn_unused_configs = true
 plugins = "sqlmypy"
 {%- endif %}
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 ignore = [
     "COM812",  # missing-trailing-comma


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3113.org.readthedocs.build/en/3113/

<!-- readthedocs-preview meltano-sdk end -->