### PR TITLE
fix: Ensure Singer SDK warnings are logged

### DIFF
--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -93,6 +93,7 @@ class SingerCommand(click.Command):
             The result of the command invocation.
         """
         logging.captureWarnings(capture=True)
+        warnings.filterwarnings("once", category=DeprecationWarning)
         try:
             return super().invoke(ctx)
         except ConfigValidationError as exc:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Enable logging of DeprecationWarnings by filtering them to be emitted only once.