### PR TITLE
chore: Simplify type annotations to plugin class methods

### DIFF
--- a/singer_sdk/mapper_base.py
+++ b/singer_sdk/mapper_base.py
@@ -125,7 +125,7 @@ class InlineMapper(BaseSingerReader, BaseSingerWriter, metaclass=abc.ABCMeta):
 
     @classmethod
     def invoke(  # type: ignore[override]
-        cls: type[InlineMapper],
+        cls,
         *,
         about: bool = False,
         about_format: str | None = None,
@@ -153,7 +153,7 @@ class InlineMapper(BaseSingerReader, BaseSingerWriter, metaclass=abc.ABCMeta):
         mapper.listen(file_input)
 
     @classmethod
-    def get_singer_command(cls: type[InlineMapper]) -> click.Command:
+    def get_singer_command(cls) -> click.Command:
         """Execute standard CLI handler for inline mappers.
 
         Returns:

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -525,7 +525,7 @@ class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
         )
 
     @classmethod
-    def append_builtin_config(cls: type[PluginBase], config_jsonschema: dict) -> None:
+    def append_builtin_config(cls, config_jsonschema: dict) -> None:
         """Appends built-in config to `config_jsonschema` if not already set.
 
         To customize or disable this behavior, developers may either override this class
@@ -654,7 +654,7 @@ class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
         return _ConfigInput.from_cli_args(*value)
 
     @classmethod
-    def get_singer_command(cls: type[PluginBase]) -> click.Command:
+    def get_singer_command(cls) -> click.Command:
         """Handle command line execution.
 
         Returns:

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -523,7 +523,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
 
     @classmethod
     def invoke(  # type: ignore[override]
-        cls: type[Tap],
+        cls,
         *,
         about: bool = False,
         about_format: str | None = None,
@@ -618,7 +618,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         ctx.exit()
 
     @classmethod
-    def get_singer_command(cls: type[Tap]) -> click.Command:
+    def get_singer_command(cls) -> click.Command:
         """Execute standard CLI handler for taps.
 
         Returns:
@@ -698,7 +698,7 @@ class SQLTap(Tap):
         super().__init__(*args, **kwargs)
 
     @classmethod
-    def append_builtin_config(cls: type[SQLTap], config_jsonschema: dict) -> None:
+    def append_builtin_config(cls, config_jsonschema: dict) -> None:
         """Appends built-in config to `config_jsonschema` if not already set.
 
         Args:

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -553,7 +553,7 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
 
     @classmethod
     def invoke(  # type: ignore[override]
-        cls: type[Target],
+        cls,
         *,
         about: bool = False,
         about_format: str | None = None,
@@ -581,7 +581,7 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
         target.listen(file_input)
 
     @classmethod
-    def get_singer_command(cls: type[Target]) -> click.Command:
+    def get_singer_command(cls) -> click.Command:
         """Execute standard CLI handler for taps.
 
         Returns:
@@ -602,7 +602,7 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
         return command
 
     @classmethod
-    def append_builtin_config(cls: type[Target], config_jsonschema: dict) -> None:
+    def append_builtin_config(cls, config_jsonschema: dict) -> None:
         """Appends built-in config to `config_jsonschema` if not already set.
 
         To customize or disable this behavior, developers may either override this class
@@ -671,7 +671,7 @@ class SQLTarget(Target):
         return self._target_connector
 
     @classmethod
-    def append_builtin_config(cls: type[SQLTarget], config_jsonschema: dict) -> None:
+    def append_builtin_config(cls, config_jsonschema: dict) -> None:
         """Appends built-in config to `config_jsonschema` if not already set.
 
         To customize or disable this behavior, developers may either override this class


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove explicit cls: type[...] annotations from invoke, get_singer_command, and append_builtin_config methods in target_base, tap_base, mapper_base, and plugin_base