### PR TITLE
packaging: Declare support for Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
         - "3.11"
         - "3.12"
         - "3.13"
+        - "3.14"
         include:
         - { session: doctest,       python-version: "3.13", os: "ubuntu-latest" }
         - { session: mypy,          python-version: "3.13", os: "ubuntu-latest" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Typing :: Typed",
@@ -185,13 +186,14 @@ addopts = [
 ]
 filterwarnings = [
     "error",
-    "ignore:No records were available to test:UserWarning",
+    "once:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning",  # https://github.com/litl/backoff/pull/220
+    "once:No records were available to test:UserWarning",
     # https://github.com/meltano/sdk/issues/1354
     "ignore:The function singer_sdk.testing.get_standard_tap_tests is deprecated:DeprecationWarning",
     # TODO: Address this SQLite warning in Python 3.13+
     "ignore::ResourceWarning",
     # universal-pathlib
-    "default:in a future version of UPath this will be set to None:PendingDeprecationWarning",
+    "once:in a future version of UPath this will be set to None:PendingDeprecationWarning",
 ]
 log_cli_level = "INFO"
 log_format = "%(levelname)s %(name)s %(message)s"


### PR DESCRIPTION
## Summary by Sourcery

Add Python 3.14 support and refine deprecation warning handling in test configuration

New Features:
- Declare support for Python 3.14 in package classifiers

Enhancements:
- Add a deprecation warning filter for 'asyncio.iscoroutinefunction'
- Adjust existing warning filters to trigger only once instead of default or ignore

CI:
- Include Python 3.14 in the GitHub Actions test matrix