### PR TITLE
feat: Support disabling stream pagination logic

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
@@ -139,7 +139,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
 {%- endif %}
         return {}
 
-    def get_new_paginator(self) -> BaseAPIPaginator:
+    def get_new_paginator(self) -> BaseAPIPaginator | None:
         """Create a new pagination helper instance.
 
         If the source API can make use of the `next_page_token_jsonpath`
@@ -150,7 +150,8 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         other approaches, please read the guide: https://sdk.meltano.com/en/v0.25.0/guides/pagination-classes.html.
 
         Returns:
-            A pagination helper instance.
+            A pagination helper instance, or ``None`` to indicate paginator is
+            not supported.
         """
         return super().get_new_paginator()
 

--- a/singer_sdk/pagination.py
+++ b/singer_sdk/pagination.py
@@ -446,3 +446,19 @@ class LegacyStreamPaginator(
                 the end of pagination.
         """
         return self.stream.get_next_page_token(response, self.current_value)
+
+
+class NoOpPaginator(BaseAPIPaginator):
+    """No-op paginator intended for use with REST streams that do not support pagination."""  # noqa: E501
+
+    def __init__(self) -> None:
+        """Create a new paginator."""
+        super().__init__(None)
+
+    @override
+    def has_more(self, response: requests.Response) -> bool:
+        return False
+
+    @override
+    def get_next(self, response: requests.Response) -> None:
+        return None

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -24,6 +24,7 @@ from singer_sdk.pagination import (
     BaseAPIPaginator,
     JSONPathPaginator,
     LegacyStreamPaginator,
+    NoOpPaginator,
     SimpleHeaderPaginator,
 )
 from singer_sdk.streams.core import Stream
@@ -444,7 +445,7 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
         Yields:
             An item for every record in the response.
         """
-        paginator = self.get_new_paginator()
+        paginator = self.get_new_paginator() or NoOpPaginator()
         decorated_request = self.request_decorator(self._request)
         pages = 0
 
@@ -640,7 +641,7 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
         ...
 
     @abc.abstractmethod
-    def get_new_paginator(self) -> BaseAPIPaginator:
+    def get_new_paginator(self) -> BaseAPIPaginator | None:
         """Get a fresh paginator for this endpoint.
 
         Returns:


### PR DESCRIPTION
Support disabling pagination for a stream by returning `None` from `get_new_paginator`. Useful when a client class defines `get_new_paginator` that isn't applicable for some child classes (i.e. endpoints do not support pagination).