### PR TITLE
feat: Add a metrics exclusion filter

### DIFF
--- a/docs/implementation/logging.md
+++ b/docs/implementation/logging.md
@@ -63,10 +63,17 @@ handlers:
     class: logging.FileHandler
     formatter: metrics
     filename: metrics.jsonl
+# Optionally, you can exclude metrics
+filters:
+  remove_events_stream_metrics:
+    (): singer_sdk.metrics.MetricExclusionFilter
+    tags:
+      stream: events
 loggers:
   singer_sdk.metrics:
     level: INFO
     handlers: [ metrics ]
+    filters: [ remove_events_stream_metrics ]
     propagate: no
 ```
 

--- a/docs/implementation/logging.md
+++ b/docs/implementation/logging.md
@@ -66,7 +66,7 @@ handlers:
 # Optionally, you can exclude metrics
 filters:
   remove_events_stream_metrics:
-    (): singer_sdk.metrics.MetricExclusionFilter
+    (): singer_sdk.metrics.SingerMetricsExclusionFilter
     tags:
       stream: events
 loggers:

--- a/docs/implementation/logging.md
+++ b/docs/implementation/logging.md
@@ -66,7 +66,7 @@ handlers:
 # Optionally, you can exclude metrics
 filters:
   remove_events_stream_metrics:
-    (): singer_sdk.metrics.SingerMetricsExclusionFilter
+    (): singer_sdk.metrics.MetricExclusionFilter
     tags:
       stream: events
 loggers:

--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -155,10 +155,10 @@ class MetricExclusionFilter(logging.Filter):
         Args:
             **kwargs: The point dictionary.
 
-        A metric record is excluded if all of the following are true:
-        - The metric is in the metrics list or the metrics list is empty.
-        - The metric type is in the types list or the types list is empty.
-        - Any of the tags match the tags dictionary or the tags dictionary is empty.
+        A metric record is excluded if any of the following are true:
+        - The metric name matches one in the metrics list
+        - The metric type matches one in the types list
+        - Any of the point's tags match the corresponding values in the tags dictionary
 
         Returns:
             True if the point should be excluded.

--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -128,7 +128,7 @@ class SingerMetricsFormatter(logging.Formatter):
         return super().format(record)
 
 
-class MetricExclusionFilter(logging.Filter):
+class SingerMetricsExclusionFilter(logging.Filter):
     """A filter for excluding metrics from logging."""
 
     def __init__(

--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -128,7 +128,7 @@ class SingerMetricsFormatter(logging.Formatter):
         return super().format(record)
 
 
-class SingerMetricsExclusionFilter(logging.Filter):
+class MetricExclusionFilter(logging.Filter):
     """A filter for excluding metrics from logging."""
 
     def __init__(

--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -16,6 +16,7 @@ from singer_sdk.helpers._compat import SingerSDKDeprecationWarning
 
 if t.TYPE_CHECKING:
     import sys
+    from collections.abc import Sequence
     from types import TracebackType
 
     from singer_sdk.helpers import types
@@ -125,6 +126,66 @@ class SingerMetricsFormatter(logging.Formatter):
         point = record.__dict__.get("point")
         record.__dict__["metric_json"] = _to_json(point) if point else ""
         return super().format(record)
+
+
+class MetricExclusionFilter(logging.Filter):
+    """A filter for excluding metrics from logging."""
+
+    def __init__(
+        self,
+        *,
+        metrics: Sequence[str | Metric] | None = None,
+        types: Sequence[str] | None = None,
+        tags: dict[str, t.Any] | None = None,
+    ):
+        """Initialize a metric filter.
+
+        Args:
+            metrics: A set of metrics to exclude.
+            types: A set of metric types to exclude.
+            tags: A dictionary of tags to exclude.
+        """
+        self.metrics = metrics or []
+        self.types = types or []
+        self.tags = tags or {}
+
+    def _exclude_point(self, **kwargs: t.Any) -> bool:
+        """Filter a point.
+
+        Args:
+            **kwargs: The point dictionary.
+
+        A metric record is excluded if all of the following are true:
+        - The metric is in the metrics list or the metrics list is empty.
+        - The metric type is in the types list or the types list is empty.
+        - Any of the tags match the tags dictionary or the tags dictionary is empty.
+
+        Returns:
+            True if the point should be excluded.
+        """
+        return (
+            (kwargs.get("metric") in self.metrics)
+            or (kwargs.get("type") in self.types)
+            or any(
+                kwargs.get("tags", {}).get(tag) == value
+                for tag, value in self.tags.items()
+            )
+        )
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Filter a log record.
+
+        Args:
+            record: A log record.
+
+        Returns:
+            True if the record should be logged.
+        """
+        return not (
+            (point := record.__dict__.get("point"))
+            and isinstance(point, dict)
+            and self._exclude_point(**point)
+        )
 
 
 def log(logger: logging.Logger, point: Point) -> None:

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -231,7 +231,7 @@ def test_metric_filter_exclude_metrics(
 def test_metric_filter_exclude_metric_types(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.MetricExclusionFilter(metrics=["sync_duration"])
+    metric_filter = metrics.MetricExclusionFilter(types=["timer"])
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 2
     assert filtered[0].msg == "Hey there"

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -74,7 +74,7 @@ def metric_log_records() -> list[logging.LogRecord]:
         tags={
             metrics.Tag.STREAM: "teams",
             metrics.Tag.CONTEXT: {
-                "account_id": 2,
+                "account_id": 1,
             },
             "test_tag": "test_value",
         },
@@ -255,19 +255,36 @@ def test_metric_filter_exclude_metric_types(
 def test_metric_filter_exclude_tags(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.MetricExclusionFilter(tags={"stream": "users"})
+    metric_filter = metrics.MetricExclusionFilter(
+        tags={
+            metrics.Tag.STREAM: "users",
+        },
+    )
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 2
     assert filtered[0].msg == "Hey there"
     assert filtered[1].__dict__["point"]["tags"]["stream"] == "teams"
 
-    metric_filter = metrics.MetricExclusionFilter(tags={"test_tag": "test_value"})
+    metric_filter = metrics.MetricExclusionFilter(
+        tags={
+            "test_tag": "test_value",
+        },
+    )
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 1
     assert filtered[0].msg == "Hey there"
 
+
+@pytest.mark.xfail(reason="Nested tags are not supported yet")
+def test_metric_filter_exclude_nested_tags(
+    metric_log_records: list[logging.LogRecord],
+) -> None:
     metric_filter = metrics.MetricExclusionFilter(
-        tags={"stream": "users", "test_tag": "test_value"},
+        tags={
+            metrics.Tag.CONTEXT: {
+                "account_id": 1,
+            },
+        },
     )
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 1

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -212,7 +212,7 @@ def _filter(
 def test_metric_filter_no_exclusions(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.SingerMetricsExclusionFilter()
+    metric_filter = metrics.MetricExclusionFilter()
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 3
 
@@ -220,7 +220,7 @@ def test_metric_filter_no_exclusions(
 def test_metric_filter_exclude_metrics(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.SingerMetricsExclusionFilter(metrics=["record_count"])
+    metric_filter = metrics.MetricExclusionFilter(metrics=["record_count"])
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 2
     assert filtered[0].msg == "Hey there"
@@ -231,7 +231,7 @@ def test_metric_filter_exclude_metrics(
 def test_metric_filter_exclude_metric_types(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.SingerMetricsExclusionFilter(metrics=["sync_duration"])
+    metric_filter = metrics.MetricExclusionFilter(metrics=["sync_duration"])
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 2
     assert filtered[0].msg == "Hey there"
@@ -242,15 +242,13 @@ def test_metric_filter_exclude_metric_types(
 def test_metric_filter_exclude_tags(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.SingerMetricsExclusionFilter(tags={"stream": "users"})
+    metric_filter = metrics.MetricExclusionFilter(tags={"stream": "users"})
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 2
     assert filtered[0].msg == "Hey there"
     assert filtered[1].__dict__["point"]["tags"]["stream"] == "teams"
 
-    metric_filter = metrics.SingerMetricsExclusionFilter(
-        tags={"test_tag": "test_value"}
-    )
+    metric_filter = metrics.MetricExclusionFilter(tags={"test_tag": "test_value"})
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 1
     assert filtered[0].msg == "Hey there"
@@ -259,7 +257,7 @@ def test_metric_filter_exclude_tags(
 def test_metric_filter_exclude_name_and_type(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.SingerMetricsExclusionFilter(
+    metric_filter = metrics.MetricExclusionFilter(
         metrics=["record_count"],
         types=["counter"],
     )
@@ -273,7 +271,7 @@ def test_metric_filter_exclude_name_and_type(
 def test_metric_filter_exclude_name_and_tag(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.SingerMetricsExclusionFilter(
+    metric_filter = metrics.MetricExclusionFilter(
         metrics=["record_count"],
         tags={"stream": "users"},
     )

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -230,6 +230,22 @@ def test_metric_filter_no_exclusions(
     assert len(filtered) == 3
 
 
+def test_metric_filter_malformed_point() -> None:
+    metric_filter = metrics.MetricExclusionFilter()
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="METRIC",
+        args=(),
+        exc_info=None,
+    )
+    record.__dict__["point"] = "Not a dict"
+
+    assert metric_filter.filter(record)
+
+
 def test_metric_filter_exclude_metrics(
     metric_log_records: list[logging.LogRecord],
 ) -> None:

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import json
 import logging
 import os
+import typing as t
 
 import pytest
 import time_machine
 
 from singer_sdk import metrics
 from singer_sdk.helpers._compat import SingerSDKDeprecationWarning
+
+if t.TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
 
 
 class CustomObject:
@@ -18,6 +22,52 @@ class CustomObject:
 
     def __str__(self) -> str:
         return f"{self.name}={self.value}"
+
+
+@pytest.fixture
+def metric_log_records() -> list[logging.LogRecord]:
+    normal_log = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="Hey there",
+        args=(),
+        exc_info=None,
+    )
+    counter = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="METRIC",
+        args=(),
+        exc_info=None,
+    )
+    counter.__dict__["point"] = metrics.Point(
+        metric_type="counter",
+        metric=metrics.Metric.RECORD_COUNT,
+        value=1,
+        tags={"test_tag": "test_value", "stream": "users"},
+    ).to_dict()
+
+    timer = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="METRIC",
+        args=(),
+        exc_info=None,
+    )
+    timer.__dict__["point"] = metrics.Point(
+        metric_type="timer",
+        metric=metrics.Metric.SYNC_DURATION,
+        value=0.314,
+        tags={"test_tag": "test_value", "stream": "teams"},
+    ).to_dict()
+
+    return [normal_log, counter, timer]
 
 
 def test_singer_metrics_formatter():
@@ -36,12 +86,12 @@ def test_singer_metrics_formatter():
 
     assert not formatter.format(record)
 
-    metric_dict = {
-        "type": "counter",
-        "metric": "test_metric",
-        "tags": {"test_tag": "test_value"},
-        "value": 1,
-    }
+    metric_dict = metrics.Point(
+        metric_type="counter",
+        metric=metrics.Metric.RECORD_COUNT,
+        value=1,
+        tags={"test_tag": "test_value"},
+    ).to_dict()
     record.__dict__["point"] = metric_dict
 
     assert formatter.format(record) == json.dumps(metric_dict)
@@ -150,3 +200,80 @@ def test_sync_timer(caplog: pytest.LogCaptureFixture):
     }
 
     assert pytest.approx(point["value"], rel=0.001) == 10.0
+
+
+def _filter(
+    records: Iterable[logging.LogRecord],
+    filter_func: Callable[[logging.LogRecord], bool],
+) -> list[logging.LogRecord]:
+    return list(filter(filter_func, records))
+
+
+def test_metric_filter_no_exclusions(
+    metric_log_records: list[logging.LogRecord],
+) -> None:
+    metric_filter = metrics.MetricExclusionFilter()
+    filtered = _filter(metric_log_records, metric_filter.filter)
+    assert len(filtered) == 3
+
+
+def test_metric_filter_exclude_metrics(
+    metric_log_records: list[logging.LogRecord],
+) -> None:
+    metric_filter = metrics.MetricExclusionFilter(metrics=["record_count"])
+    filtered = _filter(metric_log_records, metric_filter.filter)
+    assert len(filtered) == 2
+    assert filtered[0].msg == "Hey there"
+    assert filtered[1].msg == "METRIC"
+    assert filtered[1].__dict__["point"]["metric"] == "sync_duration"
+
+
+def test_metric_filter_exclude_metric_types(
+    metric_log_records: list[logging.LogRecord],
+) -> None:
+    metric_filter = metrics.MetricExclusionFilter(metrics=["sync_duration"])
+    filtered = _filter(metric_log_records, metric_filter.filter)
+    assert len(filtered) == 2
+    assert filtered[0].msg == "Hey there"
+    assert filtered[1].msg == "METRIC"
+    assert filtered[1].__dict__["point"]["metric"] == "record_count"
+
+
+def test_metric_filter_exclude_tags(
+    metric_log_records: list[logging.LogRecord],
+) -> None:
+    metric_filter = metrics.MetricExclusionFilter(tags={"stream": "users"})
+    filtered = _filter(metric_log_records, metric_filter.filter)
+    assert len(filtered) == 2
+    assert filtered[0].msg == "Hey there"
+    assert filtered[1].__dict__["point"]["tags"]["stream"] == "teams"
+
+    metric_filter = metrics.MetricExclusionFilter(tags={"test_tag": "test_value"})
+    filtered = _filter(metric_log_records, metric_filter.filter)
+    assert len(filtered) == 1
+    assert filtered[0].msg == "Hey there"
+
+
+def test_metric_filter_exclude_name_and_type(
+    metric_log_records: list[logging.LogRecord],
+) -> None:
+    metric_filter = metrics.MetricExclusionFilter(
+        metrics=["record_count"],
+        types=["counter"],
+    )
+    filtered = _filter(metric_log_records, metric_filter.filter)
+    assert len(filtered) == 2
+    assert filtered[0].msg == "Hey there"
+    assert filtered[1].msg == "METRIC"
+    assert filtered[1].__dict__["point"]["metric"] == "sync_duration"
+
+
+def test_metric_filter_exclude_name_and_tag(
+    metric_log_records: list[logging.LogRecord],
+) -> None:
+    metric_filter = metrics.MetricExclusionFilter(
+        metrics=["record_count"],
+        tags={"stream": "users"},
+    )
+    filtered = _filter(metric_log_records, metric_filter.filter)
+    assert len(filtered) == 2

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -212,7 +212,7 @@ def _filter(
 def test_metric_filter_no_exclusions(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.MetricExclusionFilter()
+    metric_filter = metrics.SingerMetricsExclusionFilter()
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 3
 
@@ -220,7 +220,7 @@ def test_metric_filter_no_exclusions(
 def test_metric_filter_exclude_metrics(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.MetricExclusionFilter(metrics=["record_count"])
+    metric_filter = metrics.SingerMetricsExclusionFilter(metrics=["record_count"])
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 2
     assert filtered[0].msg == "Hey there"
@@ -231,7 +231,7 @@ def test_metric_filter_exclude_metrics(
 def test_metric_filter_exclude_metric_types(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.MetricExclusionFilter(metrics=["sync_duration"])
+    metric_filter = metrics.SingerMetricsExclusionFilter(metrics=["sync_duration"])
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 2
     assert filtered[0].msg == "Hey there"
@@ -242,13 +242,15 @@ def test_metric_filter_exclude_metric_types(
 def test_metric_filter_exclude_tags(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.MetricExclusionFilter(tags={"stream": "users"})
+    metric_filter = metrics.SingerMetricsExclusionFilter(tags={"stream": "users"})
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 2
     assert filtered[0].msg == "Hey there"
     assert filtered[1].__dict__["point"]["tags"]["stream"] == "teams"
 
-    metric_filter = metrics.MetricExclusionFilter(tags={"test_tag": "test_value"})
+    metric_filter = metrics.SingerMetricsExclusionFilter(
+        tags={"test_tag": "test_value"}
+    )
     filtered = _filter(metric_log_records, metric_filter.filter)
     assert len(filtered) == 1
     assert filtered[0].msg == "Hey there"
@@ -257,7 +259,7 @@ def test_metric_filter_exclude_tags(
 def test_metric_filter_exclude_name_and_type(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.MetricExclusionFilter(
+    metric_filter = metrics.SingerMetricsExclusionFilter(
         metrics=["record_count"],
         types=["counter"],
     )
@@ -271,7 +273,7 @@ def test_metric_filter_exclude_name_and_type(
 def test_metric_filter_exclude_name_and_tag(
     metric_log_records: list[logging.LogRecord],
 ) -> None:
-    metric_filter = metrics.MetricExclusionFilter(
+    metric_filter = metrics.SingerMetricsExclusionFilter(
         metrics=["record_count"],
         tags={"stream": "users"},
     )


### PR DESCRIPTION
## Summary by Sourcery

Introduce MetricExclusionFilter to singer_sdk.metrics for flexible metric exclusion, add comprehensive tests for filtering behaviors, and extend logging documentation with a usage example

New Features:
- Introduce MetricExclusionFilter to enable exclusion of logged metrics by name, type, or tags

Enhancements:
- Refactor singer metrics formatter test to use Point.to_dict for constructing metric payloads

Documentation:
- Update logging documentation with an example configuration for MetricExclusionFilter

Tests:
- Add fixture and tests for MetricExclusionFilter to validate exclusion by metric name, type, and tags