### PR TITLE
fix: Ensure Singer SDK warnings are logged

### DIFF
--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -88,6 +88,7 @@ class SingerCommand(click.Command):
             The result of the command invocation.
         """
         logging.captureWarnings(capture=True)
+        warnings.filterwarnings("once", category=DeprecationWarning)
         try:
             return super().invoke(ctx)
         except ConfigValidationError as exc:


### PR DESCRIPTION
Backport of https://github.com/meltano/sdk/pull/3127.

## Summary by Sourcery

Bug Fixes:
- Add a warnings filter to emit each DeprecationWarning only once and ensure they are logged

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3128.org.readthedocs.build/en/3128/

<!-- readthedocs-preview meltano-sdk end -->