### PR TITLE
refactor(taps): Add type parameters to decorated request function

### DIFF
--- a/singer_sdk/helpers/types.py
+++ b/singer_sdk/helpers/types.py
@@ -25,6 +25,10 @@ __all__ = [
 Context: TypeAlias = Mapping[str, t.Any]
 Record: TypeAlias = dict[str, t.Any]
 Auth: TypeAlias = t.Callable[[requests.PreparedRequest], requests.PreparedRequest]
+RequestFunc: TypeAlias = t.Callable[
+    [requests.PreparedRequest, t.Union[Context, None]],
+    requests.Response,
+]
 StrPath: TypeAlias = t.Union[str, os.PathLike[str]]
 
 

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -36,7 +36,7 @@ if t.TYPE_CHECKING:
 
     from backoff.types import Details
 
-    from singer_sdk.helpers.types import Auth, Context
+    from singer_sdk.helpers.types import Auth, Context, RequestFunc
     from singer_sdk.singerlib import Schema
     from singer_sdk.tap_base import Tap
 
@@ -279,7 +279,7 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
 
         return msg
 
-    def request_decorator(self, func: t.Callable) -> t.Callable:
+    def request_decorator(self, func: RequestFunc) -> RequestFunc:
         """Instantiate a decorator for handling request failures.
 
         Uses a wait generator defined in `backoff_wait_generator` to


### PR DESCRIPTION
- **chore: Fix sample package dependencies**
- **refactor(taps): Add type parameters to decorated request function**

## Summary by Sourcery

Define a new RequestFunc type for HTTP request decorators and update sample packages to include msgspec dependency

Enhancements:
- Add a RequestFunc type alias and apply it to the request_decorator signature

Build:
- Add msgspec>=0.19.0 to tap-countries, tap-sqlite, and target-sqlite dependencies and update the lockfile