### PR TITLE
fix(templates): Set the dependabot ecosystem to `uv` in templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/dependabot.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: weekly

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/dependabot.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: weekly

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/dependabot.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Change package-ecosystem from 'pip' to 'uv' in dependabot.yml for mapper, tap, and target templates