### PR TITLE
feat: Update SQL tap and target templates with latest APIs

### DIFF
--- a/cookiecutter/tap-template/hooks/post_gen_project.py
+++ b/cookiecutter/tap-template/hooks/post_gen_project.py
@@ -15,6 +15,19 @@ if __name__ == "__main__":
     for client_py in PACKAGE_PATH.rglob("*-client.py"):
         client_py.unlink()
 
+    # Select appropriate tap.py based on stream type
+    tap_target = PACKAGE_PATH / "tap.py"
+    if "{{ cookiecutter.stream_type }}" == "SQL":
+        sql_tap_py = PACKAGE_PATH / "sql-tap.py"
+        sql_tap_py.rename(tap_target)
+    else:
+        non_sql_tap_py = PACKAGE_PATH / "non-sql-tap.py"
+        non_sql_tap_py.rename(tap_target)
+
+    # Clean up remaining tap template files
+    for tap_py in PACKAGE_PATH.rglob("*-tap.py"):
+        tap_py.unlink()
+
     if "{{ cookiecutter.stream_type }}" != "REST":
         shutil.rmtree(PACKAGE_PATH.joinpath("schemas"), ignore_errors=True)
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/non-sql-tap.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/non-sql-tap.py
@@ -2,27 +2,17 @@
 
 from __future__ import annotations
 
-from singer_sdk import {{ 'SQL' if cookiecutter.stream_type == 'SQL' else '' }}Tap
+from singer_sdk import Tap
 from singer_sdk import typing as th  # JSON schema typing helpers
-
-{%- if cookiecutter.stream_type == "SQL" %}
-
-from {{ cookiecutter.library_name }}.client import {{ cookiecutter.source_name }}Stream
-{%- else %}
 
 # TODO: Import your custom stream types here:
 from {{ cookiecutter.library_name }} import streams
-{%- endif %}
 
 
-class Tap{{ cookiecutter.source_name }}({{ 'SQL' if cookiecutter.stream_type == 'SQL' else '' }}Tap):
+class Tap{{ cookiecutter.source_name }}(Tap):
     """{{ cookiecutter.source_name }} tap class."""
 
     name = "{{ cookiecutter.tap_id }}"
-
-    {%- if cookiecutter.stream_type == "SQL" %}
-    default_stream_class = {{ cookiecutter.source_name }}Stream
-    {%- endif %}
 
     # TODO: Update this section with the actual config values you expect:
     config_jsonschema = th.PropertiesList(
@@ -64,7 +54,6 @@ class Tap{{ cookiecutter.source_name }}({{ 'SQL' if cookiecutter.stream_type == 
         ),
         {%- endif %}
     ).to_dict()
-{%- if cookiecutter.stream_type in ("GraphQL", "REST", "Other") %}
 
     def discover_streams(self) -> list[streams.{{ cookiecutter.source_name }}Stream]:
         """Return a list of discovered streams.
@@ -76,7 +65,6 @@ class Tap{{ cookiecutter.source_name }}({{ 'SQL' if cookiecutter.stream_type == 
             streams.GroupsStream(self),
             streams.UsersStream(self),
         ]
-{%- endif %}
 
 
 if __name__ == "__main__":

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
@@ -5,20 +5,100 @@ This includes {{ cookiecutter.source_name }}Stream and {{ cookiecutter.source_na
 
 from __future__ import annotations
 
+import functools
 import typing as t
 
-import sqlalchemy  # noqa: TC002
+import sqlalchemy
 from singer_sdk import SQLConnector, SQLStream
+from singer_sdk.connectors.sql import SQLToJSONSchema
+from singer_sdk.helpers._typing import TypeConformanceLevel
 
 if t.TYPE_CHECKING:
     from singer_sdk.helpers.types import Context
+    from sqlalchemy.engine import Engine
+    from sqlalchemy.engine.reflection import Inspector
+
+
+class {{ cookiecutter.source_name }}SQLToJSONSchema(SQLToJSONSchema):
+    """Custom SQL to JSON Schema conversion for {{ cookiecutter.source_name }}.
+
+    Developers should override this class to customize how SQL types are converted
+    to JSON Schema types. This is particularly useful for databases with custom
+    or non-standard SQL types.
+    """
+
+    def __init__(self, *, custom_config_option: bool = False, **kwargs):
+        """Initialize the SQL to JSON Schema converter.
+
+        Args:
+            custom_config_option: Example custom configuration option.
+            **kwargs: Additional keyword arguments passed to parent class.
+        """
+        super().__init__(**kwargs)
+        self.custom_config_option = custom_config_option
+
+    @classmethod
+    def from_config(cls, config: dict) -> {{ cookiecutter.source_name }}SQLToJSONSchema:
+        """Instantiate the SQL to JSON Schema converter from a config dictionary.
+
+        Developers should override this method to pass custom configuration options
+        from the tap's config to the converter.
+
+        Args:
+            config: The tap's configuration dictionary.
+
+        Returns:
+            An instance of the SQL to JSON Schema converter.
+        """
+        return cls(
+            custom_config_option=config.get("custom_config_option", False),
+        )
+
+    @functools.singledispatchmethod
+    def to_jsonschema(self, column_type: t.Any) -> dict:
+        """Customize the JSON Schema for {{ cookiecutter.source_name }} types.
+
+        Developers should not need to override this base method. Instead, register
+        specific type handlers using the @to_jsonschema.register decorator for
+        specific SQLAlchemy column types.
+
+        Args:
+            column_type: The SQLAlchemy column type to convert.
+
+        Returns:
+            A JSON Schema type definition.
+        """
+        return super().to_jsonschema(column_type)
+
+    # Example: Custom type conversion for database-specific types
+    # @to_jsonschema.register
+    # def custom_type_to_jsonschema(self, column_type: CustomSQLType) -> dict:
+    #     """Override the default mapping for CustomSQLType columns.
+    #
+    #     Developers may add custom type mappings by registering handlers
+    #     for specific SQLAlchemy column types.
+    #     """
+    #     if self.custom_config_option:
+    #         return {"type": ["string", "null"]}
+    #     return {"type": ["object", "null"], "additionalProperties": True}
 
 
 class {{ cookiecutter.source_name }}Connector(SQLConnector):
-    """Connects to the {{ cookiecutter.source_name }} SQL source."""
+    """Connects to the {{ cookiecutter.source_name }} SQL source.
+
+    This class handles all SQL connection logic and DDL operations.
+    Developers may override methods to customize connection behavior,
+    schema discovery, and type conversion.
+    """
+
+    # Custom SQL to JSON Schema converter
+    sql_to_jsonschema_converter = {{ cookiecutter.source_name }}SQLToJSONSchema
 
     def get_sqlalchemy_url(self, config: dict) -> str:
         """Concatenate a SQLAlchemy URL for use in connecting to the source.
+
+        Developers must implement this method to return a valid SQLAlchemy
+        connection string for your specific database.
 
         Args:
             config: A dict with connection parameters
@@ -35,6 +115,24 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
             f"s3_staging_dir={config['s3_staging_dir']}"
         )
 
+    def get_schema_names(self, engine: Engine, inspected: Inspector) -> list[str]:
+        """Return a list of schema names in DB, or overrides with user-provided values.
+
+        Developers may override this method to customize schema discovery,
+        such as filtering out system schemas or applying user-defined filters.
+
+        Args:
+            engine: SQLAlchemy engine
+            inspected: SQLAlchemy inspector instance for engine
+
+        Returns:
+            List of schema names
+        """
+        # Example: Filter schemas based on configuration
+        if "filter_schemas" in self.config and len(self.config["filter_schemas"]) != 0:
+            return self.config["filter_schemas"]
+        return super().get_schema_names(engine, inspected)
+
     def to_jsonschema_type(
         self,
         from_type: str
@@ -44,7 +142,8 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
         """Returns a JSON Schema equivalent for the given SQL type.
 
         Developers may optionally add custom logic before calling the default
-        implementation inherited from the base class.
+        implementation inherited from the base class. For more complex type
+        conversion needs, consider overriding the sql_to_jsonschema_converter class.
 
         Args:
             from_type: The SQL type as a string or as a TypeEngine. If a TypeEngine is
@@ -73,17 +172,121 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
         # You may delete this method if overrides are not needed.
         return super().to_sql_type(jsonschema_type)
 
+    # Uncomment and customize these methods as needed for your specific database:
+
+    # def get_object_names(
+    #     self, engine: Engine, inspected: Inspector, schema_name: str
+    # ) -> list[tuple[str, bool]]:
+    #     """Return a list of syncable objects in the given schema.
+    #
+    #     Developers may override this method to customize which database objects
+    #     (tables, views) are discoverable by the tap.
+    #
+    #     Args:
+    #         engine: SQLAlchemy engine
+    #         inspected: SQLAlchemy inspector instance
+    #         schema_name: Schema name to inspect
+    #
+    #     Returns:
+    #         List of tuples: (object_name, is_view)
+    #     """
+    #     return super().get_object_names(engine, inspected, schema_name)
+
+    # def prepare_column(
+    #     self, full_table_name: str, column_name: str, sql_type: sqlalchemy.types.TypeEngine
+    # ) -> sqlalchemy.Column:
+    #     """Prepare a column object for table creation or modification.
+    #
+    #     Developers may override this method to customize column definitions,
+    #     such as adding database-specific constraints or modifiers.
+    #     """
+    #     return super().prepare_column(full_table_name, column_name, sql_type)
+
+    # def create_engine(self) -> sqlalchemy.engine.Engine:
+    #     """Create a SQLAlchemy engine for database connections.
+    #
+    #     Developers may override this method to customize engine creation,
+    #     such as adding connection pooling, custom dialects, or connection arguments.
+    #     """
+    #     return super().create_engine()
+
+    # def open_connection(self) -> sqlalchemy.engine.Connection:
+    #     """Open a new database connection.
+    #
+    #     Developers may override this method to customize connection behavior,
+    #     such as setting session variables or connection-specific configurations.
+    #     """
+    #     return super().open_connection()
+
 
 class {{ cookiecutter.source_name }}Stream(SQLStream):
-    """Stream class for {{ cookiecutter.source_name }} streams."""
+    """Stream class for {{ cookiecutter.source_name }} streams.
+
+    This class handles stream-specific logic including record retrieval,
+    query filtering, and data processing. Developers may override methods
+    to customize stream behavior.
+    """
 
     connector_class = {{ cookiecutter.source_name }}Connector
+
+    # Query and data processing configuration
+    supports_nulls_first = True  # Whether the database supports NULLS FIRST/LAST
+
+    # Type conformance level - controls how strictly data types are enforced
+    # ROOT_ONLY: Only enforce types at the root level (useful for JSON/JSONB columns)
+    # RECURSIVE: Recursively enforce types throughout nested structures
+    TYPE_CONFORMANCE_LEVEL = TypeConformanceLevel.RECURSIVE
+
+    def max_record_count(self) -> int | None:
+        """Return the maximum number of records to fetch in a single query.
+
+        Developers may override this method to implement query-level pagination
+        or limit large result sets to prevent memory issues.
+
+        Returns:
+            Maximum number of records per query, or None for no limit.
+        """
+        # Example: Read from configuration
+        return self.config.get("max_record_count")
+
+    def apply_query_filters(
+        self,
+        query: sqlalchemy.sql.Select,
+        table: sqlalchemy.Table,
+        *,
+        context: Context | None = None,
+    ) -> sqlalchemy.sql.Select:
+        """Apply custom query filters to the SELECT query.
+
+        Developers may override this method to add custom WHERE clauses,
+        JOIN operations, or other query modifications based on configuration
+        or stream-specific requirements.
+
+        Args:
+            query: The base SELECT query
+            table: The SQLAlchemy table object
+            context: Stream partition or context dictionary
+
+        Returns:
+            Modified SELECT query
+        """
+        query = super().apply_query_filters(query, table, context=context)
+
+        # Example: Add custom WHERE clauses from configuration
+        stream_options = self.config.get("stream_options", {}).get(self.name, {})
+        if clauses := stream_options.get("custom_where_clauses"):
+            for clause in clauses:
+                query = query.where(sqlalchemy.text(clause.strip()))
+
+        return query
 
     def get_records(self, partition: Context | None) -> t.Iterable[dict[str, t.Any]]:
         """Return a generator of record-type dictionary objects.
 
-        Developers may optionally add custom logic before calling the default
-        implementation inherited from the base class.
+        Developers may override this method to implement custom record retrieval
+        logic, such as batch processing, result set optimization, or custom
+        data transformations. This is particularly useful when the source database
+        provides batch-optimized record retrieval mechanisms.
 
         Args:
             partition: If provided, will read specifically from this data slice.
@@ -91,8 +294,93 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
         Yields:
             One dict per record.
         """
-        # Optionally, add custom logic instead of calling the super().
-        # This is helpful if the source database provides batch-optimized record
-        # retrieval.
-        # If no overrides or optimizations are needed, you may delete this method.
-        yield from super().get_records(partition)
+        # Example implementation with query optimization:
+        # 1. Get selected columns to avoid SELECT *
+        selected_column_names = self.get_selected_schema()["properties"].keys()
+        table = self.connector.get_table(
+            full_table_name=self.fully_qualified_name,
+            column_names=selected_column_names,
+        )
+        query = table.select()
+
+        # 2. Apply replication key ordering and filtering
+        if self.replication_key:
+            replication_key_col = table.columns[self.replication_key]
+            query = query.order_by(replication_key_col)
+
+            start_val = self.get_starting_replication_key_value(partition)
+            if start_val:
+                query = query.where(replication_key_col >= start_val)
+
+        # 3. Apply record limit if configured
+        max_records = self.max_record_count()
+        if max_records:
+            query = query.limit(max_records)
+
+        # 4. Execute query and yield records
+        for record in self.connector.execute(query).mappings():
+            yield dict(record)
+
+        # Alternative: Use the default implementation
+        # yield from super().get_records(partition)
+
+    # Uncomment and customize these methods as needed for your specific database:
+
+    # def get_starting_replication_key_value(
+    #     self, context: Context | None
+    # ) -> t.Any | None:
+    #     """Get starting replication key value for incremental sync.
+    #
+    #     Developers may override this method to customize how the starting
+    #     replication key value is determined, such as converting timestamps
+    #     to native database types.
+    #     """
+    #     return super().get_starting_replication_key_value(context)
+
+    # def post_process(self, row: dict, context: Context | None = None) -> dict | None:
+    #     """Process a single record after it's been retrieved from the database.
+    #
+    #     Developers may override this method to apply custom transformations,
+    #     data validation, or filtering to individual records before they are
+    #     emitted to the output stream.
+    #
+    #     Args:
+    #         row: Individual record dictionary
+    #         context: Stream partition or context dictionary
+    #
+    #     Returns:
+    #         Processed record dictionary, or None to skip the record
+    #     """
+    #     return row
+
+    # def validate_config(self) -> None:
+    #     """Validate tap configuration.
+    #
+    #     Developers may override this method to add custom configuration
+    #     validation logic specific to their database requirements.
+    #     """
+    #     super().validate_config()
+    #
+    #     # Example: Validate required custom configuration
+    #     # if not self.config.get("custom_required_field"):
+    #     #     raise ValueError("custom_required_field is required")
+
+    # @property
+    # def is_sorted(self) -> bool:
+    #     """Indicate whether the stream is sorted by replication key.
+    #
+    #     Developers may override this property to indicate whether their
+    #     query results are naturally sorted by the replication key, which
+    #     can enable more efficient incremental sync processing.
+    #     """
+    #     return bool(self.replication_key)
+
+    # def _increment_stream_state(
+    #     self, latest_record: dict, *, context: Context | None = None
+    # ) -> None:
+    #     """Update the stream state with the latest record's replication key value.
+    #
+    #     Developers typically should not need to override this method unless
+    #     implementing custom state management logic (e.g., for log-based replication).
+    #     """
+    #     return super()._increment_stream_state(latest_record, context=context)

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
@@ -318,6 +318,7 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
             query = query.limit(max_records)
 
         # 4. Execute query and yield records
+        # NOTE: Using private _connect() method. If connector API changes, this may break.
         with self.connector._connect() as connection:
             for record in connection.execute(query).mappings():
                 yield dict(record)

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
@@ -128,9 +128,6 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
         Returns:
             List of schema names
         """
-        # Example: Filter schemas based on configuration
-        if "filter_schemas" in self.config and len(self.config["filter_schemas"]) != 0:
-            return self.config["filter_schemas"]
         return super().get_schema_names(engine, inspected)
 
     def to_jsonschema_type(

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
@@ -269,11 +269,8 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
         """
         query = super().apply_query_filters(query, table, context=context)
 
-        # Example: Add custom WHERE clauses from configuration
-        stream_options = self.config.get("stream_options", {}).get(self.name, {})
-        if clauses := stream_options.get("custom_where_clauses"):
-            for clause in clauses:
-                query = query.where(sqlalchemy.text(clause.strip()))
+        # Add custom WHERE clauses from configuration, etc.
+        # query = query.where(...)
 
         return query
 
@@ -315,7 +312,6 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
             query = query.limit(max_records)
 
         # 4. Execute query and yield records
-        # NOTE: Using private _connect() method. If connector API changes, this may break.
         with self.connector._connect() as connection:
             for record in connection.execute(query).mappings():
                 yield dict(record)

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
@@ -234,18 +234,6 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
     # RECURSIVE: Recursively enforce types throughout nested structures
     TYPE_CONFORMANCE_LEVEL = TypeConformanceLevel.RECURSIVE
 
-    def max_record_count(self) -> int | None:
-        """Return the maximum number of records to fetch in a single query.
-
-        Developers may override this method to implement query-level pagination
-        or limit large result sets to prevent memory issues.
-
-        Returns:
-            Maximum number of records per query, or None for no limit.
-        """
-        # Example: Read from configuration
-        return self.config.get("max_record_count")
-
     def apply_query_filters(
         self,
         query: sqlalchemy.sql.Select,
@@ -306,12 +294,7 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
             if start_val:
                 query = query.where(replication_key_col >= start_val)
 
-        # 3. Apply record limit if configured
-        max_records = self.max_record_count()
-        if max_records:
-            query = query.limit(max_records)
-
-        # 4. Execute query and yield records
+        # 3. Execute query and yield records
         with self.connector._connect() as connection:
             for record in connection.execute(query).mappings():
                 yield dict(record)

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
@@ -318,8 +318,9 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
             query = query.limit(max_records)
 
         # 4. Execute query and yield records
-        for record in self.connector.execute(query).mappings():
-            yield dict(record)
+        with self.connector._connect() as connection:
+            for record in connection.execute(query).mappings():
+                yield dict(record)
 
         # Alternative: Use the default implementation
         # yield from super().get_records(partition)

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-tap.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-tap.py
@@ -1,0 +1,23 @@
+"""{{ cookiecutter.source_name }} tap class."""
+
+from __future__ import annotations
+
+from singer_sdk import SQLTap
+from singer_sdk import typing as th  # JSON schema typing helpers
+
+from {{ cookiecutter.library_name }}.client import {{ cookiecutter.source_name }}Stream
+
+
+class Tap{{ cookiecutter.source_name }}(SQLTap):
+    """{{ cookiecutter.source_name }} tap class."""
+
+    name = "{{ cookiecutter.tap_id }}"
+
+    default_stream_class = {{ cookiecutter.source_name }}Stream
+
+    # TODO: Update this section with the actual config values you expect:
+    config_jsonschema = th.PropertiesList().to_dict()
+
+
+if __name__ == "__main__":
+    Tap{{ cookiecutter.source_name }}.cli()

--- a/cookiecutter/target-template/hooks/post_gen_project.py
+++ b/cookiecutter/target-template/hooks/post_gen_project.py
@@ -15,3 +15,24 @@ if __name__ == "__main__":
 
     if "{{ cookiecutter.ide }}" != "VSCode":
         shutil.rmtree(".vscode", ignore_errors=True)
+
+    # Choose the appropriate sinks file based on serialization method
+    serialization_method = "{{ cookiecutter.serialization_method }}"
+
+    if serialization_method == "Per record":
+        source_file = BASE_PATH / "sinks_record.py"
+    elif serialization_method == "Per batch":
+        source_file = BASE_PATH / "sinks_batch.py"
+    elif serialization_method == "SQL":
+        source_file = BASE_PATH / "sinks_sql.py"
+    else:
+        raise ValueError(f"Unknown serialization method: {serialization_method}")
+
+    # Copy the appropriate sinks file to sinks.py
+    target_file = BASE_PATH / "sinks.py"
+    shutil.copy2(source_file, target_file)
+
+    # Clean up the unused sink files
+    (BASE_PATH / "sinks_record.py").unlink(missing_ok=True)
+    (BASE_PATH / "sinks_batch.py").unlink(missing_ok=True)
+    (BASE_PATH / "sinks_sql.py").unlink(missing_ok=True)

--- a/cookiecutter/target-template/hooks/post_gen_project.py
+++ b/cookiecutter/target-template/hooks/post_gen_project.py
@@ -38,6 +38,5 @@ if __name__ == "__main__":
     shutil.copy2(source_file, target_file)
 
     # Clean up the unused sink files
-    (BASE_PATH / "sinks_record.py").unlink(missing_ok=True)
-    (BASE_PATH / "sinks_batch.py").unlink(missing_ok=True)
-    (BASE_PATH / "sinks_sql.py").unlink(missing_ok=True)
+    for template in ["sinks_record.py", "sinks_batch.py", "sinks_sql.py"]:
+        (BASE_PATH / template).unlink(missing_ok=True)

--- a/cookiecutter/target-template/hooks/post_gen_project.py
+++ b/cookiecutter/target-template/hooks/post_gen_project.py
@@ -26,7 +26,12 @@ if __name__ == "__main__":
     elif serialization_method == "SQL":
         source_file = BASE_PATH / "sinks_sql.py"
     else:
-        raise ValueError(f"Unknown serialization method: {serialization_method}")
+        valid_methods = ["Per record", "Per batch", "SQL"]
+        msg = (
+            f"Unknown serialization method: {serialization_method}. "
+            f"Valid methods are: {', '.join(valid_methods)}"
+        )
+        raise ValueError(msg)
 
     # Copy the appropriate sinks file to sinks.py
     target_file = BASE_PATH / "sinks.py"

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -35,7 +35,10 @@ dependencies = [
     {%- else %}
     "singer-sdk~=0.47.4",
     {%- endif %}
-    {%- if cookiecutter.serialization_method != "SQL" %}
+    {%- if cookiecutter.serialization_method == "SQL" %}
+    "sqlalchemy~=2.0",
+    "typing-extensions>=4.5.0; python_version < '3.13'",
+    {%- else %}
     "requests~=2.32.3",
     {%- endif %}
 ]

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import typing as t
+
 {%- set
     sinkclass_mapping = {
         "Per batch": "BatchSink",
@@ -14,6 +16,7 @@ from __future__ import annotations
 
 {%- if sinkclass == "SQLSink" %}
 
+import sqlalchemy
 from singer_sdk.connectors import SQLConnector
 from singer_sdk.sinks import {{ sinkclass }}
 {%- else %}
@@ -110,4 +113,270 @@ class {{ cookiecutter.destination_name }}Sink({{ sinkclass }}):
     {%- elif sinkclass == "SQLSink" -%}
 
     connector_class = {{ cookiecutter.destination_name }}Connector
+
+    def setup(self) -> None:
+        """Set up Sink.
+
+        This method is called on Sink creation, and creates the required Schema and
+        Table entities in the target database. Developers may override this method
+        to customize schema and table preparation logic.
+        """
+        # Prepare schema if specified
+        if self.schema_name:
+            self.connector.prepare_schema(self.schema_name)
+
+        # Prepare table with schema validation
+        with self.connector._connect() as connection, connection.begin():
+            self.connector.prepare_table(
+                full_table_name=self.full_table_name,
+                schema=self.schema,
+                primary_keys=self.key_properties,
+                connection=connection,
+                as_temp_table=False,
+            )
+
+    def process_batch(self, context: dict) -> None:
+        """Process a batch with the given batch context.
+
+        Writes a batch to the SQL target. Developers may override this method
+        in order to provide a more efficient upload/upsert process.
+
+        The default implementation uses a temporary table approach for optimal
+        performance with large datasets and proper transaction handling.
+
+        Args:
+            context: Stream partition or context dictionary.
+        """
+        # Use one connection so we do this all in a single transaction
+        with self.connector._connect() as connection, connection.begin():
+            # Check structure of target table
+            table = self.connector.prepare_table(
+                full_table_name=self.full_table_name,
+                schema=self.schema,
+                primary_keys=self.key_properties,
+                as_temp_table=False,
+                connection=connection,
+            )
+
+            # Create a temporary table for staging records
+            temp_table_name = self.generate_temp_table_name()
+            temp_table = self.connector.copy_table_structure(
+                full_table_name=temp_table_name,
+                from_table=table,
+                as_temp_table=True,
+                connection=connection,
+            )
+
+            try:
+                # Insert records into temporary table
+                self.bulk_insert_records(
+                    table=temp_table,
+                    schema=self.schema,
+                    primary_keys=self.key_properties,
+                    records=context["records"],
+                    connection=connection,
+                )
+
+                # Merge data from temporary table to target table
+                self.upsert(
+                    from_table=temp_table,
+                    to_table=table,
+                    schema=self.schema,
+                    join_keys=self.key_properties,
+                    connection=connection,
+                )
+            finally:
+                # Always clean up temporary table
+                self.connector.drop_table(table=temp_table, connection=connection)
+
+    def generate_temp_table_name(self) -> str:
+        """Generate a unique temporary table name.
+
+        Developers may override this method to customize temporary table naming.
+        Default implementation creates a UUID-based name to avoid collisions.
+
+        Returns:
+            A unique temporary table name.
+        """
+        import uuid
+
+        return f"temp_{str(uuid.uuid4()).replace('-', '_')}"
+
+    def bulk_insert_records(
+        self,
+        table: sqlalchemy.Table,
+        schema: dict,
+        records: t.Iterable[dict[str, t.Any]],
+        primary_keys: t.Sequence[str],
+        connection: sqlalchemy.engine.Connection,
+    ) -> int | None:
+        """Bulk insert records to an existing destination table.
+
+        Developers may override this method to provide faster, native bulk uploads
+        specific to their target database. The default implementation uses
+        SQLAlchemy's bulk insert operations.
+
+        Args:
+            table: The target table object.
+            schema: The JSON schema for the new table, to be used when inferring column
+                names.
+            records: The input records.
+            primary_keys: The primary key columns for the table.
+            connection: The database connection.
+
+        Returns:
+            Number of records inserted, or None if not detectable.
+        """
+        import sqlalchemy as sa
+
+        columns = self.column_representation(schema)
+        data = []
+
+        # Determine if we need to handle duplicates
+        append_only = not primary_keys
+        unique_records = {}
+
+        for record in records:
+            insert_record = {column.name: record.get(column.name) for column in columns}
+
+            if append_only:
+                data.append(insert_record)
+            else:
+                # Keep only the latest record per primary key
+                primary_key_tuple = tuple(record[key] for key in primary_keys)
+                unique_records[primary_key_tuple] = insert_record
+
+        if not append_only:
+            data = list(unique_records.values())
+
+        if data:
+            insert_stmt = sa.insert(table)
+            connection.execute(insert_stmt, data)
+            return len(data)
+
+        return 0
+
+    def upsert(
+        self,
+        from_table: sqlalchemy.Table,
+        to_table: sqlalchemy.Table,
+        schema: dict,
+        join_keys: t.Sequence[str],
+        connection: sqlalchemy.engine.Connection,
+    ) -> int | None:
+        """Merge upsert data from one table to another.
+
+        Developers may override this method to provide database-specific
+        MERGE or UPSERT operations for better performance. The default
+        implementation uses separate INSERT and UPDATE operations.
+
+        Args:
+            from_table: The source table.
+            to_table: The destination table.
+            schema: Singer Schema message.
+            join_keys: The merge upsert keys, or `None` to append.
+            connection: The database connection.
+
+        Returns:
+            The number of records copied, if detectable, or `None` if the API does not
+            report number of records affected/inserted.
+        """
+        import sqlalchemy as sa
+
+        if not join_keys:
+            # Append-only mode: simple insert
+            select_stmt = sa.select(from_table.columns).select_from(from_table)
+            insert_stmt = to_table.insert().from_select(
+                names=from_table.columns, select=select_stmt
+            )
+            connection.execute(insert_stmt)
+        else:
+            # Upsert mode: insert new records, update existing ones
+
+            # 1. Insert new records (those not matching existing primary keys)
+            join_predicates = []
+            for key in join_keys:
+                from_table_key = from_table.columns[key]
+                to_table_key = to_table.columns[key]
+                join_predicates.append(from_table_key == to_table_key)
+
+            join_condition = sa.and_(*join_predicates)
+
+            where_predicates = []
+            for key in join_keys:
+                to_table_key = to_table.columns[key]
+                where_predicates.append(to_table_key.is_(None))
+            where_condition = sa.and_(*where_predicates)
+
+            select_stmt = (
+                sa.select(from_table.columns)
+                .select_from(from_table.outerjoin(to_table, join_condition))
+                .where(where_condition)
+            )
+            insert_stmt = sa.insert(to_table).from_select(
+                names=from_table.columns, select=select_stmt
+            )
+            connection.execute(insert_stmt)
+
+            # 2. Update existing records
+            update_columns = {}
+            for column_name in schema["properties"]:
+                from_table_column = from_table.columns[column_name]
+                to_table_column = to_table.columns[column_name]
+                update_columns[to_table_column] = from_table_column
+
+            update_stmt = (
+                sa.update(to_table).where(join_condition).values(update_columns)
+            )
+            connection.execute(update_stmt)
+
+        return None
+
+    def column_representation(
+        self,
+        schema: dict,
+    ) -> list[sqlalchemy.Column]:
+        """Return a sqlalchemy table representation for the current schema.
+
+        Developers should not need to override this method unless they need
+        custom column definitions or type mappings.
+
+        Args:
+            schema: The JSON schema for the table.
+
+        Returns:
+            List of SQLAlchemy Column objects.
+        """
+        import sqlalchemy as sa
+
+        columns = [
+            sa.Column(
+                property_name,
+                self.connector.to_sql_type(property_jsonschema),
+            )
+            for property_name, property_jsonschema in schema["properties"].items()
+        ]
+        return columns
+
+    @property
+    def schema_name(self) -> str | None:
+        """Return the schema name or `None` if using names with no schema part.
+
+        Developers may override this method to customize schema name resolution
+        based on configuration or stream naming conventions.
+
+        Returns:
+            The target schema name.
+        """
+        # Look for a default_target_schema in the configuration file
+        default_target_schema = self.config.get("default_target_schema")
+        if default_target_schema:
+            return default_target_schema
+
+        # Parse schema from stream name if in <schema>-<table> format
+        parts = self.stream_name.split("-")
+        if len(parts) in {2, 3}:
+            return parts[-2]
+
+        return None
     {%- endif %}

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_batch.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_batch.py
@@ -1,0 +1,51 @@
+"""{{ cookiecutter.destination_name }} target sink class, which handles writing streams."""
+
+from __future__ import annotations
+
+from singer_sdk.sinks import BatchSink
+
+
+class {{ cookiecutter.destination_name }}Sink(BatchSink):
+    """{{ cookiecutter.destination_name }} target sink class."""
+
+    max_size = 10000  # Max records to write in one batch
+
+    def start_batch(self, context: dict) -> None:
+        """Start a batch.
+
+        Developers may optionally add additional markers to the `context` dict,
+        which is unique to this batch.
+
+        Args:
+            context: Stream partition or context dictionary.
+        """
+        # Sample:
+        # ------
+        # batch_key = context["batch_id"]
+        # context["file_path"] = f"{batch_key}.csv"
+
+    def process_record(self, record: dict, context: dict) -> None:
+        """Process the record.
+
+        Developers may optionally read or write additional markers within the
+        passed `context` dict from the current batch.
+
+        Args:
+            record: Individual record in the stream.
+            context: Stream partition or context dictionary.
+        """
+        # Sample:
+        # ------
+        # with open(context["file_path"], "a") as csvfile:
+        #     csvfile.write(record)
+
+    def process_batch(self, context: dict) -> None:
+        """Write out any prepped records and return once fully written.
+
+        Args:
+            context: Stream partition or context dictionary.
+        """
+        # Sample:
+        # ------
+        # client.upload(context["file_path"])  # Upload file
+        # Path(context["file_path"]).unlink()  # Delete local copy

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_record.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_record.py
@@ -1,0 +1,20 @@
+"""{{ cookiecutter.destination_name }} target sink class, which handles writing streams."""
+
+from __future__ import annotations
+
+from singer_sdk.sinks import RecordSink
+
+
+class {{ cookiecutter.destination_name }}Sink(RecordSink):
+    """{{ cookiecutter.destination_name }} target sink class."""
+
+    def process_record(self, record: dict, context: dict) -> None:
+        """Process the record.
+
+        Args:
+            record: Individual record in the stream.
+            context: Stream partition or context dictionary.
+        """
+        # Sample:
+        # ------
+        # client.write(record)  # noqa: ERA001

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_sql.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_sql.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
-import typing as t
+import sys
+from typing import TYPE_CHECKING, Any
 
-import sqlalchemy
 from singer_sdk.connectors import SQLConnector
 from singer_sdk.connectors.sql import FullyQualifiedName
 from singer_sdk.sinks import SQLSink
+
+if sys.version_info < (3, 12):
+    from typing_extensions import override
+else:
+    from typing import override
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class {{ cookiecutter.destination_name }}Connector(SQLConnector):
@@ -23,6 +31,7 @@ class {{ cookiecutter.destination_name }}Connector(SQLConnector):
     allow_overwrite: bool = False  # Whether overwrite load method is supported.
     allow_temp_tables: bool = True  # Whether temp tables are supported.
 
+    @override
     def get_sqlalchemy_url(self, config: dict) -> str:
         """Generates a SQLAlchemy URL for {{ cookiecutter.destination_name }}.
 
@@ -40,295 +49,34 @@ class {{ cookiecutter.destination_name }}Sink(SQLSink):
     def setup(self) -> None:
         """Set up Sink.
 
-        This method is called on Sink creation, and creates the required Schema and
-        Table entities in the target database. Developers may override this method
-        to customize schema and table preparation logic.
+        Creates the required Schema and Table entities in the target database.
         """
-        # Prepare schema if specified
-        if self.schema_name:
-            self.connector.prepare_schema(self.schema_name)
+        super().setup()
 
-        # Prepare table with schema validation
-        with self.connector._connect() as connection, connection.begin():
-            self.connector.prepare_table(
-                full_table_name=self.full_table_name,
-                schema=self.schema,
-                primary_keys=self.key_properties,
-                connection=connection,
-                as_temp_table=False,
-            )
-
+    @override
     def process_batch(self, context: dict) -> None:
         """Process a batch with the given batch context.
 
         Writes a batch to the SQL target. Developers may override this method
         in order to provide a more efficient upload/upsert process.
-
-        The default implementation uses a temporary table approach for optimal
-        performance with large datasets and proper transaction handling.
-
-        Args:
-            context: Stream partition or context dictionary.
         """
-        # Use one connection so we do this all in a single transaction
-        with self.connector._connect() as connection, connection.begin():
-            # Check structure of target table
-            table = self.connector.prepare_table(
-                full_table_name=self.full_table_name,
-                schema=self.schema,
-                primary_keys=self.key_properties,
-                as_temp_table=False,
-                connection=connection,
-            )
+        super().process_batch(context)
 
-            # Create a temporary table for staging records
-            temp_table_name = self.generate_temp_table_name()
-            temp_table = self.connector.copy_table_structure(
-                full_table_name=temp_table_name,
-                from_table=table,
-                as_temp_table=True,
-                connection=connection,
-            )
-
-            try:
-                # Insert records into temporary table
-                self.bulk_insert_records_to_table(
-                    table=temp_table,
-                    schema=self.schema,
-                    primary_keys=self.key_properties,
-                    records=context["records"],
-                    connection=connection,
-                )
-
-                # Merge data from temporary table to target table
-                self.upsert(
-                    from_table=temp_table,
-                    to_table=table,
-                    schema=self.schema,
-                    join_keys=self.key_properties,
-                    connection=connection,
-                )
-            finally:
-                # Always clean up temporary table
-                self.connector.drop_table(table=temp_table, connection=connection)
-
-    def generate_temp_table_name(self) -> str:
-        """Generate a unique temporary table name.
-
-        Developers may override this method to customize temporary table naming.
-        Default implementation creates a UUID-based name to avoid collisions.
-
-        Returns:
-            A unique temporary table name.
-        """
-        import uuid
-
-        return f"temp_{str(uuid.uuid4()).replace('-', '_')}"
-
+    @override
     def bulk_insert_records(
         self,
         full_table_name: str | FullyQualifiedName,
         schema: dict,
-        records: t.Iterable[dict[str, t.Any]],
+        records: Iterable[dict[str, Any]],
     ) -> int | None:
         """Bulk insert records to an existing destination table.
 
-        This is the standard interface method that matches the parent class signature.
-        Developers should typically override bulk_insert_records_to_table instead
-        for more advanced use cases.
-
-        Args:
-            full_table_name: The target table name.
-            schema: The JSON schema for the new table.
-            records: The input records.
-
-        Returns:
-            Number of records inserted, or None if not detectable.
+        The default implementation uses a generic SQLAlchemy bulk insert operation.
+        This method may optionally be overridden by developers in order to provide
+        faster, native bulk uploads.
         """
-        with self.connector._connect() as connection, connection.begin():
-            table = self.connector.get_table(full_table_name)
-            return self.bulk_insert_records_to_table(
-                table=table,
-                schema=schema,
-                primary_keys=self.key_properties,
-                records=records,
-                connection=connection,
-            )
-
-    def bulk_insert_records_to_table(
-        self,
-        table: sqlalchemy.Table,
-        schema: dict,
-        records: t.Iterable[dict[str, t.Any]],
-        primary_keys: t.Sequence[str],
-        connection: sqlalchemy.engine.Connection,
-    ) -> int | None:
-        """Bulk insert records to an existing destination table.
-
-        Developers may override this method to provide faster, native bulk uploads
-        specific to their target database. The default implementation uses
-        SQLAlchemy's bulk insert operations.
-
-        Args:
-            table: The target table object.
-            schema: The JSON schema for the new table, to be used when inferring column
-                names.
-            records: The input records.
-            primary_keys: The primary key columns for the table.
-            connection: The database connection.
-
-        Returns:
-            Number of records inserted, or None if not detectable.
-        """
-        import sqlalchemy as sa
-
-        columns = self.column_representation(schema)
-        data = []
-
-        # Determine if we need to handle duplicates
-        append_only = not primary_keys
-        unique_records = {}
-
-        for record in records:
-            insert_record = {column.name: record.get(column.name) for column in columns}
-
-            if append_only:
-                data.append(insert_record)
-            else:
-                # Keep only the latest record per primary key
-                primary_key_tuple = tuple(record[key] for key in primary_keys)
-                unique_records[primary_key_tuple] = insert_record
-
-        if not append_only:
-            data = list(unique_records.values())
-
-        if data:
-            insert_stmt = sa.insert(table)
-            connection.execute(insert_stmt, data)
-            return len(data)
-
-        return 0
-
-    def upsert(
-        self,
-        from_table: sqlalchemy.Table,
-        to_table: sqlalchemy.Table,
-        schema: dict,
-        join_keys: t.Sequence[str],
-        connection: sqlalchemy.engine.Connection,
-    ) -> int | None:
-        """Merge upsert data from one table to another.
-
-        Developers may override this method to provide database-specific
-        MERGE or UPSERT operations for better performance. The default
-        implementation uses separate INSERT and UPDATE operations.
-
-        Args:
-            from_table: The source table.
-            to_table: The destination table.
-            schema: Singer Schema message.
-            join_keys: The merge upsert keys, or `None` to append.
-            connection: The database connection.
-
-        Returns:
-            The number of records copied, if detectable, or `None` if the API does not
-            report number of records affected/inserted.
-        """
-        import sqlalchemy as sa
-
-        if not join_keys:
-            # Append-only mode: simple insert
-            select_stmt = sa.select(from_table.columns).select_from(from_table)
-            insert_stmt = to_table.insert().from_select(
-                names=from_table.columns, select=select_stmt
-            )
-            connection.execute(insert_stmt)
-        else:
-            # Upsert mode: insert new records, update existing ones
-
-            # 1. Insert new records (those not matching existing primary keys)
-            join_predicates = []
-            for key in join_keys:
-                from_table_key = from_table.columns[key]
-                to_table_key = to_table.columns[key]
-                join_predicates.append(from_table_key == to_table_key)
-
-            join_condition = sa.and_(*join_predicates)
-
-            where_predicates = []
-            for key in join_keys:
-                to_table_key = to_table.columns[key]
-                where_predicates.append(to_table_key.is_(None))
-            where_condition = sa.and_(*where_predicates)
-
-            select_stmt = (
-                sa.select(from_table.columns)
-                .select_from(from_table.outerjoin(to_table, join_condition))
-                .where(where_condition)
-            )
-            insert_stmt = sa.insert(to_table).from_select(
-                names=from_table.columns, select=select_stmt
-            )
-            connection.execute(insert_stmt)
-
-            # 2. Update existing records
-            update_columns = {}
-            for column_name in schema["properties"]:
-                from_table_column = from_table.columns[column_name]
-                to_table_column = to_table.columns[column_name]
-                update_columns[to_table_column] = from_table_column
-
-            update_stmt = (
-                sa.update(to_table).where(join_condition).values(update_columns)
-            )
-            connection.execute(update_stmt)
-
-        return None
-
-    def column_representation(
-        self,
-        schema: dict,
-    ) -> list[sqlalchemy.Column]:
-        """Return a sqlalchemy table representation for the current schema.
-
-        Developers should not need to override this method unless they need
-        custom column definitions or type mappings.
-
-        Args:
-            schema: The JSON schema for the table.
-
-        Returns:
-            List of SQLAlchemy Column objects.
-        """
-        import sqlalchemy as sa
-
-        columns = [
-            sa.Column(
-                property_name,
-                self.connector.to_sql_type(property_jsonschema),
-            )
-            for property_name, property_jsonschema in schema["properties"].items()
-        ]
-        return columns
-
-    @property
-    def schema_name(self) -> str | None:
-        """Return the schema name or `None` if using names with no schema part.
-
-        Developers may override this method to customize schema name resolution
-        based on configuration or stream naming conventions.
-
-        Returns:
-            The target schema name.
-        """
-        # Look for a default_target_schema in the configuration file
-        default_target_schema = self.config.get("default_target_schema")
-        if default_target_schema:
-            return default_target_schema
-
-        # Parse schema from stream name if in <schema>-<table> format
-        parts = self.stream_name.split("-")
-        if len(parts) in {2, 3}:
-            return parts[-2]
-
-        return None
+        return super().bulk_insert_records(
+            full_table_name=full_table_name,
+            schema=schema,
+            records=records,
+        )


### PR DESCRIPTION
- Closes https://github.com/meltano/sdk/issues/1347


<!-- readthedocs-preview meltano-sdk start -->
----
📚 Documentation preview 📚: https://meltano-sdk--3198.org.readthedocs.build/en/3198/

<!-- readthedocs-preview meltano-sdk end -->

## Summary by Sourcery

Refresh SQL tap and target cookiecutter templates to align with the latest Singer SDK APIs by adding customizable SQL type conversion, advanced connector and stream override examples, and dynamic sink template selection.

New Features:
- Add a SQLToJSONSchema subclass with singledispatch methods for custom SQL-to-JSON Schema conversions.
- Extend SQLConnector and SQLStream templates with example override methods for schema discovery, type conformance, query filtering, and custom record retrieval.
- Provide separate RecordSink, BatchSink, and SQLSink template files and a post-generation hook to select and clean up the appropriate sink based on the serialization method.

Enhancements:
- Enrich docstrings and developer guidance across tap and target template classes.
- Update the post-gen hook to remove IDE folders and handle sink file selection and cleanup.