### PR TITLE
fix(deps): Restore `<4` Python version constraint for `backoff` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.9"
 
 dependencies = [
-    "backoff>=2.0.0",
+    "backoff>=2.0.0,<4",
     'backports-datetime-fromisoformat>=2.0.1; python_version<"3.11"',
     "click>=8.0,<9",
     "fsspec>=2024.9.0",

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -2590,7 +2590,7 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "backoff", specifier = ">=2.0.0" },
+    { name = "backoff", specifier = ">=2.0.0,<4" },
     { name = "backports-datetime-fromisoformat", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "click", specifier = ">=8.0,<9" },
     { name = "cryptography", marker = "extra == 'jwt'", specifier = ">=3.4.6" },


### PR DESCRIPTION
Downstream package that use Poetry seem to have trouble resolving when
it's not present :shrug:

## Summary by Sourcery

Restore upper version constraint for the backoff dependency to <4 to resolve Poetry resolution issues and update the lock file

Bug Fixes:
- Restrict backoff dependency to backoff>=2.0.0,<4 to avoid downstream Poetry resolution failures

Chores:
- Regenerate uv.lock to reflect the updated backoff version constraint