### PR TITLE
feat: Update tap, target and mapper dependencies in templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         name: Packages
         path: dist
     - name: Upload wheel to release
-      uses: svenstaro/upload-release-action@ebd922b779f285dafcac6410a0710daee9c12b82 # 2.10.0
+      uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # 2.11.2
       with:
         repo_token: {{ '${{secrets.GITHUB_TOKEN}}' }}
         file: dist/*.whl

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Setup uv
-      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
       with:
         version: ">=0.7"
     - name: Run Tox
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: 3.x
     - name: Setup uv
-      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
       with:
         version: ">=0.7"
     - name: Run Tox

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.4
+  rev: v0.12.5
   hooks:
   - id: ruff-check
     args: [--diff]
@@ -35,7 +35,7 @@ repos:
     args: [--diff]
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.8.0
+  rev: 0.8.3
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         name: Packages
         path: dist
     - name: Upload wheel to release
-      uses: svenstaro/upload-release-action@ebd922b779f285dafcac6410a0710daee9c12b82 # 2.10.0
+      uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # 2.11.2
       with:
         repo_token: {{ '${{secrets.GITHUB_TOKEN}}' }}
         file: dist/*.whl

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Setup uv
-      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
       with:
         version: ">=0.7"
     - name: Run Tox
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: 3.x
     - name: Setup uv
-      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
       with:
         version: ">=0.7"
     - name: Run Tox

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.4
+  rev: v0.12.5
   hooks:
   - id: ruff-check
     args: [--diff]
@@ -35,7 +35,7 @@ repos:
     args: [--diff]
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.8.0
+  rev: 0.8.3
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         name: Packages
         path: dist
     - name: Upload wheel to release
-      uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # 2.9.0
+      uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # 2.11.2
       with:
         repo_token: {{ '${{secrets.GITHUB_TOKEN}}' }}
         file: dist/*.whl

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Setup uv
-      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
       with:
         version: ">=0.7"
     - name: Run Tox
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: 3.x
     - name: Setup uv
-      uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
       with:
         version: ">=0.7"
     - name: Run Tox

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.4
+  rev: v0.12.5
   hooks:
   - id: ruff-check
     args: [--diff]
@@ -35,7 +35,7 @@ repos:
     args: [--diff]
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.8.0
+  rev: 0.8.3
   hooks:
   - id: uv-lock
   - id: uv-sync


### PR DESCRIPTION
## Summary by Sourcery

Update CI and pre-commit dependencies in mapper, tap, and target templates to their latest versions.

Enhancements:
- Upgrade astral-sh/setup-uv GitHub Action to v6.4.3 in test workflows across all templates

CI:
- Bump ruff-pre-commit hook to v0.12.5 and uv-pre-commit hook to v0.8.3 in pre-commit configs
- Update svenstaro/upload-release-action to v2.11.2 in build workflows for mapper, tap, and target templates