### PR TITLE
refactor: Remove unused `plugin_type` attribute from test template classes

### DIFF
--- a/singer_sdk/testing/factory.py
+++ b/singer_sdk/testing/factory.py
@@ -365,7 +365,7 @@ class TargetTestClassFactory:
     def _annotate_test_class(  # noqa: PLR6301
         self,
         empty_test_class: type[BaseTestClass],
-        test_suites: list,
+        test_suites: list[SingerTestSuite],
     ) -> type[BaseTestClass]:
         """Annotate test class with test methods.
 

--- a/singer_sdk/testing/suites.py
+++ b/singer_sdk/testing/suites.py
@@ -68,7 +68,12 @@ def __getattr__(name: str) -> t.Any:  # noqa: ANN401
 class SingerTestSuite(t.Generic[T]):
     """Test Suite container class."""
 
-    kind: str
+    kind: t.Literal[
+        "tap",
+        "tap_stream",
+        "tap_stream_attribute",
+        "target",
+    ]
     tests: list[type[T]]
 
 

--- a/singer_sdk/testing/templates.py
+++ b/singer_sdk/testing/templates.py
@@ -39,7 +39,6 @@ class TestTemplate(t.Generic[_T]):
     """
 
     name: str | None = None
-    plugin_type: str | None = None
 
     @property
     def id(self) -> str:
@@ -107,8 +106,8 @@ class TestTemplate(t.Generic[_T]):
         Raises:
             ValueError: if Test instance does not have `name` and `type` properties.
         """
-        if not self.name or not self.plugin_type:  # pragma: no cover
-            msg = "Test must have 'name' and 'plugin_type' properties."
+        if not self.name:  # pragma: no cover
+            msg = "Test must have 'name' property."
             raise ValueError(msg)
 
         self.config = config
@@ -130,8 +129,6 @@ class TestTemplate(t.Generic[_T]):
 
 class TapTestTemplate(TestTemplate):
     """Base Tap test template."""
-
-    plugin_type = "tap"
 
     @property
     def id(self) -> str:
@@ -162,7 +159,6 @@ class TapTestTemplate(TestTemplate):
 class StreamTestTemplate(TestTemplate):
     """Base Tap Stream test template."""
 
-    plugin_type = "stream"
     required_kwargs: t.ClassVar[list[str]] = ["stream"]
 
     @property
@@ -204,8 +200,6 @@ class StreamTestTemplate(TestTemplate):
 
 class AttributeTestTemplate(StreamTestTemplate):
     """Base Tap Stream Attribute template."""
-
-    plugin_type = "attribute"
 
     @property
     def id(self) -> str:
@@ -283,8 +277,6 @@ class AttributeTestTemplate(StreamTestTemplate):
 
 class TargetTestTemplate(TestTemplate[TargetTestRunner]):
     """Base Target test template."""
-
-    plugin_type = "target"
 
     def run(
         self,


### PR DESCRIPTION
## Summary by Sourcery

Refactor testing templates to remove the unused `plugin_type` attribute and tighten type annotations across test suites and factory methods.

Enhancements:
- Remove the unused `plugin_type` attribute from TestTemplate and all its subclasses
- Simplify TestTemplate.run validation to only require the `name` property
- Strengthen type annotations by specifying SingerTestSuite.kind as a Literal union and typing the `test_suites` parameter in factory._annotate_test_class