### PR TITLE
ci: Set Codspeed mode explicitly to `instrumentation`

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -61,3 +61,4 @@ jobs:
       with:
         token: ${{ secrets.CODSPEED_TOKEN }}
         run: pytest tests/ --codspeed
+        mode: instrumentation


### PR DESCRIPTION
We could also set it to `walltime`, but that requires additional changes: https://codspeed.io/docs/instruments/walltime