### PR TITLE
fix(templates): Run mypy in templates inside of a virtualenv including the package

### DIFF
--- a/.github/workflows/cookiecutter-e2e.yml
+++ b/.github/workflows/cookiecutter-e2e.yml
@@ -79,3 +79,6 @@ jobs:
           !cookiecutter-output/tap-*/.venv/
           !cookiecutter-output/target-*/.venv/
           !cookiecutter-output/mapper-*/.venv/
+          !cookiecutter-output/tap-*/.tox/
+          !cookiecutter-output/target-*/.tox/
+          !cookiecutter-output/mapper-*/.tox/

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         name: Packages
         path: dist
     - name: Upload wheel to release
-      uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # 2.9.0
+      uses: svenstaro/upload-release-action@ebd922b779f285dafcac6410a0710daee9c12b82 # 2.10.0
       with:
         repo_token: {{ '${{secrets.GITHUB_TOKEN}}' }}
         file: dist/*.whl

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
@@ -12,7 +12,6 @@ on:
     - tests/**
     - pyproject.toml
     - uv.lock
-    - tox.ini
   pull_request:
     branches: [main]
     paths:
@@ -21,7 +20,6 @@ on:
     - tests/**
     - pyproject.toml
     - uv.lock
-    - tox.ini
   workflow_dispatch:
 
 env:
@@ -29,6 +27,7 @@ env:
 
 jobs:
   pytest:
+    name: Integration Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -45,7 +44,27 @@ jobs:
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
-    - run: pipx install tox
+    - name: Setup uv
+      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      with:
+        version: ">=0.7"
     - name: Run Tox
       run: |
-        tox -e $(echo py{{ '${{ matrix.python-version }}' }} | tr -d .)
+        uvx --with=tox-uv tox -e $(echo py{{ '${{ matrix.python-version }}' }} | tr -d .)
+
+  typing:
+    name: Type Checking
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: 3.x
+    - name: Setup uv
+      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      with:
+        version: ">=0.7"
+    - name: Run Tox
+      run: |
+        uvx --with=tox-uv tox -e typing

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
@@ -20,27 +20,22 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.33.0
+  rev: 0.33.1
   hooks:
   - id: check-dependabot
   - id: check-github-workflows
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.0
+  rev: v0.12.1
   hooks:
   - id: ruff-check
     args: [--diff]
   - id: ruff-format
     args: [--diff]
 
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.16.0
-  hooks:
-  - id: mypy
-
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.7.12
+  rev: 0.7.17
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -58,6 +58,9 @@ test = [
     {%- endif %}
     "singer-sdk[testing]",
 ]
+typing = [
+    "mypy>=1.16.0",
+]
 
 {%- if cookiecutter.variant != "None (Skip)" %}
 [tool.hatch.build.targets.wheel]
@@ -100,6 +103,7 @@ requires = [
     "tox-uv",
 ]
 env_list = [
+    "typing",
     "py313",
     "py312",
     "py311",
@@ -117,3 +121,7 @@ pass_env = [
 ]
 dependency_groups = [ "test" ]
 commands = [ [ "pytest", { replace = "posargs", default = [ "tests" ], extend = true } ] ]
+
+[tool.tox.env.typing]
+dependency_groups = [ "test", "typing" ]
+commands = [ [ "mypy", { replace = "posargs", default = [ "{{cookiecutter.library_name}}", "tests" ], extend = true } ] ]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         name: Packages
         path: dist
     - name: Upload wheel to release
-      uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # 2.9.0
+      uses: svenstaro/upload-release-action@ebd922b779f285dafcac6410a0710daee9c12b82 # 2.10.0
       with:
         repo_token: {{ '${{secrets.GITHUB_TOKEN}}' }}
         file: dist/*.whl

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
@@ -12,7 +12,6 @@ on:
     - tests/**
     - pyproject.toml
     - uv.lock
-    - tox.ini
   pull_request:
     branches: [main]
     paths:
@@ -21,7 +20,6 @@ on:
     - tests/**
     - pyproject.toml
     - uv.lock
-    - tox.ini
   workflow_dispatch:
 
 env:
@@ -29,6 +27,7 @@ env:
 
 jobs:
   pytest:
+    name: Integration Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -45,7 +44,27 @@ jobs:
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
-    - run: pipx install tox
+    - name: Setup uv
+      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      with:
+        version: ">=0.7"
     - name: Run Tox
       run: |
-        tox -e $(echo py{{ '${{ matrix.python-version }}' }} | tr -d .)
+        uvx --with=tox-uv tox -e $(echo py{{ '${{ matrix.python-version }}' }} | tr -d .)
+
+  typing:
+    name: Type Checking
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: 3.x
+    - name: Setup uv
+      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      with:
+        version: ">=0.7"
+    - name: Run Tox
+      run: |
+        uvx --with=tox-uv tox -e typing

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
@@ -20,33 +20,22 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.33.0
+  rev: 0.33.1
   hooks:
   - id: check-dependabot
   - id: check-github-workflows
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.0
+  rev: v0.12.1
   hooks:
   - id: ruff-check
     args: [--diff]
   - id: ruff-format
     args: [--diff]
 
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.16.0
-  hooks:
-  - id: mypy
-    additional_dependencies:
-    {%- if cookiecutter.stream_type == "SQL" %}
-    - sqlalchemy-stubs
-    {%- else %}
-    - types-requests
-    {%- endif %}
-
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.7.12
+  rev: 0.7.17
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -67,6 +67,14 @@ test = [
     {%- endif %}
     "singer-sdk[testing]",
 ]
+typing = [
+    "mypy>=1.16.0",
+    {%- if cookiecutter.stream_type == "SQL" %}
+    "sqlalchemy-stubs",
+    {%- else %}
+    "types-requests",
+    {%- endif %}
+]
 
 {%- if cookiecutter.variant != "None (Skip)" %}
 [tool.hatch.build.targets.wheel]
@@ -114,6 +122,7 @@ requires = [
     "tox-uv",
 ]
 env_list = [
+    "typing",
     "py313",
     "py312",
     "py311",
@@ -131,3 +140,7 @@ pass_env = [
 ]
 dependency_groups = [ "test" ]
 commands = [ [ "pytest", { replace = "posargs", default = [ "tests" ], extend = true } ] ]
+
+[tool.tox.env.typing]
+dependency_groups = [ "test", "typing" ]
+commands = [ [ "mypy", { replace = "posargs", default = [ "{{cookiecutter.library_name}}", "tests" ], extend = true } ] ]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
@@ -10,6 +10,9 @@ import typing as t
 import sqlalchemy  # noqa: TC002
 from singer_sdk import SQLConnector, SQLStream
 
+if t.TYPE_CHECKING:
+    from singer_sdk.helpers.types import Context
+
 
 class {{ cookiecutter.source_name }}Connector(SQLConnector):
     """Connects to the {{ cookiecutter.source_name }} SQL source."""
@@ -32,8 +35,8 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
             f"s3_staging_dir={config['s3_staging_dir']}"
         )
 
-    @staticmethod
     def to_jsonschema_type(
+        self,
         from_type: str
         | sqlalchemy.types.TypeEngine
         | type[sqlalchemy.types.TypeEngine],
@@ -52,10 +55,9 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
         """
         # Optionally, add custom logic before calling the parent SQLConnector method.
         # You may delete this method if overrides are not needed.
-        return SQLConnector.to_jsonschema_type(from_type)
+        return super().to_jsonschema_type(from_type)
 
-    @staticmethod
-    def to_sql_type(jsonschema_type: dict) -> sqlalchemy.types.TypeEngine:
+    def to_sql_type(self, jsonschema_type: dict) -> sqlalchemy.types.TypeEngine:
         """Returns a JSON Schema equivalent for the given SQL type.
 
         Developers may optionally add custom logic before calling the default
@@ -69,7 +71,7 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
         """
         # Optionally, add custom logic before calling the parent SQLConnector method.
         # You may delete this method if overrides are not needed.
-        return SQLConnector.to_sql_type(jsonschema_type)
+        return super().to_sql_type(jsonschema_type)
 
 
 class {{ cookiecutter.source_name }}Stream(SQLStream):
@@ -77,7 +79,7 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
 
     connector_class = {{ cookiecutter.source_name }}Connector
 
-    def get_records(self, partition: dict | None) -> t.Iterable[dict[str, t.Any]]:
+    def get_records(self, partition: Context | None) -> t.Iterable[dict[str, t.Any]]:
         """Return a generator of record-type dictionary objects.
 
         Developers may optionally add custom logic before calling the default

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
@@ -12,7 +12,6 @@ on:
     - tests/**
     - pyproject.toml
     - uv.lock
-    - tox.ini
   pull_request:
     branches: [main]
     paths:
@@ -21,7 +20,6 @@ on:
     - tests/**
     - pyproject.toml
     - uv.lock
-    - tox.ini
   workflow_dispatch:
 
 env:
@@ -29,6 +27,7 @@ env:
 
 jobs:
   pytest:
+    name: Integration Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -45,7 +44,27 @@ jobs:
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
-    - run: pipx install tox
+    - name: Setup uv
+      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      with:
+        version: ">=0.7"
     - name: Run Tox
       run: |
-        tox -e $(echo py{{ '${{ matrix.python-version }}' }} | tr -d .)
+        uvx --with=tox-uv tox -e $(echo py{{ '${{ matrix.python-version }}' }} | tr -d .)
+
+  typing:
+    name: Type Checking
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: 3.x
+    - name: Setup uv
+      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      with:
+        version: ">=0.7"
+    - name: Run Tox
+      run: |
+        uvx --with=tox-uv tox -e typing

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
@@ -20,33 +20,22 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.33.0
+  rev: 0.33.1
   hooks:
   - id: check-dependabot
   - id: check-github-workflows
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.0
+  rev: v0.12.1
   hooks:
   - id: ruff-check
     args: [--diff]
   - id: ruff-format
     args: [--diff]
 
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.16.0
-  hooks:
-  - id: mypy
-    additional_dependencies:
-    {%- if cookiecutter.serialization_method != "SQL" %}
-    - sqlalchemy-stubs
-    {%- else %}
-    - types-requests
-    {%- endif %}
-
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.7.12
+  rev: 0.7.17
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -60,6 +60,14 @@ test = [
     {%- endif %}
     "singer-sdk[testing]",
 ]
+typing = [
+    "mypy>=1.16.0",
+    {%- if cookiecutter.serialization_method == "SQL" %}
+    "sqlalchemy-stubs",
+    {%- else %}
+    "types-requests",
+    {%- endif %}
+]
 
 {%- if cookiecutter.variant != "None (Skip)" %}
 [tool.hatch.build.targets.wheel]
@@ -97,6 +105,7 @@ requires = [
     "tox-uv",
 ]
 env_list = [
+    "typing",
     "py313",
     "py312",
     "py311",
@@ -114,3 +123,7 @@ pass_env = [
 ]
 dependency_groups = [ "test" ]
 commands = [ [ "pytest", { replace = "posargs", default = [ "tests" ], extend = true } ] ]
+
+[tool.tox.env.typing]
+dependency_groups = [ "test", "typing" ]
+commands = [ [ "mypy", { replace = "posargs", default = [ "{{cookiecutter.library_name}}", "tests" ], extend = true } ] ]

--- a/noxfile.py
+++ b/noxfile.py
@@ -371,7 +371,8 @@ def templates(session: nox.Session, replay_file_path: Path) -> None:
 
     session.run("git", "init", "-b", "main", external=True)
     session.run("git", "add", ".", external=True)
-    session.run("uvx", "pre-commit", "run", "--all-files", external=True)
+    session.run("uvx", "pre-commit", "run", "--all-files")
+    session.run("uvx", "--with=tox-uv", "tox", "-e=typing")
 
 
 @nox.session(name="version-bump")


### PR DESCRIPTION
## Summary by Sourcery

Enable in-template mypy type checks by adding a dedicated tox "typing" environment and CI job, migrate tox runs to uvx virtual environments, update scaffolded SQL client type annotations, and bump CI and pre-commit hook versions.

New Features:
- Add CI job for static type checking with mypy in a dedicated tox "typing" environment across templates

Enhancements:
- Switch Actions workflows to use astral-sh/setup-uv and uvx to run tox in isolated virtual environments
- Configure a "typing" tox environment in pyproject.toml with mypy and stub dependencies
- Refine generated SQL client code with proper Context typing, super() usage, and updated method signatures
- Update pre-commit configs by bumping check-jsonschema, ruff, and uv hooks and removing the standalone mypy hook

Build:
- Upgrade svenstaro/upload-release-action to v2.10.0 in build workflows

CI:
- Rename pytest job to "Integration Tests" and remove tox.ini from workflow path filters
- Add Type Checking job and integrate uvx commands into CI workflows for both pytest and mypy runs
- Integrate type checking into the nox templates session by running tox typing environment