### PR TITLE
refactor: Consolidate test parameters in built-in tests

### DIFF
--- a/singer_sdk/testing/pytest_plugin.py
+++ b/singer_sdk/testing/pytest_plugin.py
@@ -17,17 +17,10 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     Args:
         metafunc: Pytest MetaFunc instance, representing a test function or method.
     """
-    if metafunc.cls is not None and issubclass(metafunc.cls, BaseTestClass):
-        func_arg_list = metafunc.cls.params.get(metafunc.definition.name)
-        func_arg_ids = metafunc.cls.param_ids.get(metafunc.definition.name)
-        if func_arg_list:
-            arg_names = list(func_arg_list[0].keys())
-            parameters = [
-                pytest.param(*tuple(func_args[name] for name in arg_names))
-                for func_args in func_arg_list
-            ]
-            metafunc.parametrize(
-                ",".join(arg_names),
-                parameters,
-                ids=func_arg_ids,
-            )
+    if (
+        metafunc.cls is not None
+        and issubclass(metafunc.cls, BaseTestClass)
+        and (params := metafunc.cls.params.get(metafunc.definition.name))
+    ):
+        parameters = [pytest.param(*param.values, id=param.id) for param in params]
+        metafunc.parametrize(params[0].values._fields, parameters)

--- a/tests/core/testing/test_factory.py
+++ b/tests/core/testing/test_factory.py
@@ -54,9 +54,7 @@ class TestBaseTestClass:
             pass
 
         assert hasattr(DirectSubclass, "params")
-        assert hasattr(DirectSubclass, "param_ids")
         assert DirectSubclass.params == {}
-        assert DirectSubclass.param_ids == {}
 
     def test_base_test_class_nested_subclass_no_params(self):
         """Test that subclasses of subclasses don't get params attributes."""
@@ -69,13 +67,10 @@ class TestBaseTestClass:
 
         # Direct subclass should have params
         assert hasattr(DirectSubclass, "params")
-        assert hasattr(DirectSubclass, "param_ids")
 
         # Nested subclass should not get new params (inherits from direct)
         assert hasattr(NestedSubclass, "params")
-        assert hasattr(NestedSubclass, "param_ids")
         assert NestedSubclass.params is DirectSubclass.params
-        assert NestedSubclass.param_ids is DirectSubclass.param_ids
 
 
 class TestTapTestClassFactory:
@@ -372,14 +367,11 @@ class TestTapTestClassFactory:
             expected_method_name = f"test_tap_stream_{test_template.name}"
             assert hasattr(test_class, expected_method_name)
             assert expected_method_name in test_class.params
-            assert expected_method_name in test_class.param_ids
 
             # Check parameters
             params = test_class.params[expected_method_name]
-            param_ids = test_class.param_ids[expected_method_name]
             assert len(params) == 2
-            assert len(param_ids) == 2
-            assert param_ids == ["stream1", "stream2"]
+            assert [param.id for param in params] == ["stream1", "stream2"]
 
     @patch("singer_sdk.testing.factory.TapTestRunner")
     def test_with_stream_attribute_tests(
@@ -426,11 +418,9 @@ class TestTapTestClassFactory:
             if expected_method_name in test_class.params:
                 assert hasattr(test_class, expected_method_name)
                 params = test_class.params[expected_method_name]
-                param_ids = test_class.param_ids[expected_method_name]
 
                 # Should have parameters for each property that passed evaluate
                 assert len(params) > 0
-                assert len(param_ids) > 0
 
 
 class TestTargetTestClassFactory:

--- a/tests/core/testing/test_factory.py
+++ b/tests/core/testing/test_factory.py
@@ -422,6 +422,17 @@ class TestTapTestClassFactory:
                 # Should have parameters for each property that passed evaluate
                 assert len(params) > 0
 
+                # Assert that each param's id matches the expected format and values contains correct stream and property
+                for param in params:
+                    # id should be in the format "stream.property"
+                    assert isinstance(param.id, str)
+                    assert "." in param.id
+                    stream, prop = param.id.split(".", 1)
+                    # values should contain the correct stream and property name
+                    assert hasattr(param, "values")
+                    assert param.values.get("stream_name") == stream
+                    assert param.values.get("property_name") == prop
+
 
 class TestTargetTestClassFactory:
     """Test TargetTestClassFactory functionality."""

--- a/tests/core/testing/test_factory.py
+++ b/tests/core/testing/test_factory.py
@@ -12,6 +12,7 @@ from singer_sdk import Stream, Tap, Target
 from singer_sdk.testing.config import SuiteConfig
 from singer_sdk.testing.factory import (
     BaseTestClass,
+    StreamAttributeTestParams,
     TapTestClassFactory,
     TargetTestClassFactory,
     get_tap_test_class,
@@ -422,16 +423,13 @@ class TestTapTestClassFactory:
                 # Should have parameters for each property that passed evaluate
                 assert len(params) > 0
 
-                # Assert that each param's id matches the expected format and values contains correct stream and property
+                # Assert that each param's id matches the expected format and values
+                # contains correct stream and property
                 for param in params:
-                    # id should be in the format "stream.property"
-                    assert isinstance(param.id, str)
-                    assert "." in param.id
                     stream, prop = param.id.split(".", 1)
-                    # values should contain the correct stream and property name
-                    assert hasattr(param, "values")
-                    assert param.values.get("stream_name") == stream
-                    assert param.values.get("property_name") == prop
+                    assert isinstance(param.values, StreamAttributeTestParams)
+                    assert param.values.stream.name == stream
+                    assert param.values.attribute_name == prop
 
 
 class TestTargetTestClassFactory:


### PR DESCRIPTION
## Summary by Sourcery

Refactor test parameter handling by introducing a unified TestParam dataclass along with NamedTuple wrappers for stream tests, removing the separate param_ids mechanism and updating factories, pytest plugin, and tests accordingly

Enhancements:
- Consolidate test parameters into a unified TestParam dataclass and remove the separate param_ids attribute
- Introduce StreamTestParams and StreamAttributeTestParams NamedTuples to encapsulate stream-based test arguments
- Refactor TapTestClassFactory and pytest_generate_tests to generate and consume TestParam instances instead of raw dicts and ids
- Update existing tests to validate the new TestParam structure and drop references to param_ids