### PR TITLE
fix: sqlalchemy type property bug

### DIFF
--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -1561,7 +1561,7 @@ class SQLConnector:  # noqa: PLR0904
         raise ValueError(msg)
 
     @staticmethod
-    def _sort_types(  # noqa: PLR6301
+    def _sort_types(
         sql_types: t.Iterable[sqlalchemy.types.TypeEngine],
     ) -> t.Sequence[sqlalchemy.types.TypeEngine]:
         """Return the input types sorted from most to least compatible.

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -1560,8 +1560,8 @@ class SQLConnector:  # noqa: PLR0904
         msg = f"Unable to merge sql types: {', '.join([str(t) for t in sql_types])}"
         raise ValueError(msg)
 
+    @staticmethod
     def _sort_types(  # noqa: PLR6301
-        self,
         sql_types: t.Iterable[sqlalchemy.types.TypeEngine],
     ) -> t.Sequence[sqlalchemy.types.TypeEngine]:
         """Return the input types sorted from most to least compatible.

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -1588,6 +1588,9 @@ class SQLConnector:  # noqa: PLR0904
             len_ = int(getattr(sql_type, "length", 0) or 0)
 
             pytype = t.cast("type", sql_type.python_type)
+            if isinstance(pytype, property):
+                pytype = t.cast("type", sql_type().python_type)
+
             if issubclass(pytype, (str, bytes)):
                 return 900, len_
             if issubclass(pytype, datetime):

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -1560,8 +1560,8 @@ class SQLConnector:  # noqa: PLR0904
         msg = f"Unable to merge sql types: {', '.join([str(t) for t in sql_types])}"
         raise ValueError(msg)
 
-    @staticmethod
-    def _sort_types(
+    def _sort_types(  # noqa: PLR6301
+        self,
         sql_types: t.Iterable[sqlalchemy.types.TypeEngine],
     ) -> t.Sequence[sqlalchemy.types.TypeEngine]:
         """Return the input types sorted from most to least compatible.
@@ -1587,10 +1587,7 @@ class SQLConnector:  # noqa: PLR0904
 
             len_ = int(getattr(sql_type, "length", 0) or 0)
 
-            pytype = t.cast("type", sql_type.python_type)
-            if isinstance(pytype, property):
-                pytype = t.cast("type", sql_type().python_type)
-
+            pytype = sql_type.python_type
             if issubclass(pytype, (str, bytes)):
                 return 900, len_
             if issubclass(pytype, datetime):

--- a/tests/core/test_connector_sql.py
+++ b/tests/core/test_connector_sql.py
@@ -491,6 +491,36 @@ class TestConnectorSQL:  # noqa: PLR0904
             conn.execute(sqlalchemy.text(f"DROP TABLE {table1}"))
             conn.execute(sqlalchemy.text(f"DROP TABLE {table2}"))
 
+    def test_sort_types(self, connector: SQLConnector):
+        """Test that sort_types returns the correct order of SQL types."""
+        types = [
+            sqlalchemy.Integer,
+            sqlalchemy.String,
+            sqlalchemy.String(length=255),
+            sqlalchemy.Boolean,
+            sqlalchemy.DateTime,
+            sqlalchemy.Float,
+        ]
+        sorted_types = connector._sort_types(types)
+
+        # Check that types are sorted by their type precedence
+        expected_order = [
+            sqlalchemy.String(length=255),
+            sqlalchemy.String,
+            sqlalchemy.DateTime,
+            sqlalchemy.Float,
+            sqlalchemy.Integer,
+            sqlalchemy.Boolean,
+        ]
+
+        # Zip the sorted types with the expected order and compare
+        zipped_types = zip(sorted_types, expected_order)
+        for sorted_type, expected in zipped_types:
+            assert isinstance(sorted_type, expected.__class__)
+            sorted_len = int(getattr(sorted_type, "length", 0) or 0)
+            expected_len = int(getattr(expected, "length", 0) or 0)
+            assert sorted_len == expected_len
+
 
 class TestDummySQLConnector:
     @pytest.fixture

--- a/tests/core/test_connector_sql.py
+++ b/tests/core/test_connector_sql.py
@@ -493,33 +493,29 @@ class TestConnectorSQL:  # noqa: PLR0904
 
     def test_sort_types(self, connector: SQLConnector):
         """Test that sort_types returns the correct order of SQL types."""
-        types = [
-            sqlalchemy.Integer,
-            sqlalchemy.String,
-            sqlalchemy.String(length=255),
-            sqlalchemy.Boolean,
-            sqlalchemy.DateTime,
-            sqlalchemy.Float,
-        ]
-        sorted_types = connector._sort_types(types)
+        integer_type = sqlalchemy.Integer()
+        string_type = sqlalchemy.String()
+        string_255_type = sqlalchemy.String(length=255)
+        boolean_type = sqlalchemy.Boolean()
+        datetime_type = sqlalchemy.DateTime()
+        float_type = sqlalchemy.Float()
 
-        # Check that types are sorted by their type precedence
-        expected_order = [
-            sqlalchemy.String(length=255),
-            sqlalchemy.String,
-            sqlalchemy.DateTime,
-            sqlalchemy.Float,
-            sqlalchemy.Integer,
-            sqlalchemy.Boolean,
+        types: list[sqlalchemy.types.TypeEngine] = [
+            integer_type,
+            string_type,
+            string_255_type,
+            boolean_type,
+            datetime_type,
+            float_type,
         ]
-
-        # Zip the sorted types with the expected order and compare
-        zipped_types = zip(sorted_types, expected_order)
-        for sorted_type, expected in zipped_types:
-            assert isinstance(sorted_type, expected.__class__)
-            sorted_len = int(getattr(sorted_type, "length", 0) or 0)
-            expected_len = int(getattr(expected, "length", 0) or 0)
-            assert sorted_len == expected_len
+        assert connector._sort_types(types) == [
+            string_255_type,
+            string_type,
+            datetime_type,
+            float_type,
+            integer_type,
+            boolean_type,
+        ]
 
 
 class TestDummySQLConnector:


### PR DESCRIPTION
Fixes the case when `python_type` is implemented as a `property` on the SQLAlchemy type class. In that case, `sql_type.python_type` returns a `property` instance in stead of a python type. Instantiating the SQLAlchemy type first returns the correct python type.

```log
 =================================== FAILURES ===================================
__________ TestTargetDatabricks.test_target_camelcase_complex_schema ___________

self = <tests.core.DatabricksTargetCamelcaseComplexSchema object at 0x7fa532bc0370>
config = SuiteConfig(max_records_limit=150, ignore_no_records=False, ignore_no_records_for_streams=[])
resource = None
runner = <singer_sdk.testing.runners.TargetTestRunner object at 0x7fa5395cddf0>

    def run(
        self,
        config: SuiteConfig,
        resource: t.Any,
        runner: TargetTestRunner,
    ) -> None:
        """Test main run method.
    
        Args:
            config: SuiteConfig instance, to use for test.
            resource: A generic external resource, provided by a pytest fixture.
            runner: A Tap runner instance, to use with this test.
        """
        # get input from file
        if getattr(self, "singer_filepath", None):
            assert self.singer_filepath.is_file(), (
                f"Singer file {self.singer_filepath} does not exist."
            )
            runner.input_filepath = self.singer_filepath
>       super().run(config, resource, runner)

.tox/3.9/lib/python3.9/site-packages/singer_sdk/testing/templates.py:340: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.tox/3.9/lib/python3.9/site-packages/singer_sdk/testing/templates.py:303: in run
    super().run(config, resource, runner)
.tox/3.9/lib/python3.9/site-packages/singer_sdk/testing/templates.py:122: in run
    self.test()
.tox/3.9/lib/python3.9/site-packages/singer_sdk/testing/templates.py:68: in test
    self.runner.sync_all()
.tox/3.9/lib/python3.9/site-packages/singer_sdk/testing/runners.py:275: in sync_all
    stdout, stderr = self._execute_sync(
.tox/3.9/lib/python3.9/site-packages/singer_sdk/testing/runners.py:307: in _execute_sync
    target.process_lines(target_input)
.tox/3.9/lib/python3.9/site-packages/singer_sdk/plugin_base.py:828: in process_lines
    return self.message_reader.process_lines(
.tox/3.9/lib/python3.9/site-packages/singer_sdk/singerlib/encoding/base.py:70: in process_lines
    callback(line_dict)
.tox/3.9/lib/python3.9/site-packages/singer_sdk/target_base.py:396: in _process_schema_message
    _ = self.get_sink(
.tox/3.9/lib/python3.9/site-packages/singer_sdk/target_base.py:189: in get_sink
    return self.add_sink(stream_name, schema, key_properties)
.tox/3.9/lib/python3.9/site-packages/singer_sdk/target_base.py:259: in add_sink
    sink.setup()
target_databricks/sinks.py:389: in setup
    super().setup()
.tox/3.9/lib/python3.9/site-packages/singer_sdk/sinks/sql.py:245: in setup
    self.connector.prepare_table(
.tox/3.9/lib/python3.9/site-packages/singer_sdk/connectors/sql.py:1420: in prepare_table
    self.prepare_column(
.tox/3.9/lib/python3.9/site-packages/singer_sdk/connectors/sql.py:1469: in prepare_column
    self._adapt_column_type(
.tox/3.9/lib/python3.9/site-packages/singer_sdk/connectors/sql.py:1781: in _adapt_column_type
    compatible_sql_type = self.merge_sql_types([current_type, sql_type])
.tox/3.9/lib/python3.9/site-packages/singer_sdk/connectors/sql.py:1529: in merge_sql_types
    sql_types = self._sort_types(sql_types)
.tox/3.9/lib/python3.9/site-packages/singer_sdk/connectors/sql.py:1602: in _sort_types
    return sorted(sql_types, key=_get_type_sort_key, reverse=True)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

sql_type = <class 'sqlalchemy.sql.sqltypes.String'>

    def _get_type_sort_key(
        sql_type: sqlalchemy.types.TypeEngine,
    ) -> tuple[int, int]:
        # return rank, with higher numbers ranking first
    
        len_ = int(getattr(sql_type, "length", 0) or 0)
    
        pytype = t.cast("type", sql_type.python_type)
>       if issubclass(pytype, (str, bytes)):
E       TypeError: issubclass() arg 1 must be a class

.tox/3.9/lib/python3.9/site-packages/singer_sdk/connectors/sql.py:1591: TypeError
```

String source [here](https://github.com/sqlalchemy/sqlalchemy/blob/main/lib/sqlalchemy/sql/sqltypes.py#L265)


## Summary by Sourcery

Bug Fixes:
- Detect and handle python_type properties on SQLAlchemy type classes by instantiating the type before accessing the property

## Summary by Sourcery

Fix python_type property handling in SQL type sorting and add tests to ensure correct type precedence.

Bug Fixes:
- Instantiate SQLAlchemy type classes when python_type is defined as a property to avoid returning the property instance in type sorting.

Enhancements:
- Convert _sort_types to a staticmethod for improved clarity.

Tests:
- Add unit test to verify correct sorting order of SQL types, including length-based precedence.