### PR TITLE
refactor: Parse config files early and pass the corresponding dictionaries to the Singer classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,8 +164,6 @@ filterwarnings = [
     # https://github.com/meltano/sdk/issues/2744
     "default:Passing a config file path is deprecated:singer_sdk.helpers._compat.SingerSDKDeprecationWarning",
     "default:Passing a list of config file paths is deprecated:singer_sdk.helpers._compat.SingerSDKDeprecationWarning",
-    "default:Passing a catalog file path is deprecated:singer_sdk.helpers._compat.SingerSDKDeprecationWarning",
-    "default:Passing a state file path is deprecated:singer_sdk.helpers._compat.SingerSDKDeprecationWarning",
     # TODO: Address this SQLite warning in Python 3.13+
     "ignore::ResourceWarning",
     # universal-pathlib

--- a/singer_sdk/configuration/_dict_config.py
+++ b/singer_sdk/configuration/_dict_config.py
@@ -83,6 +83,35 @@ def parse_environment_config(
     return result
 
 
+def deep_merge(a: dict[str, t.Any], b: dict[str, t.Any]) -> dict[str, t.Any]:
+    """Deep merge two dictionaries.
+
+    Args:
+        a: The first dictionary.
+        b: The second dictionary.
+
+    Returns:
+        A new dictionary with the merged contents of `a` and `b`.
+
+    Example:
+        >>> a = {"a": 1, "b": {"c": 2}}
+        >>> b = {"b": {"d": 3}, "e": 4}
+        >>> deep_merge(a, b)
+        {'a': 1, 'b': {'c': 2, 'd': 3}, 'e': 4}
+
+        >>> a = {"a": 1, "b": {"c": 2}}
+        >>> b = {"b": {"d": 3}, "e": 4}
+        >>> deep_merge(a, b)
+        {'a': 1, 'b': {'c': 2, 'd': 3}, 'e': 4}
+    """
+    for key, value in b.items():
+        if key in a and isinstance(a[key], dict) and isinstance(value, dict):
+            a[key] = deep_merge(a[key], value)
+        else:
+            a[key] = value
+    return a
+
+
 def merge_config_sources(
     inputs: t.Iterable[str],
     config_schema: dict[str, t.Any],
@@ -112,7 +141,7 @@ def merge_config_sources(
 
         if not config_path.is_file():
             msg = (
-                f"Could not locate config file at '{config_path}'.Please check that "
+                f"Could not locate config file at '{config_path}'. Please check that "
                 "the file exists."
             )
             raise FileNotFoundError(msg)

--- a/singer_sdk/mapper_base.py
+++ b/singer_sdk/mapper_base.py
@@ -152,7 +152,7 @@ class InlineMapper(BaseSingerReader, BaseSingerWriter, metaclass=abc.ABCMeta):
         config_files, parse_env_config = cls.config_from_cli_args(*config)
         config_dict = {}
         for config_file in config_files:
-            config_dict.update(read_json_file(config_file))
+            config_dict |= read_json_file(config_file)
 
         mapper = cls(
             config=config_dict,

--- a/singer_sdk/mapper_base.py
+++ b/singer_sdk/mapper_base.py
@@ -148,7 +148,7 @@ class InlineMapper(BaseSingerReader, BaseSingerWriter, metaclass=abc.ABCMeta):
         """
         super().invoke(about=about, about_format=about_format)
         cls.print_version(print_fn=cls.logger.info)
-        config_dict, parse_env_config = cls._config_from_cli_args(*config)
+        config_dict, parse_env_config = cls.config_from_cli_args(*config)
 
         mapper = cls(
             config=config_dict,

--- a/singer_sdk/mapper_base.py
+++ b/singer_sdk/mapper_base.py
@@ -8,7 +8,6 @@ import typing as t
 import click
 
 from singer_sdk.helpers._classproperty import classproperty
-from singer_sdk.helpers._util import read_json_file
 from singer_sdk.helpers.capabilities import CapabilitiesEnum, PluginCapabilities
 from singer_sdk.plugin_base import BaseSingerReader, BaseSingerWriter
 
@@ -149,10 +148,7 @@ class InlineMapper(BaseSingerReader, BaseSingerWriter, metaclass=abc.ABCMeta):
         """
         super().invoke(about=about, about_format=about_format)
         cls.print_version(print_fn=cls.logger.info)
-        config_files, parse_env_config = cls.config_from_cli_args(*config)
-        config_dict: dict[str, t.Any] = {}
-        for config_file in config_files:
-            config_dict |= read_json_file(config_file)
+        config_dict, parse_env_config = cls._config_from_cli_args(*config)
 
         mapper = cls(
             config=config_dict,

--- a/singer_sdk/mapper_base.py
+++ b/singer_sdk/mapper_base.py
@@ -150,7 +150,7 @@ class InlineMapper(BaseSingerReader, BaseSingerWriter, metaclass=abc.ABCMeta):
         super().invoke(about=about, about_format=about_format)
         cls.print_version(print_fn=cls.logger.info)
         config_files, parse_env_config = cls.config_from_cli_args(*config)
-        config_dict = {}
+        config_dict: dict[str, t.Any] = {}
         for config_file in config_files:
             config_dict |= read_json_file(config_file)
 

--- a/singer_sdk/mapper_base.py
+++ b/singer_sdk/mapper_base.py
@@ -8,6 +8,7 @@ import typing as t
 import click
 
 from singer_sdk.helpers._classproperty import classproperty
+from singer_sdk.helpers._util import read_json_file
 from singer_sdk.helpers.capabilities import CapabilitiesEnum, PluginCapabilities
 from singer_sdk.plugin_base import BaseSingerReader, BaseSingerWriter
 
@@ -149,9 +150,12 @@ class InlineMapper(BaseSingerReader, BaseSingerWriter, metaclass=abc.ABCMeta):
         super().invoke(about=about, about_format=about_format)
         cls.print_version(print_fn=cls.logger.info)
         config_files, parse_env_config = cls.config_from_cli_args(*config)
+        config_dict = {}
+        for config_file in config_files:
+            config_dict.update(read_json_file(config_file))
 
         mapper = cls(
-            config=config_files,  # type: ignore[arg-type]
+            config=config_dict,
             validate_config=True,
             parse_env_config=parse_env_config,
         )

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -567,8 +567,8 @@ class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
             FileNotFoundError: If the config file does not exist.
 
         Returns:
-            A tuple containing the config dictionary and a boolean indicating whether
-            the config file was found.
+            A tuple containing the config dictionary and a boolean indicating
+            whether environment variables should be parsed.
         """
         config_files = []
         parse_env_config = False
@@ -582,7 +582,7 @@ class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
             # Validate config file paths before adding to list
             if not Path(config_path).is_file():
                 msg = (
-                    f"Could not locate config file at '{config_path}'.Please check "
+                    f"Could not locate config file at '{config_path}'. Please check "
                     "that the file exists."
                 )
                 raise FileNotFoundError(msg)
@@ -590,6 +590,24 @@ class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
             config_files.append(Path(config_path))
 
         return config_files, parse_env_config
+
+    @classmethod
+    def _config_from_cli_args(cls, *args: str) -> tuple[dict[str, t.Any], bool]:
+        """Parse CLI arguments into a config dictionary.
+
+        Args:
+            args: CLI arguments.
+
+        Returns:
+            A tuple containing the config dictionary and a boolean indicating
+            environment variables should be parsed.
+        """
+        config_files, parse_env_config = cls.config_from_cli_args(*args)
+        config_dict: dict[str, t.Any] = {}
+        for config_file in config_files:
+            config_dict |= read_json_file(config_file)
+
+        return config_dict, parse_env_config
 
     @classmethod
     def invoke(

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -553,7 +553,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         config_files, parse_env_config = cls.config_from_cli_args(*config)
         config_dict = {}
         for config_file in config_files:
-            config_dict.update(read_json_file(config_file))
+            config_dict |= read_json_file(config_file)
 
         tap = cls(
             config=config_dict,
@@ -585,7 +585,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         config_files, parse_env_config = cls.config_from_cli_args(*config_args)
         config_dict = {}
         for config_file in config_files:
-            config_dict.update(read_json_file(config_file))
+            config_dict |= read_json_file(config_file)
 
         try:
             tap = cls(
@@ -622,7 +622,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         config_files, parse_env_config = cls.config_from_cli_args(*config_args)
         config_dict = {}
         for config_file in config_files:
-            config_dict.update(read_json_file(config_file))
+            config_dict |= read_json_file(config_file)
 
         tap = cls(
             config=config_dict,

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -550,7 +550,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         """
         super().invoke(about=about, about_format=about_format)
         cls.print_version(print_fn=cls.logger.info)
-        config_dict, parse_env_config = cls._config_from_cli_args(*config)
+        config_dict, parse_env_config = cls.config_from_cli_args(*config)
 
         tap = cls(
             config=config_dict,
@@ -579,7 +579,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
             return
 
         config_args = ctx.params.get("config", ())
-        config_dict, parse_env_config = cls._config_from_cli_args(*config_args)
+        config_dict, parse_env_config = cls.config_from_cli_args(*config_args)
 
         try:
             tap = cls(
@@ -613,10 +613,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
             return
 
         config_args = ctx.params.get("config", ())
-        config_files, parse_env_config = cls.config_from_cli_args(*config_args)
-        config_dict: dict[str, t.Any] = {}
-        for config_file in config_files:
-            config_dict |= read_json_file(config_file)
+        config_dict, parse_env_config = cls.config_from_cli_args(*config_args)
 
         tap = cls(
             config=config_dict,

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -551,7 +551,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         super().invoke(about=about, about_format=about_format)
         cls.print_version(print_fn=cls.logger.info)
         config_files, parse_env_config = cls.config_from_cli_args(*config)
-        config_dict = {}
+        config_dict: dict[str, t.Any] = {}
         for config_file in config_files:
             config_dict |= read_json_file(config_file)
 
@@ -583,7 +583,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
 
         config_args = ctx.params.get("config", ())
         config_files, parse_env_config = cls.config_from_cli_args(*config_args)
-        config_dict = {}
+        config_dict: dict[str, t.Any] = {}
         for config_file in config_files:
             config_dict |= read_json_file(config_file)
 
@@ -620,7 +620,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
 
         config_args = ctx.params.get("config", ())
         config_files, parse_env_config = cls.config_from_cli_args(*config_args)
-        config_dict = {}
+        config_dict: dict[str, t.Any] = {}
         for config_file in config_files:
             config_dict |= read_json_file(config_file)
 

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -550,10 +550,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         """
         super().invoke(about=about, about_format=about_format)
         cls.print_version(print_fn=cls.logger.info)
-        config_files, parse_env_config = cls.config_from_cli_args(*config)
-        config_dict: dict[str, t.Any] = {}
-        for config_file in config_files:
-            config_dict |= read_json_file(config_file)
+        config_dict, parse_env_config = cls._config_from_cli_args(*config)
 
         tap = cls(
             config=config_dict,
@@ -582,10 +579,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
             return
 
         config_args = ctx.params.get("config", ())
-        config_files, parse_env_config = cls.config_from_cli_args(*config_args)
-        config_dict: dict[str, t.Any] = {}
-        for config_file in config_files:
-            config_dict |= read_json_file(config_file)
+        config_dict, parse_env_config = cls._config_from_cli_args(*config_args)
 
         try:
             tap = cls(

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -15,6 +15,7 @@ from joblib import Parallel, delayed, parallel_config
 from singer_sdk.exceptions import RecordsWithoutSchemaException
 from singer_sdk.helpers._batch import BaseBatchFileEncoding
 from singer_sdk.helpers._classproperty import classproperty
+from singer_sdk.helpers._util import read_json_file
 from singer_sdk.helpers.capabilities import (
     ACTIVATE_VERSION_CONFIG,
     ADD_RECORD_METADATA_CONFIG,
@@ -579,9 +580,12 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
         super().invoke(about=about, about_format=about_format)
         cls.print_version(print_fn=cls.logger.info)
         config_files, parse_env_config = cls.config_from_cli_args(*config)
+        config_dict = {}
+        for config_file in config_files:
+            config_dict.update(read_json_file(config_file))
 
         target = cls(
-            config=config_files,  # type: ignore[arg-type]
+            config=config_dict,
             validate_config=True,
             parse_env_config=parse_env_config,
         )

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -580,7 +580,7 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
         super().invoke(about=about, about_format=about_format)
         cls.print_version(print_fn=cls.logger.info)
         config_files, parse_env_config = cls.config_from_cli_args(*config)
-        config_dict = {}
+        config_dict: dict[str, t.Any] = {}
         for config_file in config_files:
             config_dict |= read_json_file(config_file)
 

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -578,7 +578,7 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
         """
         super().invoke(about=about, about_format=about_format)
         cls.print_version(print_fn=cls.logger.info)
-        config_dict, parse_env_config = cls._config_from_cli_args(*config)
+        config_dict, parse_env_config = cls.config_from_cli_args(*config)
 
         target = cls(
             config=config_dict,

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -582,7 +582,7 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
         config_files, parse_env_config = cls.config_from_cli_args(*config)
         config_dict = {}
         for config_file in config_files:
-            config_dict.update(read_json_file(config_file))
+            config_dict |= read_json_file(config_file)
 
         target = cls(
             config=config_dict,

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -15,7 +15,6 @@ from joblib import Parallel, delayed, parallel_config
 from singer_sdk.exceptions import RecordsWithoutSchemaException
 from singer_sdk.helpers._batch import BaseBatchFileEncoding
 from singer_sdk.helpers._classproperty import classproperty
-from singer_sdk.helpers._util import read_json_file
 from singer_sdk.helpers.capabilities import (
     ACTIVATE_VERSION_CONFIG,
     ADD_RECORD_METADATA_CONFIG,
@@ -579,10 +578,7 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
         """
         super().invoke(about=about, about_format=about_format)
         cls.print_version(print_fn=cls.logger.info)
-        config_files, parse_env_config = cls.config_from_cli_args(*config)
-        config_dict: dict[str, t.Any] = {}
-        for config_file in config_files:
-            config_dict |= read_json_file(config_file)
+        config_dict, parse_env_config = cls._config_from_cli_args(*config)
 
         target = cls(
             config=config_dict,


### PR DESCRIPTION
## Summary by Sourcery

Refactor how configuration, state, and catalog inputs are handled by parsing and merging them into dictionaries early and updating CLI interfaces to accept file streams

Enhancements:
- Add _config_from_cli_args to load and merge JSON config files into a single dictionary
- Update tap, mapper, and target entry points to consume parsed config dicts instead of file paths
- Parse and deserialize state and catalog JSON streams early and pass resulting dicts to plugin initializers
- Change --state and --catalog CLI options to accept file handles for direct JSON input

Documentation:
- Clarify boolean return semantics in config_from_cli_args docstring

Chores:
- Remove deprecated warnings for catalog and state file path options in pyproject.toml