### PR TITLE
fix: Ensure Singer SDK warnings are logged (#3127)

### DIFF
--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -94,6 +94,7 @@ class SingerCommand(click.Command):
             The result of the command invocation.
         """
         logging.captureWarnings(capture=True)
+        warnings.filterwarnings("once", category=DeprecationWarning)
         try:
             return super().invoke(ctx)
         except ConfigValidationError as exc:


### PR DESCRIPTION
Backport of https://github.com/meltano/sdk/pull/3127.

## Summary by Sourcery

Bug Fixes:
- Configure the Python warnings filter to emit DeprecationWarning messages once in plugin execution

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3132.org.readthedocs.build/en/3132/

<!-- readthedocs-preview meltano-sdk end -->