### PR TITLE
refactor: Make `get_stream_schema` the public API of the `StreamSchema` descriptor

### DIFF
--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from types import ModuleType
 
 import requests
-from referencing.exceptions import PointerToNowhere
 
 from singer_sdk.exceptions import DiscoveryError
 from singer_sdk.singerlib.schema import resolve_schema_references
@@ -61,10 +60,15 @@ class SchemaSource(ABC, t.Generic[_TKey]):
             A JSON schema dictionary.
 
         Raises:
+            SchemaNotFoundError: If the schema is not found or cannot be fetched.
             SchemaNotValidError: If the schema is not a JSON object.
         """
         if key not in self._schema_cache:
-            schema = self.fetch_schema(key)
+            try:
+                schema = self.fetch_schema(key)
+            except Exception as e:
+                msg = f"Schema not found for '{key}'"
+                raise SchemaNotFoundError(msg) from e
             if not isinstance(schema, dict):
                 msg = "Schema must be a JSON object"  # type: ignore[unreachable]
                 raise SchemaNotValidError(msg)
@@ -205,25 +209,12 @@ class OpenAPISchema(SchemaSource):
 
         Returns:
             The OpenAPI specification as a dictionary.
-
-        Raises:
-            DiscoveryError: If the specification cannot be loaded from a remote or local
-                source.
         """
-        try:
-            if isinstance(self.source, str) and self.source.startswith(
-                ("http://", "https://")
-            ):
-                # Load from URL
-                spec = self._load_remote_spec(self.source)
-            else:
-                # Load from local file
-                spec = self._load_local_spec(self.source)
-        except Exception as e:
-            msg = f"Failed to load OpenAPI specification from {self.source}"
-            raise DiscoveryError(msg) from e
-
-        return spec
+        if isinstance(self.source, str) and self.source.startswith(
+            ("http://", "https://")
+        ):
+            return self._load_remote_spec(self.source)
+        return self._load_local_spec(self.source)
 
     @override
     def fetch_schema(self, key: str) -> dict[str, t.Any]:
@@ -234,20 +225,14 @@ class OpenAPISchema(SchemaSource):
 
         Returns:
             A JSON schema dictionary.
-
-        Raises:
-            SchemaNotFoundError: If the schema component is not found.
         """
         schema = {
             "$ref": f"#/components/schemas/{key}",
             "components": self.spec.get("components", {}),
         }
-        try:
-            resolved_schema = resolve_schema_references(schema)
-            return resolved_schema.get("components", {}).get("schemas", {}).get(key, {})  # type: ignore[no-any-return]
-        except PointerToNowhere as e:
-            msg = f"Failed to resolve schema references for '{key}'"
-            raise SchemaNotFoundError(msg) from e
+        resolved_schema = resolve_schema_references(schema)
+        resolved_schema.pop("components")
+        return resolved_schema
 
 
 class SchemaDirectory(SchemaSource):
@@ -288,17 +273,6 @@ class SchemaDirectory(SchemaSource):
 
         Returns:
             A JSON schema dictionary.
-
-        Raises:
-            SchemaNotFoundError: If the schema file is not found.
-            SchemaNotValidError: If the schema file is invalid.
         """
         file_path = self.dir_path.joinpath(f"{key}.{self.extension}")
-        try:
-            return json.loads(file_path.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
-        except FileNotFoundError as e:
-            msg = f"Schema file not found for '{key}'"
-            raise SchemaNotFoundError(msg) from e
-        except json.JSONDecodeError as e:
-            msg = f"Invalid JSON for '{key}' schema"
-            raise SchemaNotValidError(msg) from e
+        return json.loads(file_path.read_text(encoding="utf-8"))  # type: ignore[no-any-return]

--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -114,6 +114,7 @@ class StreamSchema(t.Generic[_TKey]):
         self.schema_source = schema_source
         self.key = key
 
+    @t.final
     def __get__(self, obj: Stream, objtype: type[Stream]) -> dict[str, t.Any]:
         """Get the schema from the schema source.
 
@@ -124,7 +125,23 @@ class StreamSchema(t.Generic[_TKey]):
         Returns:
             A JSON schema dictionary.
         """
-        return self.schema_source.get_schema(self.key or obj.name)  # type: ignore[arg-type]
+        return self.get_stream_schema(obj, objtype)
+
+    def get_stream_schema(
+        self,
+        stream: Stream,
+        stream_class: type[Stream],  # noqa: ARG002
+    ) -> dict[str, t.Any]:
+        """Get the schema from the stream instance or class.
+
+        Args:
+            stream: The stream instance to get the schema from.
+            stream_class: The stream class to get the schema from.
+
+        Returns:
+            A JSON schema dictionary.
+        """
+        return self.schema_source.get_schema(self.key or stream.name)  # type: ignore[arg-type]
 
 
 class OpenAPISchema(SchemaSource):

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -356,6 +356,13 @@ class TestStreamSchemaDescriptor:
         stream_schema = StreamSchema(schema_source)
         assert stream_schema.get_stream_schema(stream, type(stream)) == foo_schema
 
+        stream_schema = StreamSchema(schema_source, key="bar")
+        with pytest.raises(
+            SchemaNotFoundError,
+            match="Schema file not found for 'bar'",
+        ):
+            stream_schema.get_stream_schema(stream, type(stream))
+
     def test_stream_schema_descriptor(
         self,
         foo_schema: dict[str, t.Any],

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -11,8 +11,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 import requests
+from referencing.exceptions import PointerToNowhere
 
-from singer_sdk.exceptions import DiscoveryError
 from singer_sdk.helpers._compat import Traversable
 from singer_sdk.schema.source import (
     OpenAPISchema,
@@ -118,9 +118,11 @@ class TestSchemaDirectory:
         source = SchemaDirectory(tmp_path)
         with pytest.raises(
             SchemaNotFoundError,
-            match="Schema file not found for 'users'",
-        ):
+            match="Schema not found for 'users'",
+        ) as exc:
             source.get_schema("users")
+
+        assert isinstance(exc.value.__cause__, FileNotFoundError)
 
     def test_dir_source_invalid_json_file(self, tmp_path: Path):
         """Test FileSchema with invalid JSON content."""
@@ -131,10 +133,11 @@ class TestSchemaDirectory:
 
         source = SchemaDirectory(tmp_path)
         with pytest.raises(
-            SchemaNotValidError,
-            match="Invalid JSON for 'invalid' schema",
-        ):
+            SchemaNotFoundError,
+            match="Schema not found for 'invalid'",
+        ) as exc:
             source.get_schema("invalid")
+        assert isinstance(exc.value.__cause__, json.decoder.JSONDecodeError)
 
 
 class TestOpenAPISchema:
@@ -227,13 +230,11 @@ class TestOpenAPISchema:
 
         source = OpenAPISchema("https://api.example.com/openapi.json")
 
-        with pytest.raises(
-            DiscoveryError,
-            match="Failed to load OpenAPI specification",
-        ) as exc:
-            _ = source.spec
+        with pytest.raises(SchemaNotFoundError) as exc:
+            _ = source.get_schema("User")
 
         assert isinstance(exc.value.__cause__, requests.RequestException)
+        assert exc.value.__cause__.args == ("Network error",)
 
     def test_openapi_load_from_file(
         self,
@@ -254,11 +255,8 @@ class TestOpenAPISchema:
         openapi_file.write_text("this is not a valid json object")
 
         source = OpenAPISchema(openapi_file)
-        with pytest.raises(
-            DiscoveryError,
-            match="Failed to load OpenAPI specification",
-        ) as exc:
-            _ = source.spec
+        with pytest.raises(SchemaNotFoundError) as exc:
+            _ = source.get_schema("User")
 
         assert isinstance(exc.value.__cause__, json.decoder.JSONDecodeError)
 
@@ -288,9 +286,10 @@ class TestOpenAPISchema:
         source = OpenAPISchema(openapi_file)
         with pytest.raises(
             SchemaNotFoundError,
-            match="Failed to resolve schema references for 'InvalidComponent'",
-        ):
+            match="Schema not found for 'InvalidComponent'",
+        ) as exc:
             source.get_schema("InvalidComponent")
+        assert isinstance(exc.value.__cause__, PointerToNowhere)
 
     def test_openapi_schema_spec_caching(
         self,
@@ -359,9 +358,10 @@ class TestStreamSchemaDescriptor:
         stream_schema = StreamSchema(schema_source, key="bar")
         with pytest.raises(
             SchemaNotFoundError,
-            match="Schema file not found for 'bar'",
-        ):
+            match="Schema not found for 'bar'",
+        ) as exc:
             stream_schema.get_stream_schema(stream, type(stream))
+        assert isinstance(exc.value.__cause__, FileNotFoundError)
 
     def test_stream_schema_descriptor(
         self,
@@ -404,6 +404,7 @@ class TestStreamSchemaDescriptor:
         stream = BarStream()
         with pytest.raises(
             SchemaNotFoundError,
-            match="Schema file not found for 'bar'",
-        ):
+            match="Schema not found for 'bar'",
+        ) as exc:
             _ = stream.schema
+        assert isinstance(exc.value.__cause__, FileNotFoundError)


### PR DESCRIPTION
## Summary by Sourcery

Refactor StreamSchema descriptor to surface get_stream_schema as its public interface, simplify __get__ implementation, and enhance tests with reusable fixtures and more thorough coverage.

Enhancements:
- Expose get_stream_schema() as the public API for StreamSchema and delegate the descriptor’s __get__ to it
- Mark the StreamSchema descriptor’s __get__ method as final

Tests:
- Introduce pytest fixtures for schema data and source directory
- Add a dedicated test for get_stream_schema and update descriptor tests to cover explicit keys and schema-not-found errors