### PR TITLE
refactor: Rename `TestSuite` → `SingerTestSuite` to prevent a pytest test collection warning

### DIFF
--- a/singer_sdk/testing/factory.py
+++ b/singer_sdk/testing/factory.py
@@ -9,7 +9,7 @@ import pytest
 from .config import SuiteConfig
 from .runners import TapTestRunner, TargetTestRunner
 from .suites import (
-    TestSuite,
+    SingerTestSuite,
     tap_stream_attribute_tests,
     tap_stream_tests,
     tap_tests,
@@ -154,7 +154,7 @@ class TapTestClassFactory:
     def _annotate_test_class(
         self,
         empty_test_class: type[BaseTestClass],
-        test_suites: list[TestSuite],
+        test_suites: list[SingerTestSuite],
         test_runner: TapTestRunner,
     ) -> type[BaseTestClass]:
         """Annotate test class with test methods.
@@ -185,7 +185,7 @@ class TapTestClassFactory:
     def _with_tap_tests(  # noqa: PLR6301
         self,
         empty_test_class: type[BaseTestClass],
-        suite: TestSuite[TapTestTemplate],
+        suite: SingerTestSuite[TapTestTemplate],
     ) -> None:
         for test_class in suite.tests:
             test = test_class()
@@ -195,7 +195,7 @@ class TapTestClassFactory:
     def _with_stream_tests(  # noqa: PLR6301
         self,
         empty_test_class: type[BaseTestClass],
-        suite: TestSuite[StreamTestTemplate],
+        suite: SingerTestSuite[StreamTestTemplate],
         streams: list[Stream],
     ) -> None:
         params = [
@@ -220,7 +220,7 @@ class TapTestClassFactory:
     def _with_stream_attribute_tests(  # noqa: PLR6301
         self,
         empty_test_class: type[BaseTestClass],
-        suite: TestSuite[AttributeTestTemplate],
+        suite: SingerTestSuite[AttributeTestTemplate],
         streams: list[Stream],
     ) -> None:
         for test_class in suite.tests:

--- a/singer_sdk/testing/suites.py
+++ b/singer_sdk/testing/suites.py
@@ -49,8 +49,23 @@ from .templates import TestTemplate
 T = t.TypeVar("T", bound=TestTemplate)
 
 
+def __getattr__(name: str) -> t.Any:  # noqa: ANN401
+    """Provide backwards compatibility for TestSuite."""  # noqa: DOC201, DOC501
+    if name == "TestSuite":
+        import warnings  # noqa: PLC0415
+
+        warnings.warn(
+            "TestSuite is deprecated, use SingerTestSuite instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return SingerTestSuite
+    msg = f"module '{__name__}' has no attribute '{name}'"
+    raise AttributeError(msg)
+
+
 @dataclass
-class TestSuite(t.Generic[T]):
+class SingerTestSuite(t.Generic[T]):
     """Test Suite container class."""
 
     kind: str
@@ -58,7 +73,7 @@ class TestSuite(t.Generic[T]):
 
 
 # Tap Test Suites
-tap_tests = TestSuite(
+tap_tests = SingerTestSuite(
     kind="tap",
     tests=[
         TapCLIPrintsTest,
@@ -67,7 +82,7 @@ tap_tests = TestSuite(
         TapValidFinalStateTest,
     ],
 )
-tap_stream_tests = TestSuite(
+tap_stream_tests = SingerTestSuite(
     kind="tap_stream",
     tests=[
         StreamCatalogSchemaMatchesRecordTest,
@@ -78,7 +93,7 @@ tap_stream_tests = TestSuite(
         StreamPrimaryKeysTest,
     ],
 )
-tap_stream_attribute_tests = TestSuite(
+tap_stream_attribute_tests = SingerTestSuite(
     kind="tap_stream_attribute",
     tests=[
         AttributeIsBooleanTest,
@@ -92,7 +107,7 @@ tap_stream_attribute_tests = TestSuite(
 
 
 # Target Test Suites
-target_tests = TestSuite(
+target_tests = SingerTestSuite(
     kind="target",
     tests=[
         TargetArrayData,


### PR DESCRIPTION


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3164.org.readthedocs.build/en/3164/

<!-- readthedocs-preview meltano-sdk end -->