### PR TITLE
fix: Handle logging configuration not found gracefully

### DIFF
--- a/singer_sdk/_logging.py
+++ b/singer_sdk/_logging.py
@@ -9,6 +9,8 @@ from pathlib import Path
 if t.TYPE_CHECKING:
     from singer_sdk.helpers._compat import Traversable
 
+logger = logging.getLogger(__name__)
+
 
 def _load_yaml_logging_config(path: Traversable | Path) -> t.Any:  # noqa: ANN401 # pragma: no cover
     """Load the logging config from the YAML file.
@@ -44,4 +46,7 @@ def _setup_console_logging(*, log_level: str | int | None = None) -> None:
 
     if "SINGER_SDK_LOG_CONFIG" in os.environ:  # pragma: no cover
         log_config_path = Path(os.environ["SINGER_SDK_LOG_CONFIG"])
-        logging.config.dictConfig(_load_yaml_logging_config(log_config_path))
+        try:
+            logging.config.dictConfig(_load_yaml_logging_config(log_config_path))
+        except FileNotFoundError:
+            logger.warning("Logging config file not found: %s", log_config_path)


### PR DESCRIPTION
## Summary by Sourcery

Handle missing YAML logging configuration file gracefully and log a warning instead of raising an error.

Bug Fixes:
- Catch FileNotFoundError when loading the logging config to prevent startup failures.

Enhancements:
- Add a module-level logger to report configuration load issues.