### PR TITLE
ci: Use separate coverage flags for contrib and end-to-end package tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,10 @@ jobs:
       NOXSESSION: ${{ matrix.session }}
     permissions:
       contents: read
+    outputs:
+      os: ${{ matrix.os }}
+      nox-session: ${{ matrix.session }}
+      python-version: ${{ matrix.python-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -62,12 +66,13 @@ jobs:
         - "3.12"
         - "3.13"
         include:
-        - { session: doctest,      python-version: "3.13", os: "ubuntu-latest" }
-        - { session: mypy,         python-version: "3.13", os: "ubuntu-latest" }
-        - { session: mypy,         python-version: "3.9",  os: "ubuntu-latest" }
-        - { session: deps,         python-version: "3.13", os: "ubuntu-latest" }
-        - { session: test-lowest,  python-version: "3.9",  os: "ubuntu-latest" }
-        - { session: test-modules, python-version: "3.13", os: "ubuntu-latest" }
+        - { session: doctest,       python-version: "3.13", os: "ubuntu-latest" }
+        - { session: mypy,          python-version: "3.13", os: "ubuntu-latest" }
+        - { session: mypy,          python-version: "3.9",  os: "ubuntu-latest" }
+        - { session: deps,          python-version: "3.13", os: "ubuntu-latest" }
+        - { session: test-lowest,   python-version: "3.9",  os: "ubuntu-latest" }
+        - { session: test-contrib,  python-version: "3.13", os: "ubuntu-latest" }
+        - { session: test-packages, python-version: "3.13", os: "ubuntu-latest" }
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -94,7 +99,7 @@ jobs:
         nox --verbose
 
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      if: always() && (matrix.session == 'tests' || matrix.session == 'test-modules')
+      if: always() && (matrix.session == 'tests' || matrix.session == 'test-contrib' || matrix.session == 'test-packages')
       with:
         include-hidden-files: true
         name: coverage-data-nox_${{ matrix.session }}-${{ matrix.os }}-py${{ matrix.python-version }}
@@ -176,4 +181,5 @@ jobs:
     - uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
       with:
         fail_ci_if_error: true
+        flags: ${{ needs.tests.outputs.nox-session }}
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,6 +145,12 @@ jobs:
     needs: tests
     env:
       NOXSESSION: coverage
+    strategy:
+      matrix:
+        flag:
+        - "tests"
+        - "test-contrib"
+        - "test-packages"
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
@@ -155,7 +161,7 @@ jobs:
 
     - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
-        pattern: coverage-data-*
+        pattern: coverage-data-nox_${{ matrix.flag }}-*
         merge-multiple: true
 
     - uses: astral-sh/setup-uv@7edac99f961f18b581bbd960d59d049f04c0002f # v6.4.1
@@ -181,5 +187,5 @@ jobs:
     - uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
       with:
         fail_ci_if_error: true
-        flags: ${{ needs.tests.outputs.nox-session }}
+        flags: ${{ matrix.flag }}
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,10 +148,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flag:
-        - "tests"
-        - "test-contrib"
-        - "test-packages"
+        include:
+        - flag: core
+          nox-session: tests
+        - flag: optional-components
+          nox-session: test-contrib
+        - flag: end-to-end
+          nox-session: test-packages
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
@@ -162,7 +165,7 @@ jobs:
 
     - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
-        pattern: coverage-data-nox_${{ matrix.flag }}-*
+        pattern: coverage-data-nox_${{ matrix.nox-session }}-*
         merge-multiple: true
 
     - uses: astral-sh/setup-uv@7edac99f961f18b581bbd960d59d049f04c0002f # v6.4.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,6 +146,7 @@ jobs:
     env:
       NOXSESSION: coverage
     strategy:
+      fail-fast: false
       matrix:
         flag:
         - "tests"

--- a/noxfile.py
+++ b/noxfile.py
@@ -135,18 +135,13 @@ def test_external(session: nox.Session) -> None:
     )
 
 
-@nox.session(name="test-modules", tags=["test"])
-def test_modules(session: nox.Session) -> None:
+@nox.session(name="test-contrib", tags=["test"])
+def test_contrib(session: nox.Session) -> None:
     """Execute pytest tests and compute coverage."""
     session.run_install(
         *UV_SYNC_COMMAND,
-        "--group=packages",
         "--group=testing",
-        "--extra=faker",
-        "--extra=jwt",
-        "--extra=s3",
-        "--extra=msgspec",  # more performant SerDe
-        "--extra=parquet",  # BATCH message support
+        "--all-extras",
         env=_install_env(session),
     )
 
@@ -154,9 +149,35 @@ def test_modules(session: nox.Session) -> None:
         session,
         "--durations=10",
         "--benchmark-skip",
+        "--ignore=tests/benchmarks",
+        "--ignore=tests/external",
+        "--ignore=tests/packages",
+        "-m",
+        "contrib",
+        *session.posargs,
+    )
+
+
+@nox.session(name="test-packages", tags=["test"])
+def test_packages(session: nox.Session) -> None:
+    """Execute pytest tests and compute coverage."""
+    session.run_install(
+        *UV_SYNC_COMMAND,
+        "--group=packages",
+        "--group=testing",
+        "--all-extras",
+        env=_install_env(session),
+    )
+
+    _run_pytest(
+        session,
+        "--durations=10",
+        "--benchmark-skip",
+        "--ignore=tests/benchmarks",
+        "--ignore=tests/contrib",
         "--ignore=tests/external",
         "-m",
-        "contrib or packages",
+        "packages",
         *session.posargs,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ exclude_also = [
     '''@(abc\.)?abstractmethod''',
     '''if (t\.)?TYPE_CHECKING:''',
 ]
-fail_under = 82
+fail_under = 70
 show_missing = true
 
 [tool.deptry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,6 @@ exclude_also = [
     '''@(abc\.)?abstractmethod''',
     '''if (t\.)?TYPE_CHECKING:''',
 ]
-fail_under = 70
 show_missing = true
 
 [tool.deptry]


### PR DESCRIPTION
## Summary by Sourcery

Separate contrib and package tests into distinct nox sessions and update the CI workflow to support individual coverage flags

Enhancements:
- Split the original test-modules nox session into separate test-contrib and test-packages sessions with isolated coverage runs

CI:
- Add test-contrib and test-packages sessions to the GitHub Actions matrix and export os, nox-session, and python-version as job outputs
- Extend the artifact upload step to include test-contrib and test-packages sessions
- Set Codecov flags dynamically based on the nox-session output