### PR TITLE
packaging: Require SQLAlchemy >= 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "requests>=2.25.1",
     "simpleeval>=0.9.13,!=1.0.1",
     "simplejson>=3.17.6",
-    "sqlalchemy>=1.4,<3.0",
+    "sqlalchemy>=2",
     "typing-extensions>=4.5.0",
     "universal-pathlib>=0.2.6",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2533,7 +2533,7 @@ requires-dist = [
     { name = "s3fs", marker = "extra == 's3'", specifier = ">=2024.9.0" },
     { name = "simpleeval", specifier = ">=0.9.13,!=1.0.1" },
     { name = "simplejson", specifier = ">=3.17.6" },
-    { name = "sqlalchemy", specifier = ">=1.4,<3.0" },
+    { name = "sqlalchemy", specifier = ">=2" },
     { name = "typing-extensions", specifier = ">=4.5.0" },
     { name = "universal-pathlib", specifier = ">=0.2.6" },
 ]


### PR DESCRIPTION
## Summary by Sourcery

Require SQLAlchemy version 2.0 or higher by updating the dependency constraint and refreshing the lockfile

Build:
- Update pyproject.toml to specify sqlalchemy>=2.0
- Regenerate uv.lock to reflect the new dependency requirement

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3126.org.readthedocs.build/en/3126/

<!-- readthedocs-preview meltano-sdk end -->