### PR TITLE
fix: Centralize state writing to avoid emitting duplicate STATE messages

### DIFF
--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -338,31 +338,7 @@ class StateWriter:
         Args:
             state: The current tap state to potentially emit.
         """
-        if not state:
-            return
-
         # Check if state has changed since last emission
         if self._last_emitted_state is None or state != self._last_emitted_state:
             self._message_writer.write_message(StateMessage(value=state))
             self._last_emitted_state = copy.deepcopy(state)
-
-    def reset_last_emitted_state(self) -> None:
-        """Reset the tracking of last emitted state.
-
-        This can be useful when you want to force the next state write
-        regardless of whether it appears to be a duplicate.
-        """
-        self._last_emitted_state = None
-
-    @property
-    def last_emitted_state(self) -> types.TapState | None:
-        """Get the last emitted state for inspection purposes.
-
-        Returns:
-            A deep copy of the last emitted state, or None if no state has been emitted.
-        """
-        return (
-            copy.deepcopy(self._last_emitted_state)
-            if self._last_emitted_state
-            else None
-        )

--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import copy
 import logging
-import threading
 import typing as t
 
 from singer_sdk.exceptions import InvalidStreamSortException
@@ -329,7 +328,6 @@ class StateWriter:
         """
         self._message_writer = message_writer
         self._last_emitted_state: types.TapState | None = None
-        self._lock = threading.Lock()
 
     def write_state(self, state: types.TapState) -> None:
         """Write a state message if the state has changed.
@@ -337,43 +335,34 @@ class StateWriter:
         This method checks if the provided state is different from the last
         emitted state and only writes a STATE message if there are changes.
 
-        Thread-safe: Uses a lock to ensure atomic state comparison and emission.
-
         Args:
             state: The current tap state to potentially emit.
         """
         if not state:
             return
 
-        with self._lock:
-            # Check if state has changed since last emission
-            if self._last_emitted_state is None or state != self._last_emitted_state:
-                self._message_writer.write_message(StateMessage(value=state))
-                self._last_emitted_state = copy.deepcopy(state)
+        # Check if state has changed since last emission
+        if self._last_emitted_state is None or state != self._last_emitted_state:
+            self._message_writer.write_message(StateMessage(value=state))
+            self._last_emitted_state = copy.deepcopy(state)
 
     def reset_last_emitted_state(self) -> None:
         """Reset the tracking of last emitted state.
 
         This can be useful when you want to force the next state write
         regardless of whether it appears to be a duplicate.
-
-        Thread-safe: Uses a lock to ensure atomic reset operation.
         """
-        with self._lock:
-            self._last_emitted_state = None
+        self._last_emitted_state = None
 
     @property
     def last_emitted_state(self) -> types.TapState | None:
         """Get the last emitted state for inspection purposes.
 
-        Thread-safe: Uses a lock to ensure consistent read of state.
-
         Returns:
             A deep copy of the last emitted state, or None if no state has been emitted.
         """
-        with self._lock:
-            return (
-                copy.deepcopy(self._last_emitted_state)
-                if self._last_emitted_state
-                else None
-            )
+        return (
+            copy.deepcopy(self._last_emitted_state)
+            if self._last_emitted_state
+            else None
+        )

--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -9,11 +9,13 @@ import typing as t
 
 from singer_sdk.exceptions import InvalidStreamSortException
 from singer_sdk.helpers._typing import to_json_compatible
+from singer_sdk.singerlib.encoding.simple import StateMessage
 
 if t.TYPE_CHECKING:
     import datetime
 
     from singer_sdk.helpers import types
+    from singer_sdk.singerlib.encoding.base import GenericSingerWriter
 
     _T = t.TypeVar("_T", datetime.datetime, str, int, float)
 
@@ -318,7 +320,7 @@ class StateWriter:
     has actually changed.
     """
 
-    def __init__(self, message_writer: t.Any) -> None:
+    def __init__(self, message_writer: GenericSingerWriter) -> None:
         """Initialize the StateWriter.
 
         Args:
@@ -346,9 +348,6 @@ class StateWriter:
         with self._lock:
             # Check if state has changed since last emission
             if self._last_emitted_state is None or state != self._last_emitted_state:
-                # Import here to avoid circular imports
-                from singer_sdk.singerlib.encoding.simple import StateMessage
-
                 self._message_writer.write_message(StateMessage(value=state))
                 self._last_emitted_state = copy.deepcopy(state)
 

--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -327,7 +327,6 @@ class StateWriter:
         """
         self._message_writer = message_writer
         self._last_emitted_state: types.TapState | None = None
-        self._logger = logging.getLogger("singer_sdk.state_writer")
         self._lock = threading.Lock()
 
     def write_state(self, state: types.TapState) -> None:
@@ -352,9 +351,6 @@ class StateWriter:
 
                 self._message_writer.write_message(StateMessage(value=state))
                 self._last_emitted_state = copy.deepcopy(state)
-                self._logger.debug("State message written")
-            else:
-                self._logger.debug("State unchanged, skipping duplicate state message")
 
     def reset_last_emitted_state(self) -> None:
         """Reset the tracking of last emitted state.

--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 import typing as t
 
@@ -305,3 +306,64 @@ def log_sort_error(
         msg += f"Context was {current_context!s}. "
     msg += str(ex)
     log_fn(msg)
+
+
+class StateWriter:
+    """Centralized state message writer that prevents duplicate state emissions.
+
+    This class manages the writing of STATE messages to ensure that duplicate
+    state messages are not emitted across multiple streams or tap-level operations.
+    It tracks the last emitted state and only writes new messages when the state
+    has actually changed.
+    """
+
+    def __init__(self, message_writer: t.Any) -> None:
+        """Initialize the StateWriter.
+
+        Args:
+            message_writer: The message writer instance (typically from tap)
+                           that has a write_message method.
+        """
+        self._message_writer = message_writer
+        self._last_emitted_state: types.TapState | None = None
+        self._logger = logging.getLogger("singer_sdk.state_writer")
+
+    def write_state(self, state: types.TapState) -> None:
+        """Write a state message if the state has changed.
+
+        This method checks if the provided state is different from the last
+        emitted state and only writes a STATE message if there are changes.
+
+        Args:
+            state: The current tap state to potentially emit.
+        """
+        if not state:
+            return
+
+        # Check if state has changed since last emission
+        if self._last_emitted_state is None or state != self._last_emitted_state:
+            # Import here to avoid circular imports
+            from singer_sdk.singerlib.encoding.simple import StateMessage
+
+            self._message_writer.write_message(StateMessage(value=state))
+            self._last_emitted_state = copy.deepcopy(state)
+            self._logger.debug("State message written")
+        else:
+            self._logger.debug("State unchanged, skipping duplicate state message")
+
+    def reset_last_emitted_state(self) -> None:
+        """Reset the tracking of last emitted state.
+
+        This can be useful when you want to force the next state write
+        regardless of whether it appears to be a duplicate.
+        """
+        self._last_emitted_state = None
+
+    @property
+    def last_emitted_state(self) -> types.TapState | None:
+        """Get the last emitted state for inspection purposes."""
+        return (
+            copy.deepcopy(self._last_emitted_state)
+            if self._last_emitted_state
+            else None
+        )

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -107,7 +107,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         self._input_catalog: Catalog | None = None
         self._state: types.TapState = {}
         self._catalog: Catalog | None = None  # Tap's working catalog
-        self._state_writer: StateWriter = StateWriter(self)
+        self._state_writer: StateWriter = StateWriter(self.message_writer)
 
         # Process input catalog
         if isinstance(catalog, Catalog):

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -20,7 +20,7 @@ from singer_sdk.exceptions import (
 from singer_sdk.helpers import _state
 from singer_sdk.helpers._classproperty import classproperty
 from singer_sdk.helpers._compat import SingerSDKDeprecationWarning
-from singer_sdk.helpers._state import write_stream_state
+from singer_sdk.helpers._state import StateWriter, write_stream_state
 from singer_sdk.helpers._util import dump_json, read_json_file
 from singer_sdk.helpers.capabilities import (
     BATCH_CONFIG,
@@ -31,7 +31,7 @@ from singer_sdk.helpers.capabilities import (
 )
 from singer_sdk.io_base import SingerWriter
 from singer_sdk.plugin_base import BaseSingerWriter, PluginBase
-from singer_sdk.singerlib import Catalog, StateMessage
+from singer_sdk.singerlib import Catalog
 
 if t.TYPE_CHECKING:
     from pathlib import PurePath
@@ -107,6 +107,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         self._input_catalog: Catalog | None = None
         self._state: types.TapState = {}
         self._catalog: Catalog | None = None  # Tap's working catalog
+        self._state_writer: StateWriter = StateWriter(self)
 
         # Process input catalog
         if isinstance(catalog, Catalog):
@@ -185,6 +186,15 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
             Catalog dictionary input, or None if not provided.
         """
         return self._input_catalog
+
+    @property
+    def state_writer(self) -> StateWriter:
+        """Get the centralized state writer for this tap.
+
+        Returns:
+            The StateWriter instance for coordinated state message writing.
+        """
+        return self._state_writer
 
     @property
     def catalog(self) -> Catalog:
@@ -473,7 +483,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         self._reset_state_progress_markers()
         self._set_compatible_replication_methods()
         if self.state:
-            self.write_message(StateMessage(value=self.state))
+            self._state_writer.write_state(self.state)
 
         stream: Stream
         for stream in self.streams.values():
@@ -515,7 +525,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         # Emit a final state message to ensure the state is written to the output
         # even if the process is terminated by a signal.
         try:
-            self.write_message(StateMessage(value=self.state))
+            self._state_writer.write_state(self.state)
         finally:
             super()._handle_termination(signum, frame)
 

--- a/tests/core/snapshots/test_parent_child/test_child_deselected_parent/singer.jsonl
+++ b/tests/core/snapshots/test_parent_child/test_child_deselected_parent/singer.jsonl
@@ -14,4 +14,3 @@
 {"type":"RECORD","stream":"child","record":{"id":3,"pid":3},"time_extracted":"2022-01-01T00:00:00+00:00"}
 {"type":"STATE","value":{"bookmarks":{"parent":{"starting_replication_value":null},"child":{"partitions":[{"context":{"pid":1}},{"context":{"pid":2}},{"context":{"pid":3}}]}}}}
 {"type":"STATE","value":{"bookmarks":{"parent":{},"child":{"partitions":[{"context":{"pid":1}},{"context":{"pid":2}},{"context":{"pid":3}}]}}}}
-{"type":"STATE","value":{"bookmarks":{"parent":{},"child":{"partitions":[{"context":{"pid":1}},{"context":{"pid":2}},{"context":{"pid":3}}]}}}}

--- a/tests/core/snapshots/test_parent_child/test_one_parent_many_children/singer.jsonl
+++ b/tests/core/snapshots/test_parent_child/test_one_parent_many_children/singer.jsonl
@@ -10,4 +10,3 @@
 {"type":"STATE","value":{"bookmarks":{"parent_many":{"starting_replication_value":null},"child_many":{"partitions":[{"context":{"child_id":1,"pid":"1"}},{"context":{"child_id":2,"pid":"1"}},{"context":{"child_id":3,"pid":"1"}}]}}}}
 {"type":"RECORD","stream":"parent_many","record":{"id":"1","children":[1,2,3]},"time_extracted":"2022-01-01T00:00:00+00:00"}
 {"type":"STATE","value":{"bookmarks":{"parent_many":{},"child_many":{"partitions":[{"context":{"child_id":1,"pid":"1"}},{"context":{"child_id":2,"pid":"1"}},{"context":{"child_id":3,"pid":"1"}}]}}}}
-{"type":"STATE","value":{"bookmarks":{"parent_many":{},"child_many":{"partitions":[{"context":{"child_id":1,"pid":"1"}},{"context":{"child_id":2,"pid":"1"}},{"context":{"child_id":3,"pid":"1"}}]}}}}

--- a/tests/core/snapshots/test_parent_child/test_parent_context_fields_in_child/singer.jsonl
+++ b/tests/core/snapshots/test_parent_child/test_parent_context_fields_in_child/singer.jsonl
@@ -18,4 +18,3 @@
 {"type":"STATE","value":{"bookmarks":{"parent":{"starting_replication_value":null},"child":{"partitions":[{"context":{"pid":1}},{"context":{"pid":2}},{"context":{"pid":3}}]}}}}
 {"type":"RECORD","stream":"parent","record":{"id":3},"time_extracted":"2022-01-01T00:00:00+00:00"}
 {"type":"STATE","value":{"bookmarks":{"parent":{},"child":{"partitions":[{"context":{"pid":1}},{"context":{"pid":2}},{"context":{"pid":3}}]}}}}
-{"type":"STATE","value":{"bookmarks":{"parent":{},"child":{"partitions":[{"context":{"pid":1}},{"context":{"pid":2}},{"context":{"pid":3}}]}}}}

--- a/tests/samples/snapshots/test_target_csv/test_fake_people_to_csv/tap.jsonl
+++ b/tests/samples/snapshots/test_target_csv/test_fake_people_to_csv/tap.jsonl
@@ -99,3 +99,4 @@
 {"type":"RECORD","stream":"people","record":{"id":97,"name":"Alicia Miller","email":"jamesjoe@example.org","phone":"408-377-5354","address":"Unit 5905 Box 3700\nDPO AP 51100"},"time_extracted":"2022-01-01T00:00:00+00:00"}
 {"type":"RECORD","stream":"people","record":{"id":98,"name":"James Ramos","email":"thomashaynes@example.net","phone":"606.891.5645","address":"2064 Miller Harbor Suite 747\nWest James, NE 28488"},"time_extracted":"2022-01-01T00:00:00+00:00"}
 {"type":"RECORD","stream":"people","record":{"id":99,"name":"Dylan Johnson","email":"yjennings@example.net","phone":"001-745-528-7595x79930","address":"476 Lewis Lights\nMelissaville, MP 78914"},"time_extracted":"2022-01-01T00:00:00+00:00"}
+{"type":"STATE","value":{"bookmarks":{"people":{}}}}

--- a/tests/samples/snapshots/test_target_csv/test_fake_people_to_csv/target.jsonl
+++ b/tests/samples/snapshots/test_target_csv/test_fake_people_to_csv/target.jsonl
@@ -1,0 +1,1 @@
+{"bookmarks": {"people": {}}}


### PR DESCRIPTION
## Summary by Sourcery

Integrate a centralized StateWriter to manage and deduplicate STATE messages across taps and streams, replacing direct state emissions and redundant tracking logic.

New Features:
- Introduce StateWriter class to centralize and deduplicate STATE message emissions

Bug Fixes:
- Prevent duplicate STATE messages across taps and streams by tracking last emitted state

Enhancements:
- Integrate StateWriter into TapBase and core streams for consistent state emission
- Remove redundant per-stream state tracking in favor of centralized StateWriter

Tests:
- Update parent-child stream snapshot tests to reflect new state emission behavior

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3114.org.readthedocs.build/en/3114/

<!-- readthedocs-preview meltano-sdk end -->

## Summary by Sourcery

Centralize and deduplicate STATE message emission by introducing a StateWriter class and integrating it into TapBase and core streams.

New Features:
- Introduce StateWriter class to manage and deduplicate STATE messages.

Bug Fixes:
- Prevent duplicate STATE messages across taps and streams by centralizing state tracking.

Enhancements:
- Integrate StateWriter into TapBase and core streams for consistent state emission.
- Remove redundant per-stream state tracking logic in favor of centralized state management.

Tests:
- Update snapshot tests to reflect new centralized state emission behavior.