### PR TITLE
test: Avoid early failures during collection for tap-gitlab tests

### DIFF
--- a/tests/external/test_tap_gitlab.py
+++ b/tests/external/test_tap_gitlab.py
@@ -1,24 +1,12 @@
 from __future__ import annotations
 
-import warnings
-
 from tap_gitlab.tap import TapGitlab
 
-from singer_sdk.exceptions import ConfigValidationError
 from singer_sdk.helpers import _catalog
 from singer_sdk.singerlib import Catalog
 from singer_sdk.testing import get_tap_test_class
 
-try:
-    TestSampleTapGitlab = get_tap_test_class(TapGitlab)
-except ConfigValidationError as e:
-    warnings.warn(
-        UserWarning(
-            "Could not configure external gitlab tests. "
-            f"Config in CI is expected via env vars.\n{e}",
-        ),
-        stacklevel=2,
-    )
+TestSampleTapGitlab = get_tap_test_class(TapGitlab, validate_config=False)
 
 
 def test_gitlab_replication_keys():


### PR DESCRIPTION
## Summary by Sourcery

Configure the tap-gitlab test class to skip config validation and remove the early-failure try/catch, preventing test collection errors.

Bug Fixes:
- Remove the warnings import and try/except block that caused early failures during test collection

Enhancements:
- Call get_tap_test_class with validate_config=False for TapGitlab tests

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3174.org.readthedocs.build/en/3174/

<!-- readthedocs-preview meltano-sdk end -->