### PR TITLE
ci: Use uv 0.8

### DIFF
--- a/.github/workflows/api-changes.yml
+++ b/.github/workflows/api-changes.yml
@@ -39,7 +39,7 @@ jobs:
 
     - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
       with:
-        version: ">=0.6,<0.7"
+        version: ">=0.8,<0.9"
 
     - name: Install tools
       run: |

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
       with:
-        version: ">=0.6,<0.7"
+        version: ">=0.8,<0.9"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/cookiecutter-e2e.yml
+++ b/.github/workflows/cookiecutter-e2e.yml
@@ -44,7 +44,7 @@ jobs:
         persist-credentials: false
     - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
       with:
-        version: ">=0.6,<0.7"
+        version: ">=0.8,<0.9"
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: 3.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
 
     - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
       with:
-        version: ">=0.6,<0.7"
+        version: ">=0.8,<0.9"
 
     - name: Install Nox
       run: |
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.head.repo.fork }}
     env:
-      NOXPYTHON: "3.12"
+      NOXPYTHON: "3.13"
       NOXSESSION: tests
       TAP_GITLAB_AUTH_TOKEN: ${{ secrets.SAMPLE_TAP_GITLAB_AUTH_TOKEN }}
       TAP_GITLAB_GROUP_IDS: ${{ secrets.SAMPLE_TAP_GITLAB_GROUP_IDS }}
@@ -128,7 +128,7 @@ jobs:
 
     - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
       with:
-        version: ">=0.6,<0.7"
+        version: ">=0.8,<0.9"
 
     - name: Install Nox
       run: |
@@ -160,7 +160,7 @@ jobs:
 
     - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
       with:
-        version: ">=0.6,<0.7"
+        version: ">=0.8,<0.9"
 
     - name: Install Nox
       run: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
         with:
-          version: ">=0.7,<0.8"
+          version: ">=0.8,<0.9"
 
       - name: Run zizmor 🌈
         run: >


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflows to use UV 0.8 and bump Nox Python version to 3.13

CI:
- Update astral-sh/setup-uv version constraints to ">=0.8,<0.9" across multiple workflows
- Bump NOXPYTHON environment variable from 3.12 to 3.13 in the test workflow