### PR TITLE
chore: Use uv in cookiecutter readme instructions

### DIFF
--- a/cookiecutter/mapper-template/README.md
+++ b/cookiecutter/mapper-template/README.md
@@ -3,10 +3,10 @@
 To use this cookie cutter template:
 
 ```bash
-pip3 install pipx
-pipx ensurepath
+# Install uv (see https://docs.astral.sh/uv/getting-started/installation/ for more options)
+curl -LsSf https://astral.sh/uv/install.sh | sh
 # You may need to reopen your shell at this point
-pipx install cookiecutter
+uv tool install cookiecutter
 ```
 
 Initialize Cookiecutter template directly from Git:

--- a/cookiecutter/tap-template/README.md
+++ b/cookiecutter/tap-template/README.md
@@ -3,10 +3,10 @@
 To use this cookie cutter template:
 
 ```bash
-pip3 install pipx
-pipx ensurepath
+# Install uv (see https://docs.astral.sh/uv/getting-started/installation/ for more options)
+curl -LsSf https://astral.sh/uv/install.sh | sh
 # You may need to reopen your shell at this point
-pipx install cookiecutter
+uv tool install cookiecutter
 ```
 
 Initialize Cookiecutter template directly from Git:

--- a/cookiecutter/target-template/README.md
+++ b/cookiecutter/target-template/README.md
@@ -3,10 +3,10 @@
 To use this cookie cutter template:
 
 ```bash
-pip3 install pipx
-pipx ensurepath
+# Install uv (see https://docs.astral.sh/uv/getting-started/installation/ for more options)
+curl -LsSf https://astral.sh/uv/install.sh | sh
 # You may need to reopen your shell at this point
-pipx install cookiecutter
+uv tool install cookiecutter
 ```
 
 Initialize Cookiecutter template directly from Git:


### PR DESCRIPTION
## Summary by Sourcery

Update cookiecutter template README instructions to install and use uv instead of pipx for installing cookiecutter

Documentation:
- Replace pipx installation steps with uv installation script in all cookiecutter template READMEs
- Use `uv tool install cookiecutter` in place of `pipx install cookiecutter` across mapper, tap, and target templates