### PR TITLE
feat: Pytest markers for tap built-in tests

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,5 +1,6 @@
 paths:
   - samples
+  - packages
   - singer_sdk
   - tests
 paths-ignore:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "samples/**"
+      - "packages/**"
       - "singer_sdk/**"
       - "tests/**"
       - "noxfile.py"
@@ -18,6 +19,7 @@ on:
       - v*
     paths:
       - "samples/**"
+      - "packages/**"
       - "singer_sdk/**"
       - "tests/**"
       - "noxfile.py"

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -73,6 +73,10 @@ packages = [
 addopts = [
     "--durations=10",
 ]
+markers = [
+    "singer_stream: Tests that validate Singer stream-level functionality",
+    "singer_stream_attribute: Tests that validate individual Singer stream attributes/properties",
+]
 
 [tool.mypy]
 warn_unused_configs = true

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -87,6 +87,10 @@ packages = [
 addopts = [
     "--durations=10",
 ]
+markers = [
+    "singer_stream: Tests that validate Singer stream-level functionality",
+    "singer_stream_attribute: Tests that validate individual Singer stream attributes/properties",
+]
 
 [tool.mypy]
 warn_unused_configs = true

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -76,6 +76,15 @@ packages = [
 ]
 {%- endif %}
 
+[tool.pytest.ini_options]
+addopts = [
+    "--durations=10",
+]
+markers = [
+    "singer_stream: Tests that validate Singer stream-level functionality",
+    "singer_stream_attribute: Tests that validate individual Singer stream attributes/properties",
+]
+
 [tool.mypy]
 warn_unused_configs = true
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -103,6 +103,51 @@ TestTapStackExchange = get_tap_test_class(
 
 Check out [the reference](#reference) for more information on the available configuration options.
 
+## Pytest Markers
+
+The Singer SDK automatically adds pytest markers to auto-generated tests, allowing you to run specific subsets of tests using pytest's `-m` option. This is particularly useful for focusing on specific test categories during development or CI/CD workflows.
+
+### Available Markers
+
+- **`singer_stream`**: Tests that validate stream-level functionality (schema validation, record validation, etc.)
+- **`singer_stream_attribute`**: Tests that validate individual stream attributes/properties
+
+### Usage Examples
+
+#### Basic Usage
+
+```shell
+# Run all stream-level tests
+pytest -m "singer_stream"
+
+# Run all stream attribute tests
+pytest -m "singer_stream_attribute"
+```
+
+#### Practical Examples
+
+```shell
+# Focus on stream functionality during development
+pytest -m "singer_stream" tests/
+
+# Test only attribute validation
+pytest -m "singer_stream_attribute" tests/
+
+# CI pipeline: test stream functionality with fast failure
+pytest -m "singer_stream" --maxfail=1
+
+# Run both stream and attribute tests
+pytest -m "singer_stream or singer_stream_attribute" tests/
+```
+
+### Benefits
+
+- **Granular Control**: Run only the tests you need
+- **Faster Development**: Focus on specific test categories during development
+- **CI/CD Optimization**: Run different test subsets in parallel or on different stages
+- **Debugging**: Isolate issues by running specific test types
+- **Faster Test Execution**: Skip irrelevant test categories to reduce overall test runtime
+
 ## Writing New Tests
 
 Writing new tests is as easy as subclassing the appropriate class.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,8 @@ markers = [
     "linux: Tests that only run on Linux",
     "darwin: Tests that only run on Darwin",
     "snapshot: Tests that use pytest-snapshot",
+    "singer_stream: Tests that validate Singer stream-level functionality",
+    "singer_stream_attribute: Tests that validate individual Singer stream attributes/properties",
 ]
 minversion = "7"
 testpaths = ["tests"]

--- a/singer_sdk/testing/factory.py
+++ b/singer_sdk/testing/factory.py
@@ -28,7 +28,7 @@ if t.TYPE_CHECKING:
 class BaseTestClass:
     """Base test class."""
 
-    params: dict[str, t.Any]
+    params: dict[str, list[dict[str, t.Any]]]
     param_ids: dict[str, list[str]]
 
     def __init_subclass__(cls, **kwargs: t.Any) -> None:

--- a/singer_sdk/testing/pytest_plugin.py
+++ b/singer_sdk/testing/pytest_plugin.py
@@ -18,12 +18,23 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         metafunc: Pytest MetaFunc instance, representing a test function or method.
     """
     if metafunc.cls is not None and issubclass(metafunc.cls, BaseTestClass):
-        func_arg_list = metafunc.cls.params.get(metafunc.definition.name)
-        func_arg_ids = metafunc.cls.param_ids.get(metafunc.definition.name)
+        name = metafunc.definition.name
+        func_arg_list = metafunc.cls.params.get(name)
+        func_arg_ids = metafunc.cls.param_ids.get(name)
+
         if func_arg_list:
+            markers = []
+            if "tap_stream_" in name and "attribute" not in name:
+                markers.append(pytest.mark.singer_stream)
+            elif "tap_stream_attribute_" in name:
+                markers.append(pytest.mark.singer_stream_attribute)
+
             arg_names = list(func_arg_list[0].keys())
             parameters = [
-                pytest.param(*tuple(func_args[name] for name in arg_names))
+                pytest.param(
+                    *tuple(func_args[name] for name in arg_names),
+                    marks=markers,
+                )
                 for func_args in func_arg_list
             ]
             metafunc.parametrize(

--- a/singer_sdk/testing/runners.py
+++ b/singer_sdk/testing/runners.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import abc
 import io
 import json
+import sys
 import typing as t
 from collections import defaultdict
 from contextlib import redirect_stderr, redirect_stdout
@@ -12,6 +13,12 @@ from contextlib import redirect_stderr, redirect_stdout
 from singer_sdk import Tap, Target
 from singer_sdk.plugin_base import PluginBase
 from singer_sdk.testing.config import SuiteConfig
+
+if sys.version_info < (3, 12):
+    from typing_extensions import override
+else:
+    from typing import override  # noqa: ICN003
+
 
 if t.TYPE_CHECKING:
     from pathlib import Path
@@ -150,7 +157,8 @@ class TapTestRunner(SingerTestRunner[Tap]):
             dry_run_record_limit=self.suite_config.max_records_limit,
         )
 
-    def sync_all(self, **kwargs: t.Any) -> None:  # noqa: ARG002
+    @override
+    def sync_all(self, **kwargs: t.Any) -> None:
         """Run a full tap sync, assigning output to the runner object.
 
         Args:
@@ -256,12 +264,8 @@ class TargetTestRunner(SingerTestRunner[Target]):
     def target_input(self, value: t.IO[str]) -> None:
         self._input = value
 
-    def sync_all(
-        self,
-        *,
-        finalize: bool = True,
-        **kwargs: t.Any,  # noqa: ARG002
-    ) -> None:
+    @override
+    def sync_all(self, *, finalize: bool = True, **kwargs: t.Any) -> None:
         """Run a full tap sync, assigning output to the runner object.
 
         Args:


### PR DESCRIPTION
## Summary by Sourcery

Introduce pytest markers for Singer SDK built-in tests, enabling granular test selection and updating documentation, project templates, and CI workflows to support the new markers.

New Features:
- Add pytest markers singer_stream and singer_stream_attribute to auto-generated tests

Enhancements:
- Apply markers automatically in pytest_generate_tests for BaseTestClass subclasses
- Annotate sync_all methods with override decorator in testing runners
- Refine BaseTestClass.params type annotation to list of parameter mappings

Build:
- Include packages/** path in test and CodeQL workflows
- Add pytest.ini marker definitions and addopts to cookiecutter and root pyproject.toml

CI:
- Update GitHub test workflow to include packages/** in paths

Documentation:
- Add Pytest Markers section with usage examples and benefits in testing documentation