### PR TITLE
chore: Configure which directories go into the SDist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,21 @@ benchmark = [
     "pytest-codspeed>=2.2.0",
 ]
 
+[tool.hatch.build.targets.sdist]
+include = [
+    "cookiecutter",
+    "docs",
+    "fixtures",
+    "samples",
+    "singer_sdk",
+    "tests",
+]
+
+[tool.hatch.build.targets.wheel]
+include = [
+    "singer_sdk",
+]
+
 [tool.hatch.version]
 fallback-version = "0.0.0"
 source = "vcs"


### PR DESCRIPTION
## Summary by Sourcery

Configure Hatch build targets to include specific project directories in the source distribution and restrict the wheel to the core package

Build:
- Add sdist target in pyproject.toml to include cookiecutter, fixtures, samples, singer_sdk, tests, and docs directories
- Add wheel target in pyproject.toml to include only the singer_sdk directory