### PR TITLE
chore: Fix sample package dependencies

### DIFF
--- a/packages/tap-countries/pyproject.toml
+++ b/packages/tap-countries/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.9"
 dependencies = [
+    "msgspec>=0.19.0",
     "requests-cache~=1.2.1",
     "singer-sdk~=0.48.0",
     "typing-extensions>=4.5.0; python_version < '3.12'",

--- a/packages/tap-sqlite/pyproject.toml
+++ b/packages/tap-sqlite/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.9"
 dependencies = [
+    "msgspec>=0.19.0",
     "singer-sdk~=0.48.0",
     "sqlalchemy",
 ]

--- a/packages/target-sqlite/pyproject.toml
+++ b/packages/target-sqlite/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.9"
 dependencies = [
+    "msgspec>=0.19.0",
     "singer-sdk~=0.48.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -3024,6 +3024,7 @@ name = "tap-countries"
 version = "0.1.0"
 source = { editable = "packages/tap-countries" }
 dependencies = [
+    { name = "msgspec" },
     { name = "requests-cache" },
     { name = "singer-sdk" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
@@ -3031,6 +3032,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "msgspec", specifier = ">=0.19.0" },
     { name = "requests-cache", specifier = "~=1.2.1" },
     { name = "singer-sdk", editable = "." },
     { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.5.0" },
@@ -3137,12 +3139,14 @@ name = "tap-sqlite"
 version = "0.1.0"
 source = { editable = "packages/tap-sqlite" }
 dependencies = [
+    { name = "msgspec" },
     { name = "singer-sdk" },
     { name = "sqlalchemy" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "msgspec", specifier = ">=0.19.0" },
     { name = "singer-sdk", editable = "." },
     { name = "sqlalchemy" },
 ]
@@ -3178,11 +3182,15 @@ name = "target-sqlite"
 version = "0.1.0"
 source = { editable = "packages/target-sqlite" }
 dependencies = [
+    { name = "msgspec" },
     { name = "singer-sdk" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "singer-sdk", editable = "." }]
+requires-dist = [
+    { name = "msgspec", specifier = ">=0.19.0" },
+    { name = "singer-sdk", editable = "." },
+]
 
 [[package]]
 name = "time-machine"


### PR DESCRIPTION
## Summary by Sourcery

Add missing msgspec dependency to sample packages and update lock file

Build:
- Regenerate uv.lock to reflect dependency updates

Chores:
- Add msgspec>=0.19.0 to dependencies of tap-countries, tap-sqlite, and target-sqlite