### PR TITLE
ci: Check types of sample packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,9 @@ jobs:
         - { session: mypy,          python-version: "3.9",  os: "ubuntu-latest" }
         - { session: deps,          python-version: "3.13", os: "ubuntu-latest" }
         - { session: test-lowest,   python-version: "3.9",  os: "ubuntu-latest" }
+        - { session: test-contrib,  python-version: "3.9",  os: "ubuntu-latest" }
         - { session: test-contrib,  python-version: "3.13", os: "ubuntu-latest" }
+        - { session: test-packages, python-version: "3.9",  os: "ubuntu-latest" }
         - { session: test-packages, python-version: "3.13", os: "ubuntu-latest" }
 
     steps:

--- a/noxfile.py
+++ b/noxfile.py
@@ -62,9 +62,15 @@ def _install_env(session: nox.Session) -> dict[str, str]:
 @nox.session(python=[python_versions[0], main_python])
 def mypy(session: nox.Session) -> None:
     """Check types with mypy."""
-    args = session.posargs or ["singer_sdk"]
+    default_locations = [
+        "packages",
+        "samples",
+        "singer_sdk",
+    ]
+    args = session.posargs or default_locations
     session.run_install(
         *UV_SYNC_COMMAND,
+        "--group=packages",
         "--group=typing",
         "--all-extras",
         env=_install_env(session),
@@ -112,7 +118,11 @@ def tests(session: nox.Session) -> None:
     )
 
 
-@nox.session(name="test-external", tags=["test"])
+@nox.session(
+    name="test-external",
+    python=[python_versions[0], main_python],
+    tags=["test"],
+)
 def test_external(session: nox.Session) -> None:
     """Execute pytest tests and compute coverage."""
     session.run_install(
@@ -132,7 +142,11 @@ def test_external(session: nox.Session) -> None:
     )
 
 
-@nox.session(name="test-contrib", tags=["test"])
+@nox.session(
+    name="test-contrib",
+    python=[python_versions[0], main_python],
+    tags=["test"],
+)
 def test_contrib(session: nox.Session) -> None:
     """Execute pytest tests and compute coverage."""
     session.run_install(
@@ -155,7 +169,11 @@ def test_contrib(session: nox.Session) -> None:
     )
 
 
-@nox.session(name="test-packages", tags=["test"])
+@nox.session(
+    name="test-packages",
+    python=[python_versions[0], main_python],
+    tags=["test"],
+)
 def test_packages(session: nox.Session) -> None:
     """Execute pytest tests and compute coverage."""
     session.run_install(

--- a/packages/tap-csv/tap_csv/client.py
+++ b/packages/tap-csv/tap_csv/client.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import csv
+import sys
 import typing as t
 
 from singer_sdk.contrib.filesystem import FileStream
 from singer_sdk.contrib.filesystem.stream import SDC_META_FILEPATH
+
+if sys.version_info < (3, 12):
+    from typing_extensions import override
+else:
+    from typing import override  # noqa: ICN003
 
 if t.TYPE_CHECKING:
     from singer_sdk.helpers.types import Record
@@ -18,11 +24,9 @@ SDC_META_LINE_NUMBER = "_sdc_line_number"
 class CSVStream(FileStream):
     """CSV stream class."""
 
-    @property
-    def primary_keys(self) -> t.Sequence[str]:
-        """Return the primary key fields for records in this stream."""
-        return (SDC_META_FILEPATH, SDC_META_LINE_NUMBER)
+    primary_keys = (SDC_META_FILEPATH, SDC_META_LINE_NUMBER)
 
+    @override
     def get_schema(self, path: str) -> dict[str, t.Any]:
         """Return a schema for the given file."""
         with self.filesystem.open(path, mode="r") as file:
@@ -34,13 +38,25 @@ class CSVStream(FileStream):
                 doublequote=self.config["doublequote"],
                 lineterminator=self.config["lineterminator"],
             )
-            schema = {
-                "type": "object",
-                "properties": {key: {"type": "string"} for key in reader.fieldnames},
-            }
-            schema["properties"][SDC_META_LINE_NUMBER] = {"type": "integer"}
+            if reader.fieldnames is not None:
+                schema: dict[str, t.Any] = {
+                    "type": "object",
+                    "properties": {
+                        key: {"type": "string"} for key in reader.fieldnames
+                    },
+                }
+                schema["properties"][SDC_META_LINE_NUMBER] = {"type": "integer"}
+            else:
+                schema = {
+                    "type": "object",
+                    "properties": {
+                        SDC_META_LINE_NUMBER: {"type": "integer"},
+                    },
+                    "additionalProperties": True,
+                }
             return schema
 
+    @override
     def read_file(self, path: str) -> t.Iterable[Record]:
         """Read the given file and emit records."""
         with self.filesystem.open(path, mode="r") as file:

--- a/packages/tap-dummyjson/pyproject.toml
+++ b/packages/tap-dummyjson/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "requests~=2.32.3",
     "requests-cache~=1.2.1",
     "singer-sdk~=0.47.4",
+    "typing-extensions>=4.5.0; python_version < '3.12'",
 ]
 optional-dependencies.s3 = [
     "s3fs~=2025.5.0",

--- a/packages/tap-dummyjson/tap_dummyjson/client.py
+++ b/packages/tap-dummyjson/tap_dummyjson/client.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import sys
+
 from requests_cache import CachedSession
 from singer_sdk.pagination import BaseOffsetPaginator
 from singer_sdk.streams import RESTStream
 
 from .auth import DummyJSONAuthenticator
+
+if sys.version_info < (3, 12):
+    from typing_extensions import override
+else:
+    from typing import override
 
 PAGE_SIZE = 25
 
@@ -14,13 +21,15 @@ PAGE_SIZE = 25
 class DummyJSONStream(RESTStream):
     """DummyJSON stream class."""
 
-    records_jsonpath: str = ...
+    records_jsonpath: str = "$[*]"
 
     @property
+    @override
     def url_base(self):
         return self.config["api_url"]
 
     @property
+    @override
     def requests_session(self) -> CachedSession:
         return CachedSession(
             ".http_cache",
@@ -29,6 +38,7 @@ class DummyJSONStream(RESTStream):
         )
 
     @property
+    @override
     def authenticator(self):
         return DummyJSONAuthenticator(
             auth_url=f"{self.url_base}/auth/login",
@@ -37,14 +47,17 @@ class DummyJSONStream(RESTStream):
             password=self.config["password"],
         )
 
+    @override
     def get_new_paginator(self):
         return BaseOffsetPaginator(start_value=0, page_size=PAGE_SIZE)
 
+    @override
     def get_url_params(self, context, next_page_token):
         return {
             "skip": next_page_token,
             "limit": PAGE_SIZE,
         }
 
+    @override
     def post_process(self, row, context=None):
         return row

--- a/packages/tap-fake-people/tap_fake_people/tap.py
+++ b/packages/tap-fake-people/tap_fake_people/tap.py
@@ -19,7 +19,7 @@ else:
 if t.TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
-    from singer_sdk.helpers.types import Record
+    from singer_sdk.helpers.types import Context, Record
 
 
 class FakePeopleStream(Stream):
@@ -36,7 +36,7 @@ class FakePeopleStream(Stream):
     ).to_dict()
 
     @override
-    def get_records(self, context: dict | None) -> Iterable[Record]:
+    def get_records(self, context: Context | None) -> Iterable[Record]:
         faker = Faker()
         faker.seed_instance(42)
         for i in range(100):
@@ -54,7 +54,7 @@ class TapFakePeople(Tap):
 
     name = "tap-fake-people"
 
-    @override
+    @override  # type: ignore[misc]
     def write_message(self, message: Message) -> None:
         if message.type == SingerMessageType.STATE:
             return

--- a/packages/tap-gitlab/tap_gitlab/graphql_streams.py
+++ b/packages/tap-gitlab/tap_gitlab/graphql_streams.py
@@ -7,9 +7,15 @@
 from __future__ import annotations
 
 import importlib.resources
+import sys
 
 from singer_sdk.streams import GraphQLStream
 from tap_gitlab import schemas
+
+if sys.version_info < (3, 12):
+    from typing_extensions import override
+else:
+    from typing import override  # noqa: ICN003
 
 SITE_URL = "https://gitlab.com/graphql"
 
@@ -21,6 +27,8 @@ class GitlabGraphQLStream(GraphQLStream):
 
     url_base = SITE_URL
 
+    @property
+    @override
     def http_headers(self) -> dict:
         """Return headers dict to be used for HTTP requests.
 
@@ -53,6 +61,7 @@ class GraphQLProjectsStream(GitlabGraphQLStream):
     schema_filepath = SCHEMAS_DIR / "projects-graphql.json"
 
     @property
+    @override
     def query(self) -> str:
         """Return dynamic GraphQL query."""
         return f"project(fullPath: {self.config['project_id']} {{ name }}"

--- a/packages/tap-hostile/tap_hostile/streams.py
+++ b/packages/tap-hostile/tap_hostile/streams.py
@@ -10,6 +10,9 @@ import typing as t
 from singer_sdk import typing as th
 from singer_sdk.streams import Stream
 
+if t.TYPE_CHECKING:
+    from singer_sdk.helpers.types import Context
+
 if sys.version_info < (3, 12):
     from typing_extensions import override
 else:
@@ -43,7 +46,7 @@ class HostilePropertyNamesStream(Stream):
     @override
     def get_records(
         self,
-        context: dict | None,
+        context: Context | None,
     ) -> t.Iterable[dict | tuple[dict, dict]]:
         return (
             {

--- a/packages/target-parquet/target_parquet/sink.py
+++ b/packages/target-parquet/target_parquet/sink.py
@@ -26,7 +26,9 @@ def json_schema_to_arrow(schema: dict[str, t.Any]) -> pa.Schema:
     return pa.schema(fields)
 
 
-def _json_schema_to_arrow_fields(schema: dict[str, t.Any]) -> pa.StructType:
+def _json_schema_to_arrow_fields(
+    schema: dict[str, t.Any],
+) -> list[pa.Field[pa.DataType]]:
     """Convert a JSON Schema to an Arrow struct.
 
     Args:

--- a/samples/aapl/__main__.py
+++ b/samples/aapl/__main__.py
@@ -7,6 +7,6 @@ $ uv run python samples/aapl
 
 from __future__ import annotations
 
-from aapl import Fundamentals
+from .aapl import Fundamentals
 
 Fundamentals.cli()

--- a/samples/sample_custom_sql_adapter/connector.py
+++ b/samples/sample_custom_sql_adapter/connector.py
@@ -28,4 +28,4 @@ class CustomSQLDialect(DefaultDialect):
 
         NOTE: This is a legacy method that will stop being used by SQLAlchemy at some point.
         """  # noqa: E501
-        return cls.import_dbapi()
+        return cls.import_dbapi()  # type: ignore[no-any-return]

--- a/samples/sample_tap_bigquery/tap_bigquery/__main__.py
+++ b/samples/sample_tap_bigquery/tap_bigquery/__main__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from tap_bigquery.tap import TapBigQuery
+from . import TapBigQuery
 
 TapBigQuery.cli()

--- a/singer_sdk/contrib/filesystem/stream.py
+++ b/singer_sdk/contrib/filesystem/stream.py
@@ -4,12 +4,19 @@ from __future__ import annotations
 
 import abc
 import functools
+import sys
 import typing as t
 
 from singer_sdk import Stream
 from singer_sdk.exceptions import ConfigValidationError
 from singer_sdk.helpers._util import utc_now
 from singer_sdk.streams.core import REPLICATION_INCREMENTAL
+
+if sys.version_info < (3, 12):
+    from typing_extensions import override
+else:
+    from typing import override  # noqa: ICN003
+
 
 if t.TYPE_CHECKING:
     import datetime
@@ -31,6 +38,7 @@ class FileStream(Stream, metaclass=abc.ABCMeta):
         SDC_META_MODIFIED_AT: {"type": ["string", "null"], "format": "date-time"},
     }
 
+    @override
     def __init__(
         self,
         tap: Tap,
@@ -66,6 +74,7 @@ class FileStream(Stream, metaclass=abc.ABCMeta):
         self._partitions = [{SDC_META_FILEPATH: path} for path in self._filepaths]
 
     @property
+    @override
     def partitions(self) -> list[dict[str, t.Any]]:
         """Return the list of partitions for this stream."""
         return self._partitions
@@ -85,10 +94,12 @@ class FileStream(Stream, metaclass=abc.ABCMeta):
         return schema
 
     @functools.cached_property
+    @override
     def schema(self) -> dict[str, t.Any]:
         """Return the schema for the stream."""
         return self._get_full_schema()
 
+    @override
     def get_records(
         self,
         context: Context | None,
@@ -113,7 +124,7 @@ class FileStream(Stream, metaclass=abc.ABCMeta):
 
         mtime: datetime.datetime | None
         try:
-            mtime: datetime.datetime = self.filesystem.modified(path)  # type: ignore[no-redef]
+            mtime = self.filesystem.modified(path)
         except NotImplementedError:  # pragma: no cover
             self.logger.warning("Filesystem does not support modified time")
             mtime = None

--- a/uv.lock
+++ b/uv.lock
@@ -793,7 +793,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -3023,6 +3023,7 @@ dependencies = [
     { name = "requests" },
     { name = "requests-cache" },
     { name = "singer-sdk" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 
 [package.optional-dependencies]
@@ -3042,6 +3043,7 @@ requires-dist = [
     { name = "requests-cache", specifier = "~=1.2.1" },
     { name = "s3fs", marker = "extra == 's3'", specifier = "~=2025.5.0" },
     { name = "singer-sdk", editable = "." },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.5.0" },
 ]
 provides-extras = ["s3"]
 


### PR DESCRIPTION
## Summary by Sourcery

Improve static typing coverage by adding conditional imports of `override`, enhancing type annotations and signatures, and extending CI type checks to sample and package code

Enhancements:
- Import and apply the `override` decorator conditionally from typing or typing_extensions across all relevant modules
- Annotate overridden methods with `@override` and update method signatures to use the `Context` type where applicable
- Simplify primary_keys property definition and refine JSON schema and Arrow field conversion signatures
- Add type ignore comments to suppress type-checking errors in legacy or dynamic-return scenarios

Build:
- Add typing-extensions as a dependency for Python versions below 3.12

CI:
- Expand mypy session to include both packages and samples directories in type checking