### PR TITLE
docs: Document `post_process` changes in 0.47

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/graphql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/graphql-client.py
@@ -72,6 +72,9 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     ) -> dict | None:
         """As needed, append or transform raw data to match expected structure.
 
+        Note: As of SDK v0.47.0, this method is automatically executed for all stream types.
+        You should not need to call this method directly in custom `get_records` implementations.
+
         Args:
             row: An individual record from the stream.
             context: The stream context.

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
@@ -217,6 +217,9 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     ) -> dict | None:
         """As needed, append or transform raw data to match expected structure.
 
+        Note: As of SDK v0.47.0, this method is automatically executed for all stream types.
+        You should not need to call this method directly in custom `get_records` implementations.
+
         Args:
             row: An individual record from the stream.
             context: The stream context.

--- a/docs/guides/porting.md
+++ b/docs/guides/porting.md
@@ -30,6 +30,10 @@ If you are porting over a SQL tap... skip ahead now to the [Installing Dependenc
 
 Continue until just before you reach the "Pagination" section, at which point you are probably done! 🚀 Optionally, you can further optimize performance by overriding `get_records()` with a sync method native to your SQL operations.
 
+```{note}
+As of SDK v0.47.0, the `post_process` method is automatically executed for all stream types. If your legacy tap includes manual calls to `post_process` within custom `get_records` implementations, you should remove these calls to avoid duplicate processing.
+```
+
 ## Authentication
 
 1. Open the `auth.py` or `client.py` file (depending on auth method) and locate the authentication logic.

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -1544,21 +1544,29 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         row: types.Record,
         context: types.Context | None = None,  # noqa: ARG002
     ) -> types.Record | None:
-        """As needed, append or transform raw data to match expected structure.
+        """Process individual records after extraction from the source.
 
-        Optional. This method gives developers an opportunity to "clean up" the results
-        prior to returning records to the downstream tap - for instance: cleaning,
-        renaming, or appending properties to the raw record result returned from the
-        API.
+        This method provides an opportunity to clean, transform, or validate records
+        before they are emitted. Common use cases include:
 
-        Developers may also return `None` from this method to filter out
-        invalid or not-applicable records from the stream.
+        - Cleaning or normalizing field values
+        - Renaming fields to match expected schema
+        - Adding computed or derived fields
+        - Filtering out invalid or unwanted records
+
+        Developers may return `None` from this method to exclude records from the
+        stream output.
+
+        .. versionchanged:: 0.47.0
+           This method is now automatically executed for all stream types during
+           record processing. You should not call this method directly in custom
+           `get_records` implementations.
 
         Args:
-            row: Individual record in the stream.
+            row: Individual record from the stream.
             context: Stream partition or context dictionary.
 
         Returns:
-            The resulting record dict, or `None` if the record should be excluded.
+            The processed record dict, or `None` to exclude the record.
         """
         return row


### PR DESCRIPTION
## Summary by Sourcery

Document the automatic execution of the `post_process` method introduced in SDK v0.47.0 and advise against manual invocation in custom implementations.

Enhancements:
- Add a `.. versionchanged:: 0.47.0` note to `post_process` docstring in the core stream implementation.
- Clarify `post_process` docstring to list common use cases and emphasize returning `None` to filter records.

Documentation:
- Add a note to the porting guide advising removal of manual `post_process` calls in custom `get_records` implementations.
- Include guidance in the cookiecutter templates’ `graphql-client.py` and `rest-client.py` to avoid direct invocation of `post_process` post-migration.