### PR TITLE
fix(templates): Use `uv` in templates README

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/README.md
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/README.md
@@ -13,13 +13,13 @@ Developer TODO: Update the below as needed to correctly describe the install pro
 Install from PyPI:
 
 ```bash
-pipx install {{ cookiecutter.mapper_id }}
+uv tool install {{ cookiecutter.mapper_id }}
 ```
 
 Install from GitHub:
 
 ```bash
-pipx install git+https://github.com/ORG_NAME/{{ cookiecutter.mapper_id }}.git@main
+uv tool install git+https://github.com/ORG_NAME/{{ cookiecutter.mapper_id }}.git@main
 ```
 
 -->
@@ -113,7 +113,7 @@ Next, install Meltano (if you haven't already) and any needed plugins:
 
 ```bash
 # Install meltano
-pipx install meltano
+uv tool install meltano
 # Initialize meltano within this directory
 cd {{ cookiecutter.mapper_id }}
 meltano install

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/README.md
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/README.md
@@ -13,13 +13,13 @@ Developer TODO: Update the below as needed to correctly describe the install pro
 Install from PyPI:
 
 ```bash
-pipx install {{ cookiecutter.tap_id }}
+uv tool install {{ cookiecutter.tap_id }}
 ```
 
 Install from GitHub:
 
 ```bash
-pipx install git+https://github.com/ORG_NAME/{{ cookiecutter.tap_id }}.git@main
+uv tool install git+https://github.com/ORG_NAME/{{ cookiecutter.tap_id }}.git@main
 ```
 
 -->
@@ -114,7 +114,7 @@ Next, install Meltano (if you haven't already) and any needed plugins:
 
 ```bash
 # Install meltano
-pipx install meltano
+uv tool install meltano
 # Initialize meltano within this directory
 cd {{ cookiecutter.tap_id }}
 meltano install

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/README.md
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/README.md
@@ -13,13 +13,13 @@ Developer TODO: Update the below as needed to correctly describe the install pro
 Install from PyPI:
 
 ```bash
-pipx install {{ cookiecutter.target_id }}
+uv tool install {{ cookiecutter.target_id }}
 ```
 
 Install from GitHub:
 
 ```bash
-pipx install git+https://github.com/ORG_NAME/{{ cookiecutter.target_id }}.git@main
+uv tool install git+https://github.com/ORG_NAME/{{ cookiecutter.target_id }}.git@main
 ```
 
 -->
@@ -115,7 +115,7 @@ Next, install Meltano (if you haven't already) and any needed plugins:
 
 ```bash
 # Install meltano
-pipx install meltano
+uv tool install meltano
 # Initialize meltano within this directory
 cd {{ cookiecutter.target_id }}
 meltano install


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Replace pipx install commands with uv tool install for PyPI and GitHub installs in the mapper, tap, and target template READMEs