### PR TITLE
fix: Read input as bytes in MsgSpec Singer message reader

### DIFF
--- a/singer_sdk/contrib/msgspec.py
+++ b/singer_sdk/contrib/msgspec.py
@@ -62,12 +62,15 @@ def serialize_jsonl(obj: object, **kwargs: t.Any) -> bytes:  # noqa: ARG001
     return _jsonl_msg_buffer
 
 
-class MsgSpecReader(GenericSingerReader[str]):
+class MsgSpecReader(GenericSingerReader[bytes]):
     """Base class for all plugins reading Singer messages as strings from stdin."""
 
-    default_input = sys.stdin
+    @property
+    def default_input(self) -> t.IO[bytes]:
+        """Default input stream for the reader."""
+        return sys.stdin.buffer
 
-    def deserialize_json(self, line: str) -> dict:  # noqa: PLR6301
+    def deserialize_json(self, line: bytes) -> dict:  # noqa: PLR6301
         """Deserialize a line of json.
 
         Args:
@@ -83,7 +86,7 @@ class MsgSpecReader(GenericSingerReader[str]):
             return decoder.decode(line)  # type: ignore[no-any-return]
         except msgspec.DecodeError as exc:
             logger.exception("Unable to parse:\n%s", line)
-            msg = f"Unable to parse line as JSON: {line}"
+            msg = f"Unable to parse line as JSON: {line!r}"
             raise InvalidInputLine(msg) from exc
 
 


### PR DESCRIPTION
## Summary by Sourcery

Make MsgSpecReader consume raw bytes from stdin by updating its generic parameter, default_input, and deserialize_json signature, and improve error messaging

Bug Fixes:
- Include repr of the input line in JSON parse error messages

Enhancements:
- Change MsgSpecReader to use sys.stdin.buffer as default_input
- Update GenericSingerReader parameter and deserialize_json to handle bytes instead of str