### PR TITLE
refactor: Make `SchemaSource` generic on any hashable key type

### DIFF
--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -127,7 +127,7 @@ class StreamSchema(t.Generic[_TKey]):
         return self.schema_source.get_schema(self.key or obj.name)  # type: ignore[arg-type]
 
 
-class OpenAPISchema(SchemaSource[str]):
+class OpenAPISchema(SchemaSource):
     """Schema source for OpenAPI specifications.
 
     Supports loading schemas from a local or remote OpenAPI 3.1 specification.
@@ -233,7 +233,7 @@ class OpenAPISchema(SchemaSource[str]):
             raise SchemaNotFoundError(msg) from e
 
 
-class SchemaDirectory(SchemaSource[str]):
+class SchemaDirectory(SchemaSource):
     """Schema source for local file-based schemas."""
 
     def __init__(


### PR DESCRIPTION
## Related

- https://github.com/meltano/sdk/issues/2746
- https://github.com/meltano/sdk/pull/3190

## Summary by Sourcery

Make SchemaSource and related classes generic on a hashable key type to improve type flexibility

Enhancements:
- Introduce a _TKey TypeVar bound to Hashable and parameterize SchemaSource and StreamSchema classes with it
- Update SchemaSource internal cache and methods (get_schema, fetch_schema) to use the generic key type
- Annotate OpenAPISchema and SchemaDirectory to specify the str key type for their SchemaSource instances

## Summary by Sourcery

Make SchemaSource and related classes generic over a hashable key type to improve type flexibility.

Enhancements:
- Introduce a TypeVar (_TKey) bound to Hashable and parameterize SchemaSource and StreamSchema classes with it
- Update SchemaSource internal cache and schema retrieval methods (get_schema, fetch_schema) to use the generic key type
- Parameterize OpenAPISchema and SchemaDirectory as SchemaSource[str] to retain string-specific behavior
- Adjust TypeVar and override imports to choose between typing and typing_extensions based on Python version