### PR TITLE
packaging: Test with click 8.2.x

### DIFF
--- a/singer_sdk/contrib/batch_encoder_parquet.py
+++ b/singer_sdk/contrib/batch_encoder_parquet.py
@@ -46,7 +46,7 @@ class ParquetBatcher(BaseBatcher):
                     pylist = list(chunk)
                     table = pa.Table.from_pylist(pylist)
                     if self.batch_config.encoding.compression == "gzip":
-                        pq.write_table(table, f, compression="GZIP")
+                        pq.write_table(table, f, compression="gzip")
                     else:
                         pq.write_table(table, f)
 

--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -67,7 +67,7 @@ def get_state_if_exists(
 
 def get_state_partitions_list(tap_state: dict, tap_stream_id: str) -> list[dict] | None:
     """Return a list of partitions defined in the state, or None if not defined."""
-    return (get_state_if_exists(tap_state, tap_stream_id) or {}).get("partitions", None)  # type: ignore[no-any-return]
+    return (get_state_if_exists(tap_state, tap_stream_id) or {}).get("partitions", None)
 
 
 def _find_in_partitions_list(

--- a/singer_sdk/helpers/capabilities.py
+++ b/singer_sdk/helpers/capabilities.py
@@ -253,7 +253,7 @@ class DeprecatedEnum(Enum):
             Deprecation message.
         """
         self.deprecation: str | None
-        return self.deprecation
+        return self.deprecation  # type: ignore[no-any-return]
 
     def emit_warning(self) -> None:
         """Emit deprecation warning."""

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -448,7 +448,7 @@ class CustomStreamMap(StreamMap):
         if stream_map and MAPPER_FILTER_OPTION in stream_map:
             filter_rule = stream_map.pop(MAPPER_FILTER_OPTION)
             try:
-                filter_rule_parsed: ast.Expr = ast.parse(filter_rule).body[0]  # type: ignore[arg-type,assignment]
+                filter_rule_parsed: ast.Expr = ast.parse(filter_rule).body[0]  # type: ignore[assignment]
             except (SyntaxError, IndexError) as ex:
                 msg = f"Failed to parse expression {filter_rule}."
                 raise MapExpressionError(msg) from ex

--- a/singer_sdk/streams/graphql.py
+++ b/singer_sdk/streams/graphql.py
@@ -27,7 +27,7 @@ class GraphQLStream(RESTStream, t.Generic[_TToken], metaclass=abc.ABCMeta):
     http_method = "POST"
 
     @classproperty
-    def records_jsonpath(cls) -> str:  # type: ignore[override] # noqa: N805
+    def records_jsonpath(cls) -> str:  # noqa: N805
         """Get the JSONPath expression to extract records from an API response.
 
         Returns:

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -116,7 +116,7 @@ class SQLStream(Stream, metaclass=abc.ABCMeta):
         return self._singer_catalog_entry.metadata.root.table_key_properties or []
 
     @primary_keys.setter
-    def primary_keys(self, new_value: t.Sequence[str]) -> None:
+    def primary_keys(self, new_value: t.Sequence[str] | None) -> None:
         """Set or reset the primary key(s) in the stream's catalog entry.
 
         Args:

--- a/singer_sdk/testing/tap_tests.py
+++ b/singer_sdk/testing/tap_tests.py
@@ -160,7 +160,7 @@ class StreamRecordMatchesStreamSchema(StreamTestTemplate):
         schema = self.stream.schema
         default = DEFAULT_JSONSCHEMA_VALIDATOR
         validator = validators.validator_for(schema, default=default)(schema)
-        validator.format_checker = default.FORMAT_CHECKER
+        validator.format_checker = default.FORMAT_CHECKER  # type: ignore[attr-defined]
 
         for record in self.stream_records:
             errors = list(validator.iter_errors(record))

--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -599,7 +599,7 @@ class ArrayType(JSONTypeHelper[list], t.Generic[W]):
         super().__init__(**kwargs)
 
     @property
-    def type_dict(self) -> dict:  # type: ignore[override]
+    def type_dict(self) -> dict:
         """Get type dictionary.
 
         Returns:
@@ -690,7 +690,7 @@ class Property(JSONTypeHelper[T], t.Generic[T]):
         self.kwargs = kwargs
 
     @property
-    def type_dict(self) -> dict:  # type: ignore[override]
+    def type_dict(self) -> dict:
         """Get type dictionary.
 
         Returns:
@@ -852,7 +852,7 @@ class ObjectType(JSONTypeHelper):
         super().__init__(**kwargs)
 
     @property
-    def type_dict(self) -> dict:  # type: ignore[override]
+    def type_dict(self) -> dict:
         """Get type dictionary.
 
         Returns:
@@ -919,7 +919,7 @@ class OneOf(JSONTypeHelper):
         self.wrapped = types
 
     @property
-    def type_dict(self) -> dict:  # type: ignore[override]
+    def type_dict(self) -> dict:
         """Get type dictionary.
 
         Returns:
@@ -976,7 +976,7 @@ class AllOf(JSONTypeHelper):
         self.wrapped = types
 
     @property
-    def type_dict(self) -> dict:  # type: ignore[override]
+    def type_dict(self) -> dict:
         """Get type dictionary.
 
         Returns:
@@ -1007,7 +1007,7 @@ class Constant(JSONTypeHelper):
         self.value = value
 
     @property
-    def type_dict(self) -> dict:  # type: ignore[override]
+    def type_dict(self) -> dict:
         """Get type dictionary.
 
         Returns:
@@ -1099,7 +1099,7 @@ class CustomType(JSONTypeHelper):
         self._jsonschema_type_dict = jsonschema_type_dict
 
     @property
-    def type_dict(self) -> dict:  # type: ignore[override]
+    def type_dict(self) -> dict:
         """Get type dictionary.
 
         Returns:
@@ -1128,7 +1128,7 @@ class PropertiesList(ObjectType):
         self.wrapped[property.name] = property
 
     @property
-    def type_dict(self) -> dict:  # type: ignore[override]
+    def type_dict(self) -> dict:
         """Get type dictionary.
 
         Returns:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def pytest_collection_modifyitems(config: Config, items: list[pytest.Item]):
             item.add_marker("external")
 
 
-def pytest_runtest_setup(item):
+def pytest_runtest_setup(item: pytest.Item):
     supported_systems = SYSTEMS.intersection(mark.name for mark in item.iter_markers())
     system = platform.system().lower()
     if supported_systems and system not in supported_systems:

--- a/tests/core/test_mapper_class.py
+++ b/tests/core/test_mapper_class.py
@@ -37,7 +37,9 @@ def test_config_errors(config_dict: dict, expectation, errors: list[str]):
 
 def test_cli_help():
     """Test the CLI help message."""
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
+    # TODO: Remote this once support for Python 3.9 and thus Click<8.2 is dropped
+    runner.mix_stderr = False
     result = runner.invoke(StreamTransform.cli, ["--help"])
     assert result.exit_code == 0
     assert "Show this message and exit." in result.output
@@ -45,7 +47,9 @@ def test_cli_help():
 
 def test_cli_config_validation(tmp_path):
     """Test the CLI config validation."""
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
+    # TODO: Remote this once support for Python 3.9 and thus Click<8.2 is dropped
+    runner.mix_stderr = False
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps({}))
     result = runner.invoke(StreamTransform.cli, ["--config", str(config_path)])

--- a/tests/core/test_tap_class.py
+++ b/tests/core/test_tap_class.py
@@ -81,7 +81,9 @@ def test_config_errors(
 
 def test_cli(tap_class: type[Tap]):
     """Test the CLI."""
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
+    # TODO: Remote this once support for Python 3.9 and thus Click<8.2 is dropped
+    runner.mix_stderr = False
     result = runner.invoke(tap_class.cli, ["--help"])
     assert result.exit_code == 0
     assert "Show this message and exit." in result.output
@@ -89,7 +91,9 @@ def test_cli(tap_class: type[Tap]):
 
 def test_cli_config_validation(tap_class: type[Tap], tmp_path):
     """Test the CLI config validation."""
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
+    # TODO: Remote this once support for Python 3.9 and thus Click<8.2 is dropped
+    runner.mix_stderr = False
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps({}))
     result = runner.invoke(tap_class.cli, ["--config", str(config_path)])
@@ -101,7 +105,9 @@ def test_cli_config_validation(tap_class: type[Tap], tmp_path):
 
 def test_cli_discover(tap_class: type[Tap], tmp_path):
     """Test the CLI discover command."""
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
+    # TODO: Remote this once support for Python 3.9 and thus Click<8.2 is dropped
+    runner.mix_stderr = False
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps({}))
     result = runner.invoke(

--- a/tests/core/test_target_class.py
+++ b/tests/core/test_target_class.py
@@ -37,7 +37,9 @@ def test_config_errors(config_dict: dict, expectation, errors: list[str]):
 
 def test_cli():
     """Test the CLI."""
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
+    # TODO: Remote this once support for Python 3.9 and thus Click<8.2 is dropped
+    runner.mix_stderr = False
     result = runner.invoke(SQLiteTarget.cli, ["--help"])
     assert result.exit_code == 0
     assert "Show this message and exit." in result.output
@@ -45,7 +47,9 @@ def test_cli():
 
 def test_cli_config_validation(tmp_path):
     """Test the CLI config validation."""
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
+    # TODO: Remote this once support for Python 3.9 and thus Click<8.2 is dropped
+    runner.mix_stderr = False
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps({}))
     result = runner.invoke(SQLiteTarget.cli, ["--config", str(config_path)])

--- a/tests/samples/test_tap_countries.py
+++ b/tests/samples/test_tap_countries.py
@@ -150,7 +150,9 @@ def test_write_schema(
 ):
     snapshot.snapshot_dir = snapshot_dir.joinpath("countries_write_schemas")
 
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
+    # TODO: Remote this once support for Python 3.9 and thus Click<8.2 is dropped
+    runner.mix_stderr = False
     result = runner.invoke(SampleTapCountries.cli, ["--test", "schema"])
 
     snapshot_name = "countries_write_schemas"


### PR DESCRIPTION
## Summary by Sourcery

Update test suite to accommodate Click 8.2 changes and clean up pytest setup signature.

Enhancements:
- Replace use of the deprecated mix_stderr constructor argument by instantiating CliRunner without it and setting runner.mix_stderr post-creation in CLI tests to support Click 8.2+
- Add TODO comments to remove compatibility code once support for Click versions below 8.2 (Python 3.9) is dropped
- Annotate pytest_runtest_setup parameter with pytest.Item for improved type clarity

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3129.org.readthedocs.build/en/3129/

<!-- readthedocs-preview meltano-sdk end -->