### PR TITLE
fix: Fixed the return type of `RESTStream.get_new_paginator` to indicate returning `None` is supported to indicate no pagination

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -802,11 +802,11 @@ class RESTStream(_HTTPStream, t.Generic[_TToken], metaclass=abc.ABCMeta):
             input=response.json(parse_float=decimal.Decimal),
         )
 
-    def get_new_paginator(self) -> BaseAPIPaginator:
+    def get_new_paginator(self) -> BaseAPIPaginator | None:
         """Get a fresh paginator for this API endpoint.
 
         Returns:
-            A paginator instance.
+            A paginator instance, or ``None`` to indicate pagination is not supported.
         """
         if hasattr(self, "get_next_page_token"):
             warn(


### PR DESCRIPTION
## Related

- https://github.com/meltano/sdk/pull/3141
- https://github.com/meltano/sdk/pull/3142

## Summary by Sourcery

Allow RESTStream.get_new_paginator to return None when pagination is unsupported

Bug Fixes:
- Change get_new_paginator return type annotation to allow None
- Update docstring to indicate None can be returned for no pagination

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3148.org.readthedocs.build/en/3148/

<!-- readthedocs-preview meltano-sdk end -->

## Summary by Sourcery

Bug Fixes:
- Allow RESTStream.get_new_paginator to return None when pagination is unsupported by updating its return type annotation and docstring