### PR TITLE
fix(templates): Remove duplicate prefix from generated `.env` in templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.env.example
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.env.example
@@ -2,4 +2,4 @@
 # Copy this file to .env and fill in your actual values
 
 # Example configuration - replace or remove based on your needs
-MAPPER_{{ cookiecutter.mapper_id.upper().replace('-', '_') }}_EXAMPLE_CONFIG=example_value
+{{ cookiecutter.mapper_id.upper().replace('-', '_') }}_EXAMPLE_CONFIG=example_value

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.env.example
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.env.example
@@ -2,19 +2,19 @@
 # Copy this file to .env and fill in your actual values
 
 # Required: Authentication token for the API service
-TAP_{{ cookiecutter.tap_id.upper().replace('-', '_') }}_AUTH_TOKEN=your_auth_token_here
+{{ cookiecutter.tap_id.upper().replace('-', '_') }}_AUTH_TOKEN=your_auth_token_here
 
 # Required: Project IDs to replicate (comma-separated)
-TAP_{{ cookiecutter.tap_id.upper().replace('-', '_') }}_PROJECT_IDS=project1,project2,project3
+{{ cookiecutter.tap_id.upper().replace('-', '_') }}_PROJECT_IDS=project1,project2,project3
 
 # Optional: The earliest record date to sync (ISO format)
-TAP_{{ cookiecutter.tap_id.upper().replace('-', '_') }}_START_DATE=2023-01-01T00:00:00Z
+{{ cookiecutter.tap_id.upper().replace('-', '_') }}_START_DATE=2023-01-01T00:00:00Z
 
 # Optional: API URL (defaults to https://api.mysample.com)
-TAP_{{ cookiecutter.tap_id.upper().replace('-', '_') }}_API_URL=https://api.mysample.com
+{{ cookiecutter.tap_id.upper().replace('-', '_') }}_API_URL=https://api.mysample.com
 
 {%- if cookiecutter.stream_type in ("GraphQL", "REST") %}
 
 # Optional: Custom User-Agent header
-TAP_{{ cookiecutter.tap_id.upper().replace('-', '_') }}_USER_AGENT={{ cookiecutter.tap_id }}/1.0.0
+{{ cookiecutter.tap_id.upper().replace('-', '_') }}_USER_AGENT={{ cookiecutter.tap_id }}/1.0.0
 {%- endif %}

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.env.example
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.env.example
@@ -3,14 +3,14 @@
 
 {%- if cookiecutter.serialization_method == "SQL" %}
 # Required: SQLAlchemy connection string
-TARGET_{{ cookiecutter.target_id.upper().replace('-', '_') }}_SQLALCHEMY_URL=sqlite:///example.db
+{{ cookiecutter.target_id.upper().replace('-', '_') }}_SQLALCHEMY_URL=sqlite:///example.db
 {%- else %}
 # Required: Output file path
-TARGET_{{ cookiecutter.target_id.upper().replace('-', '_') }}_FILEPATH=./output/data.jsonl
+{{ cookiecutter.target_id.upper().replace('-', '_') }}_FILEPATH=./output/data.jsonl
 
 # Required: File naming scheme
-TARGET_{{ cookiecutter.target_id.upper().replace('-', '_') }}_FILE_NAMING_SCHEME={stream_name}.jsonl
+{{ cookiecutter.target_id.upper().replace('-', '_') }}_FILE_NAMING_SCHEME={stream_name}.jsonl
 
 # Required: Authentication token
-TARGET_{{ cookiecutter.target_id.upper().replace('-', '_') }}_AUTH_TOKEN=your_auth_token_here
+{{ cookiecutter.target_id.upper().replace('-', '_') }}_AUTH_TOKEN=your_auth_token_here
 {%- endif %}


### PR DESCRIPTION
## Summary by Sourcery

Fix duplicated prefix in generated .env.example files in cookiecutter mapper, tap, and target templates

Bug Fixes:
- Remove redundant prefix from environment variable names in mapper .env.example
- Remove redundant prefix from environment variable names in tap .env.example
- Remove redundant prefix from environment variable names in target .env.example