### PR TITLE
chore: Use `nonlocal` to update stream metadata

### DIFF
--- a/singer_sdk/singerlib/catalog.py
+++ b/singer_sdk/singerlib/catalog.py
@@ -196,6 +196,8 @@ class MetadataMapping(dict[Breadcrumb, AnyMetadata]):
             breadcrumb: Breadcrumb = (),
         ) -> None:
             """Add breadcrumbs and metadata for subfields."""
+            nonlocal mapping
+
             for field_name, field_schema in properties.items():
                 key = (*breadcrumb, "properties", field_name)
                 mapping[key] = Metadata(inclusion=Metadata.InclusionType.AVAILABLE)


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Introduce a nonlocal declaration for the mapping variable to enable in-place updates within the nested function

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3124.org.readthedocs.build/en/3124/

<!-- readthedocs-preview meltano-sdk end -->