### PR TITLE
feat: Added `.env.example` files to tap, target and mapper templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.env.example
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.env.example
@@ -1,0 +1,5 @@
+# {{ cookiecutter.name }} Configuration
+# Copy this file to .env and fill in your actual values
+
+# Example configuration - replace or remove based on your needs
+MAPPER_{{ cookiecutter.mapper_id.upper().replace('-', '_') }}_EXAMPLE_CONFIG=example_value

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.env.example
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.env.example
@@ -1,0 +1,20 @@
+# {{ cookiecutter.source_name }} Configuration
+# Copy this file to .env and fill in your actual values
+
+# Required: Authentication token for the API service
+TAP_{{ cookiecutter.tap_id.upper().replace('-', '_') }}_AUTH_TOKEN=your_auth_token_here
+
+# Required: Project IDs to replicate (comma-separated)
+TAP_{{ cookiecutter.tap_id.upper().replace('-', '_') }}_PROJECT_IDS=project1,project2,project3
+
+# Optional: The earliest record date to sync (ISO format)
+TAP_{{ cookiecutter.tap_id.upper().replace('-', '_') }}_START_DATE=2023-01-01T00:00:00Z
+
+# Optional: API URL (defaults to https://api.mysample.com)
+TAP_{{ cookiecutter.tap_id.upper().replace('-', '_') }}_API_URL=https://api.mysample.com
+
+{%- if cookiecutter.stream_type in ("GraphQL", "REST") %}
+
+# Optional: Custom User-Agent header
+TAP_{{ cookiecutter.tap_id.upper().replace('-', '_') }}_USER_AGENT={{ cookiecutter.tap_id }}/1.0.0
+{%- endif %}

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.env.example
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.env.example
@@ -1,0 +1,16 @@
+# {{ cookiecutter.destination_name }} Configuration
+# Copy this file to .env and fill in your actual values
+
+{%- if cookiecutter.serialization_method == "SQL" %}
+# Required: SQLAlchemy connection string
+TARGET_{{ cookiecutter.target_id.upper().replace('-', '_') }}_SQLALCHEMY_URL=sqlite:///example.db
+{%- else %}
+# Required: Output file path
+TARGET_{{ cookiecutter.target_id.upper().replace('-', '_') }}_FILEPATH=./output/data.jsonl
+
+# Required: File naming scheme
+TARGET_{{ cookiecutter.target_id.upper().replace('-', '_') }}_FILE_NAMING_SCHEME={stream_name}.jsonl
+
+# Required: Authentication token
+TARGET_{{ cookiecutter.target_id.upper().replace('-', '_') }}_AUTH_TOKEN=your_auth_token_here
+{%- endif %}


### PR DESCRIPTION
## Summary by Sourcery

Add .env.example files to the cookiecutter tap, target, and mapper templates

New Features:
- Include .env.example file in the tap template
- Include .env.example file in the target template
- Include .env.example file in the mapper template

<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3189.org.readthedocs.build/en/3189/

<!-- readthedocs-preview meltano-sdk end -->