### PR TITLE
refactor: Fetch OpenAPI spec with a session

### DIFF
--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -174,6 +174,12 @@ class OpenAPISchema(SchemaSource):
         """
         super().__init__(*args, **kwargs)
         self.source = source
+        self._requests_session = requests.Session()
+
+    @property
+    def requests_session(self) -> requests.Session:
+        """The requests session to use for fetching the OpenAPI spec."""
+        return self._requests_session
 
     @cached_property
     def spec(self) -> dict[str, t.Any]:
@@ -184,13 +190,13 @@ class OpenAPISchema(SchemaSource):
         """
         return self._load_spec()
 
-    def _load_remote_spec(self, url: str) -> dict[str, t.Any]:  # noqa: PLR6301
+    def _load_remote_spec(self, url: str) -> dict[str, t.Any]:
         """Load the OpenAPI specification from a remote source.
 
         Returns:
             The OpenAPI specification as a dictionary.
         """
-        response = requests.get(url, timeout=30)
+        response = self.requests_session.get(url, timeout=30)
         response.raise_for_status()
         return response.json()  # type: ignore[no-any-return]
 

--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -162,24 +162,31 @@ class OpenAPISchema(SchemaSource):
         self,
         source: str | Path | Traversable,
         *args: t.Any,
+        requests_session: requests.Session | None = None,
         **kwargs: t.Any,
     ) -> None:
         """Initialize the OpenAPI schema source.
 
         Args:
             source: URL, file path, or Traversable object pointing to an OpenAPI spec.
+            requests_session: A requests session to use for fetching the OpenAPI spec.
             *args: Additional arguments to pass to the superclass constructor.
             **kwargs: Additional keyword arguments to pass to the superclass
                 constructor.
         """
         super().__init__(*args, **kwargs)
         self.source = source
-        self._requests_session = requests.Session()
+        self._requests_session = requests_session or requests.Session()
 
     @property
     def requests_session(self) -> requests.Session:
         """The requests session to use for fetching the OpenAPI spec."""
         return self._requests_session
+
+    @requests_session.setter
+    def requests_session(self, value: requests.Session) -> None:
+        """Set the requests session to use for fetching the OpenAPI spec."""
+        self._requests_session = value
 
     @cached_property
     def spec(self) -> dict[str, t.Any]:

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -201,7 +201,7 @@ class TestOpenAPISchema:
         source = OpenAPISchema("/path/to/openapi.json")
         assert source.source == "/path/to/openapi.json"
 
-    @patch("requests.get")
+    @patch("requests.Session.get")
     def test_openapi_load_from_url(
         self,
         mock_get,
@@ -223,7 +223,7 @@ class TestOpenAPISchema:
         )
         mock_response.raise_for_status.assert_called_once()
 
-    @patch("requests.get")
+    @patch("requests.Session.get")
     def test_openapi_load_from_url_error(self, mock_get):
         """Test error handling when loading from URL."""
         mock_get.side_effect = requests.RequestException("Network error")


### PR DESCRIPTION
## Summary by Sourcery

Refactor OpenAPISchema to use a persistent requests.Session for fetching remote OpenAPI specifications and update tests accordingly

Enhancements:
- Initialize and expose a requests.Session instance in the schema source
- Switch _load_remote_spec to use the session’s get method instead of requests.get

Tests:
- Update tests to patch requests.Session.get instead of requests.get