### PR TITLE
refactor: Use slotted dataclasses

### DIFF
--- a/docs/batch.md
+++ b/docs/batch.md
@@ -94,7 +94,7 @@ Taps can optionally customize the batch file creation by implementing the [`get_
 class MyStream(Stream):
     def get_batches(self, records):
         return (
-            ParquetEncoding(compression="snappy"),
+            BaseBatchFileEncoding(format="parquet", compression="snappy"),
             [
                 "s3://my-bucket/my-batch-file-1.parquet",
                 "s3://my-bucket/my-batch-file-2.parquet",

--- a/singer_sdk/about.py
+++ b/singer_sdk/about.py
@@ -99,7 +99,7 @@ def python_versions(package_metadata: PackageMetadata) -> list[str]:
     )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class AboutInfo:
     """About information for a plugin."""
 

--- a/singer_sdk/helpers/_batch.py
+++ b/singer_sdk/helpers/_batch.py
@@ -86,7 +86,7 @@ class SDKBatchMessage(Message):
         self.type = SingerMessageType.BATCH
 
 
-@dataclass(slots=True)
+@dataclass
 class StorageTarget:
     """Storage target for batch files."""
 

--- a/singer_sdk/helpers/_batch.py
+++ b/singer_sdk/helpers/_batch.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 
 from upath import UPath
 
+from singer_sdk.helpers._compat import deprecated
 from singer_sdk.singerlib.messages import Message, SingerMessageType
 
 if t.TYPE_CHECKING:
@@ -44,6 +45,22 @@ class BaseBatchFileEncoding:
     def from_dict(cls, data: dict[str, t.Any]) -> BaseBatchFileEncoding:
         """Create an encoding from a dictionary."""
         return cls(**data)
+
+
+@deprecated("Use BaseBatchFileEncoding with format='jsonl' instead")
+@dataclass(slots=True)
+class JSONLinesEncoding(BaseBatchFileEncoding):
+    """JSON Lines encoding for batch files."""
+
+    format: t.Literal["jsonl"] = "jsonl"
+
+
+@deprecated("Use BaseBatchFileEncoding with format='parquet' instead")
+@dataclass(slots=True)
+class ParquetEncoding(BaseBatchFileEncoding):
+    """Parquet encoding for batch files."""
+
+    format: t.Literal["parquet"] = "parquet"
 
 
 @dataclass(slots=True)

--- a/singer_sdk/helpers/_batch.py
+++ b/singer_sdk/helpers/_batch.py
@@ -29,57 +29,24 @@ class BatchFileFormat(str, enum.Enum):
     """Parquet format."""
 
 
-@dataclass
+@dataclass(slots=True)
 class BaseBatchFileEncoding:
     """Base class for batch file encodings."""
 
-    registered_encodings: t.ClassVar[dict[str, type[BaseBatchFileEncoding]]] = {}
-    __encoding_format__: t.ClassVar[str] = "OVERRIDE_ME"
-
     # Base encoding fields
-    format: str = field(init=False)
+    format: str
     """The format of the batch file."""
 
     compression: str | None = None
     """The compression of the batch file."""
 
-    def __init_subclass__(cls, **kwargs: t.Any) -> None:
-        """Register subclasses.
-
-        Args:
-            **kwargs: Keyword arguments.
-        """
-        super().__init_subclass__(**kwargs)
-        cls.registered_encodings[cls.__encoding_format__] = cls
-
-    def __post_init__(self) -> None:
-        """Post-init hook."""
-        self.format = self.__encoding_format__
-
     @classmethod
     def from_dict(cls, data: dict[str, t.Any]) -> BaseBatchFileEncoding:
         """Create an encoding from a dictionary."""
-        data = data.copy()
-        encoding_format = data.pop("format")
-        encoding_cls = cls.registered_encodings[encoding_format]
-        return encoding_cls(**data)
+        return cls(**data)
 
 
-@dataclass
-class JSONLinesEncoding(BaseBatchFileEncoding):
-    """JSON Lines encoding for batch files."""
-
-    __encoding_format__ = "jsonl"
-
-
-@dataclass
-class ParquetEncoding(BaseBatchFileEncoding):
-    """Parquet encoding for batch files."""
-
-    __encoding_format__ = "parquet"
-
-
-@dataclass
+@dataclass(slots=True)
 class SDKBatchMessage(Message):
     """Singer batch message in the Meltano Singer SDK flavor."""
 
@@ -102,7 +69,7 @@ class SDKBatchMessage(Message):
         self.type = SingerMessageType.BATCH
 
 
-@dataclass
+@dataclass(slots=True)
 class StorageTarget:
     """Storage target for batch files."""
 
@@ -211,7 +178,7 @@ class StorageTarget:
             yield f
 
 
-@dataclass
+@dataclass(slots=True)
 class BatchConfig:
     """Batch configuration."""
 

--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -64,7 +64,7 @@ class Metric(str, enum.Enum):
     BATCH_PROCESSING_TIME = "batch_processing_time"
 
 
-@dataclass
+@dataclass(slots=True)
 class Point(t.Generic[_TVal]):
     """An individual metric measurement."""
 

--- a/singer_sdk/singerlib/catalog.py
+++ b/singer_sdk/singerlib/catalog.py
@@ -40,7 +40,7 @@ class SelectionMask(dict[Breadcrumb, bool]):
         return self[breadcrumb[:-2]] if len(breadcrumb) >= 2 else True  # noqa: PLR2004
 
 
-@dataclass
+@dataclass(slots=True)
 class Metadata:
     """Base stream or property metadata."""
 
@@ -88,7 +88,7 @@ class Metadata:
         return result
 
 
-@dataclass
+@dataclass(slots=True)
 class StreamMetadata(Metadata):
     """Stream metadata."""
 
@@ -298,7 +298,7 @@ class MetadataMapping(dict[Breadcrumb, AnyMetadata]):
         return parent_value or False
 
 
-@dataclass
+@dataclass(slots=True)
 class CatalogEntry:
     """Singer catalog entry."""
 

--- a/singer_sdk/singerlib/encoding/simple.py
+++ b/singer_sdk/singerlib/encoding/simple.py
@@ -31,7 +31,7 @@ def exclude_null_dict(pairs: list[tuple[str, t.Any]]) -> dict[str, t.Any]:
     return {key: value for key, value in pairs if value is not None}
 
 
-@dataclass
+@dataclass(slots=True)
 class Message:
     """Singer base message."""
 
@@ -63,7 +63,7 @@ class Message:
         return cls(**data)
 
 
-@dataclass
+@dataclass(slots=True)
 class RecordMessage(Message):
     """Singer record message."""
 
@@ -140,7 +140,7 @@ class RecordMessage(Message):
             self.time_extracted = self.time_extracted.astimezone(timezone.utc)
 
 
-@dataclass
+@dataclass(slots=True)
 class SchemaMessage(Message):
     """Singer schema message."""
 
@@ -171,7 +171,7 @@ class SchemaMessage(Message):
             raise ValueError(msg)
 
 
-@dataclass
+@dataclass(slots=True)
 class StateMessage(Message):
     """Singer state message."""
 
@@ -183,7 +183,7 @@ class StateMessage(Message):
         self.type = SingerMessageType.STATE
 
 
-@dataclass
+@dataclass(slots=True)
 class ActivateVersionMessage(Message):
     """Singer activate version message."""
 

--- a/singer_sdk/singerlib/schema.py
+++ b/singer_sdk/singerlib/schema.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import typing as t
-from dataclasses import dataclass
+from dataclasses import KW_ONLY, dataclass
 
 from referencing import Registry
 from referencing.jsonschema import DRAFT202012
@@ -49,7 +49,7 @@ STANDARD_KEYS = [
 ]
 
 
-@dataclass
+@dataclass(slots=True)
 class Schema:
     """Object model for JSON Schema.
 
@@ -93,8 +93,7 @@ class Schema:
     deprecated: bool | None = None
     oneOf: t.Any | None = None  # noqa: N815
 
-    # TODO: Use dataclass.KW_ONLY when Python 3.9 support is dropped
-    # _: KW_ONLY  # noqa: ERA001
+    _: KW_ONLY
 
     def to_dict(self) -> dict[str, t.Any]:
         """Return the raw JSON Schema as a (possibly nested) dict.
@@ -112,12 +111,12 @@ class Schema:
 
         for key in STANDARD_KEYS:
             attr = key.replace("-", "_")
-            if (val := self.__dict__.get(attr)) is not None:
+            if (val := getattr(self, attr, None)) is not None:
                 result[key] = val
 
         for key in META_KEYS:
             attr = key.replace("-", "_")
-            if (val := self.__dict__.get(attr)) is not None:
+            if (val := getattr(self, attr, None)) is not None:
                 result[f"${key}"] = val
 
         return result

--- a/singer_sdk/testing/config.py
+++ b/singer_sdk/testing/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 
-@dataclass
+@dataclass(slots=True)
 class SuiteConfig:
     """Test Suite Config, passed to each test.
 

--- a/singer_sdk/testing/factory.py
+++ b/singer_sdk/testing/factory.py
@@ -39,7 +39,7 @@ class StreamAttributeTestParams(t.NamedTuple):
     attribute_name: str
 
 
-@dataclass
+@dataclass(slots=True)
 class TestParam:
     """Test parameters."""
 

--- a/singer_sdk/testing/suites.py
+++ b/singer_sdk/testing/suites.py
@@ -64,7 +64,7 @@ def __getattr__(name: str) -> t.Any:  # noqa: ANN401
     raise AttributeError(msg)
 
 
-@dataclass
+@dataclass(slots=True)
 class SingerTestSuite(t.Generic[T]):
     """Test Suite container class."""
 

--- a/tests/contrib/batch/test_jsonl.py
+++ b/tests/contrib/batch/test_jsonl.py
@@ -11,8 +11,6 @@ from singer_sdk.contrib.batch_encoder_jsonl import JSONLinesBatcher
 from singer_sdk.helpers._batch import (
     BaseBatchFileEncoding,
     BatchConfig,
-    JSONLinesEncoding,
-    ParquetEncoding,
     StorageTarget,
 )
 
@@ -20,10 +18,22 @@ from singer_sdk.helpers._batch import (
 @pytest.mark.parametrize(
     "encoding,expected",
     [
-        (JSONLinesEncoding("gzip"), {"compression": "gzip", "format": "jsonl"}),
-        (JSONLinesEncoding(), {"compression": None, "format": "jsonl"}),
-        (ParquetEncoding("gzip"), {"compression": "gzip", "format": "parquet"}),
-        (ParquetEncoding(), {"compression": None, "format": "parquet"}),
+        (
+            BaseBatchFileEncoding(format="jsonl", compression="gzip"),
+            {"compression": "gzip", "format": "jsonl"},
+        ),
+        (
+            BaseBatchFileEncoding(format="jsonl"),
+            {"compression": None, "format": "jsonl"},
+        ),
+        (
+            BaseBatchFileEncoding(format="parquet", compression="gzip"),
+            {"compression": "gzip", "format": "parquet"},
+        ),
+        (
+            BaseBatchFileEncoding(format="parquet"),
+            {"compression": None, "format": "parquet"},
+        ),
     ],
     ids=[
         "jsonl-compression-gzip",
@@ -141,7 +151,7 @@ def test_json_lines_batcher():
         "tap-test",
         "stream-test",
         batch_config=BatchConfig(
-            encoding=JSONLinesEncoding("gzip"),
+            encoding=BaseBatchFileEncoding(format="jsonl", compression="gzip"),
             storage=StorageTarget("file:///tmp/sdk-batches"),
             batch_size=2,
         ),
@@ -167,7 +177,7 @@ def test_batcher_with_jsonl_encoding():
         "tap-test",
         "stream-test",
         batch_config=BatchConfig(
-            encoding=JSONLinesEncoding("gzip"),
+            encoding=BaseBatchFileEncoding(format="jsonl", compression="gzip"),
             storage=StorageTarget("file:///tmp/sdk-batches"),
             batch_size=2,
         ),

--- a/tests/contrib/batch/test_parquet.py
+++ b/tests/contrib/batch/test_parquet.py
@@ -10,8 +10,8 @@ import pytest
 from singer_sdk.batch import Batcher
 from singer_sdk.contrib.batch_encoder_parquet import ParquetBatcher
 from singer_sdk.helpers._batch import (
+    BaseBatchFileEncoding,
     BatchConfig,
-    ParquetEncoding,
     StorageTarget,
 )
 
@@ -36,7 +36,7 @@ def test_batcher(tmp_path: Path) -> None:
     root = tmp_path.joinpath("batches")
     root.mkdir()
     config = BatchConfig(
-        encoding=ParquetEncoding(),
+        encoding=BaseBatchFileEncoding(format="parquet"),
         storage=StorageTarget(root=str(root)),
         batch_size=2,
     )
@@ -56,7 +56,7 @@ def test_batcher_gzip(tmp_path: Path) -> None:
     root = tmp_path.joinpath("batches")
     root.mkdir()
     config = BatchConfig(
-        encoding=ParquetEncoding(compression="gzip"),
+        encoding=BaseBatchFileEncoding(format="parquet", compression="gzip"),
         storage=StorageTarget(root=str(root)),
         batch_size=2,
     )
@@ -77,7 +77,7 @@ def test_parquet_batcher():
         "tap-test",
         "stream-test",
         batch_config=BatchConfig(
-            encoding=ParquetEncoding("gzip"),
+            encoding=BaseBatchFileEncoding(format="parquet", compression="gzip"),
             storage=StorageTarget("file:///tmp/sdk-batches"),
             batch_size=2,
         ),
@@ -104,7 +104,7 @@ def test_batcher_with_parquet_encoding():
         "tap-test",
         "stream-test",
         batch_config=BatchConfig(
-            encoding=ParquetEncoding("gzip"),
+            encoding=BaseBatchFileEncoding(format="parquet", compression="gzip"),
             storage=StorageTarget("file:///tmp/sdk-batches"),
             batch_size=2,
         ),

--- a/tests/core/test_singer_messages.py
+++ b/tests/core/test_singer_messages.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import pytest
 
 from singer_sdk.helpers._batch import (
-    JSONLinesEncoding,
-    ParquetEncoding,
+    BaseBatchFileEncoding,
     SDKBatchMessage,
 )
 from singer_sdk.singerlib import SingerMessageType
@@ -16,7 +15,7 @@ from singer_sdk.singerlib import SingerMessageType
         (
             SDKBatchMessage(
                 stream="test_stream",
-                encoding=JSONLinesEncoding("gzip"),
+                encoding=BaseBatchFileEncoding(format="jsonl", compression="gzip"),
                 manifest=[
                     "path/to/file1.jsonl.gz",
                     "path/to/file2.jsonl.gz",
@@ -35,7 +34,7 @@ from singer_sdk.singerlib import SingerMessageType
         (
             SDKBatchMessage(
                 stream="test_stream",
-                encoding=ParquetEncoding("gzip"),
+                encoding=BaseBatchFileEncoding(format="parquet", compression="gzip"),
                 manifest=[
                     "path/to/file1.parquet.gz",
                     "path/to/file2.parquet.gz",


### PR DESCRIPTION
## Summary by Sourcery

Convert various SDK classes to use slotted dataclasses and unify batch file encoding under BaseBatchFileEncoding with explicit format, deprecating the old JSONLinesEncoding and ParquetEncoding classes

Enhancements:
- Enable slots on dataclasses for Message, metadata, catalog, testing, and batch classes to reduce memory usage
- Consolidate batch file encoding into BaseBatchFileEncoding with explicit format field and remove subclass registry logic
- Add deprecation notices to JSONLinesEncoding and ParquetEncoding in favor of BaseBatchFileEncoding

Documentation:
- Update batch.md to illustrate BaseBatchFileEncoding usage instead of the specialized encoding classes

Tests:
- Revise batch and message tests to instantiate BaseBatchFileEncoding directly rather than JSONLinesEncoding or ParquetEncoding