### PR TITLE
refactor: Update type annotations of some functions to indicate they accept string path or a path-like object

### DIFF
--- a/singer_sdk/configuration/_dict_config.py
+++ b/singer_sdk/configuration/_dict_config.py
@@ -12,6 +12,9 @@ from dotenv.main import DotEnv
 from singer_sdk.helpers import _typing
 from singer_sdk.helpers._util import load_json
 
+if t.TYPE_CHECKING:
+    from singer_sdk.helpers.types import StrPath
+
 logger = logging.getLogger(__name__)
 
 TRUTHY = ("true", "1", "yes", "on")
@@ -28,7 +31,7 @@ def _legacy_parse_array_of_strings(value: str) -> list[str]:
 def parse_environment_config(
     config_schema: dict[str, t.Any],
     prefix: str,
-    dotenv_path: str | None = None,
+    dotenv_path: StrPath | None = None,
 ) -> dict[str, t.Any]:
     """Parse configuration from environment variables.
 

--- a/singer_sdk/helpers/_util.py
+++ b/singer_sdk/helpers/_util.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import datetime
 import decimal
 import typing as t
-from pathlib import Path, PurePath
+from pathlib import Path
 
 import simplejson
+
+if t.TYPE_CHECKING:
+    from singer_sdk.helpers.types import StrPath
 
 
 def dump_json(obj: t.Any, **kwargs: t.Any) -> str:  # noqa: ANN401
@@ -51,7 +54,7 @@ def load_json(json_str: str, **kwargs: t.Any) -> dict:
     )
 
 
-def read_json_file(path: PurePath | str) -> dict[str, t.Any]:
+def read_json_file(path: StrPath) -> dict[str, t.Any]:
     """Read json file, throwing an error if missing."""
     if not path:
         msg = "Could not open file. Filepath not provided."

--- a/singer_sdk/helpers/types.py
+++ b/singer_sdk/helpers/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import typing as t
 from collections.abc import Mapping
 
@@ -24,6 +25,7 @@ __all__ = [
 Context: TypeAlias = Mapping[str, t.Any]
 Record: TypeAlias = dict[str, t.Any]
 Auth: TypeAlias = t.Callable[[requests.PreparedRequest], requests.PreparedRequest]
+StrPath: TypeAlias = t.Union[str, os.PathLike[str]]
 
 
 class TapState(t.TypedDict, total=False):

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -45,6 +45,7 @@ from singer_sdk.typing import (
 if t.TYPE_CHECKING:
     from jsonschema import ValidationError
 
+    from singer_sdk.helpers.types import StrPath
     from singer_sdk.singerlib.encoding.base import (
         GenericSingerReader,
         GenericSingerWriter,
@@ -75,7 +76,7 @@ class _ConfigInput:
     """Whether to parse environment variables."""
 
     @classmethod
-    def from_cli_args(cls, *args: str) -> _ConfigInput:
+    def from_cli_args(cls, *args: StrPath) -> _ConfigInput:
         """Create a _ConfigInput from CLI arguments.
 
         Args:

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -119,7 +119,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
     def __init__(
         self,
         tap: Tap,
-        schema: str | PathLike | dict[str, t.Any] | singer.Schema | None = None,
+        schema: types.StrPath | dict[str, t.Any] | singer.Schema | None = None,
         name: str | None = None,
     ) -> None:
         """Init tap stream.

--- a/tests/core/test_plugin_base.py
+++ b/tests/core/test_plugin_base.py
@@ -105,7 +105,7 @@ def test_config_from_cli_args_env(tmp_path: Path):
     """Test that input is converted to a merged config dict and parse_env is true."""
     config_path = tmp_path / "config.json"
     config_path.write_text('{"prop1": "hello"}')
-    config_input = _ConfigInput.from_cli_args(str(config_path), "ENV")
+    config_input = _ConfigInput.from_cli_args(config_path, "ENV")
     assert config_input.config == {"prop1": "hello"}
     assert config_input.parse_env
 
@@ -117,7 +117,7 @@ def test_config_from_cli_args_invalid_file(tmp_path: Path):
         FileNotFoundError,
         match=r"File at '.*' was not found",
     ) as exc_info:
-        _ConfigInput.from_cli_args(str(missing_path), "ENV")
+        _ConfigInput.from_cli_args(missing_path, "ENV")
     # Assert the error message includes the specific file path
     assert str(missing_path) in str(exc_info.value)
 


### PR DESCRIPTION
## Summary by Sourcery

Define a unified StrPath alias for string or os.PathLike path arguments and update type annotations across utility, configuration, plugin, and stream modules to use StrPath instead of raw strings or PurePath, and adjust tests accordingly.

Enhancements:
- Add StrPath type alias to represent string or PathLike file paths
- Update all path-related function and method signatures to use the new StrPath alias
- Introduce TYPE_CHECKING imports to enable StrPath annotations without runtime dependency

Tests:
- Modify tests to pass Path objects to from_cli_args instead of raw strings