### PR TITLE
fix: Ensure Singer SDK warnings are logged (#3127)

### DIFF
--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -93,6 +93,7 @@ class SingerCommand(click.Command):
             The result of the command invocation.
         """
         logging.captureWarnings(capture=True)
+        warnings.filterwarnings("once", category=DeprecationWarning)
         try:
             return super().invoke(ctx)
         except ConfigValidationError as exc:


### PR DESCRIPTION
Backport of https://github.com/meltano/sdk/pull/3127.

## Summary by Sourcery

Backport a fix to ensure DeprecationWarning messages are captured and logged during Singer SDK plugin invocation

Bug Fixes:
- Add a filter to show DeprecationWarning messages only once so they appear in logs

Chores:
- Backport Singer SDK warning logging fix from upstream PR #3127

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3138.org.readthedocs.build/en/3138/

<!-- readthedocs-preview meltano-sdk end -->