### PR TITLE
WIP: Use backoff fork

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.9"
 
 dependencies = [
-    "backoff>=2.0.0,<4",
+    "backoff>=2.0.0",
     'backports-datetime-fromisoformat>=2.0.1; python_version<"3.11"',
     "click>=8.0,<9",
     "fsspec>=2024.9.0",
@@ -187,7 +187,6 @@ addopts = [
 ]
 filterwarnings = [
     "error",
-    "once:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning",  # https://github.com/litl/backoff/pull/220
     "once:No records were available to test:UserWarning",
     # https://github.com/meltano/sdk/issues/1354
     "ignore:The function singer_sdk.testing.get_standard_tap_tests is deprecated:DeprecationWarning",
@@ -467,6 +466,7 @@ max-args = 9
 required-version = ">=0.5.19"
 
 [tool.uv.sources]
+backoff = { git = "https://github.com/python-backoff/backoff.git" }
 mapper-custom = { workspace = true }
 tap-countries = { workspace = true }
 tap-csv = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -245,11 +245,7 @@ wheels = [
 [[package]]
 name = "backoff"
 version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
-]
+source = { git = "https://github.com/python-backoff/backoff.git#e66af014cee5963dac95f3eeeb7e5d8f6456ac39" }
 
 [[package]]
 name = "backports-datetime-fromisoformat"
@@ -794,7 +790,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -2590,7 +2586,7 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "backoff", specifier = ">=2.0.0,<4" },
+    { name = "backoff", git = "https://github.com/python-backoff/backoff.git" },
     { name = "backports-datetime-fromisoformat", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "click", specifier = ">=8.0,<9" },
     { name = "cryptography", marker = "extra == 'jwt'", specifier = ">=3.4.6" },


### PR DESCRIPTION
## Summary by Sourcery

Switch to a backoff fork for dependency management and remove an obsolete deprecation warning workaround

Enhancements:
- Remove the upper version bound on the backoff dependency and source it from the official git repository
- Drop the custom DeprecationWarning filter for asyncio.iscoroutinefunction now addressed upstream