### PR TITLE
chore: Bump Ruff to 0.13.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
   - id: check-readthedocs
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.12
+  rev: v0.13.0
   hooks:
   - id: ruff-check
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
@@ -64,7 +64,7 @@ repos:
       )$
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.8.15
+  rev: 0.8.16
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.10
+  rev: v0.13.0
   hooks:
   - id: ruff-check
     args: [--diff]
@@ -35,7 +35,7 @@ repos:
     args: [--diff]
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.8.13
+  rev: 0.8.16
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -78,7 +78,12 @@ addopts = [
 [tool.mypy]
 warn_unused_configs = true
 
+[tool.ruff]
+line-length = 100
+required-version = ">=0.13"
+
 [tool.ruff.lint]
+future-annotations = true
 ignore = [
     "COM812",  # missing-trailing-comma
 ]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.10
+  rev: v0.13.0
   hooks:
   - id: ruff-check
     args: [--diff]
@@ -35,7 +35,7 @@ repos:
     args: [--diff]
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.8.13
+  rev: 0.8.16
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -97,7 +97,12 @@ warn_unused_configs = true
 plugins = "sqlmypy"
 {%- endif %}
 
+[tool.ruff]
+line-length = 100
+required-version = ">=0.13"
+
 [tool.ruff.lint]
+future-annotations = true
 ignore = [
     "COM812",  # missing-trailing-comma
 ]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
@@ -132,9 +132,7 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
 
     def to_jsonschema_type(
         self,
-        from_type: str
-        | sqlalchemy.types.TypeEngine
-        | type[sqlalchemy.types.TypeEngine],
+        from_type: str | sqlalchemy.types.TypeEngine | type[sqlalchemy.types.TypeEngine],
     ) -> dict:
         """Returns a JSON Schema equivalent for the given SQL type.
 

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.10
+  rev: v0.13.0
   hooks:
   - id: ruff-check
     args: [--diff]
@@ -35,7 +35,7 @@ repos:
     args: [--diff]
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.8.13
+  rev: 0.8.16
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -83,7 +83,12 @@ packages = [
 [tool.mypy]
 warn_unused_configs = true
 
+[tool.ruff]
+line-length = 100
+required-version = ">=0.13"
+
 [tool.ruff.lint]
+future-annotations = true
 ignore = [
     "COM812",  # missing-trailing-comma
 ]

--- a/packages/tap-countries/tap_countries/tap.py
+++ b/packages/tap-countries/tap_countries/tap.py
@@ -8,9 +8,14 @@ See the online explorer and query builder here:
 
 from __future__ import annotations
 
-from singer_sdk import Stream, Tap
+import typing as t
+
+from singer_sdk import Tap
 from singer_sdk.contrib.msgspec import MsgSpecWriter
 from tap_countries.streams import ContinentsStream, CountriesStream
+
+if t.TYPE_CHECKING:
+    from singer_sdk import Stream
 
 
 class TapCountries(Tap):

--- a/packages/tap-fake-people/tap_fake_people/tap.py
+++ b/packages/tap-fake-people/tap_fake_people/tap.py
@@ -9,7 +9,7 @@ from faker import Faker
 
 from singer_sdk import Stream, Tap
 from singer_sdk import typing as th
-from singer_sdk.singerlib import Message, SingerMessageType
+from singer_sdk.singerlib import SingerMessageType
 
 if sys.version_info >= (3, 12):
     from typing import override  # noqa: ICN003
@@ -20,6 +20,7 @@ if t.TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
     from singer_sdk.helpers.types import Context, Record
+    from singer_sdk.singerlib import Message
 
 
 class FakePeopleStream(Stream):

--- a/packages/tap-gitlab/tap_gitlab/tap.py
+++ b/packages/tap-gitlab/tap_gitlab/tap.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from singer_sdk import Stream, Tap
+import typing as t
+
+from singer_sdk import Tap
 from singer_sdk.typing import (
     ArrayType,
     DateTimeType,
@@ -18,6 +20,9 @@ from tap_gitlab.streams import (
     ProjectsStream,
     ReleasesStream,
 )
+
+if t.TYPE_CHECKING:
+    from singer_sdk import Stream
 
 DEFAULT_URL_BASE = "https://gitlab.com/api/v4"
 STREAM_TYPES = [

--- a/packages/tap-hostile/tap_hostile/tap.py
+++ b/packages/tap-hostile/tap_hostile/tap.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-from singer_sdk import Stream, Tap
+import typing as t
+
+from singer_sdk import Tap
 from singer_sdk.typing import PropertiesList
 from tap_hostile.streams import HostilePropertyNamesStream
+
+if t.TYPE_CHECKING:
+    from singer_sdk import Stream
 
 
 class TapHostile(Tap):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,13 +331,14 @@ extend-exclude = [
     "cookiecutter/*",
 ]
 line-length = 88
-required-version = ">=0.9"
+required-version = ">=0.13"
 
 [tool.ruff.format]
 docstring-code-format = true
 
 [tool.ruff.lint]
 explicit-preview-rules = false
+future-annotations = true
 ignore = [
     "N818",    # Exception name should be named with an Error suffix
     "COM812",  # missing-trailing-comma

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -22,7 +22,6 @@ import singer_sdk.typing as th
 from singer_sdk.exceptions import MapExpressionError, StreamMapConfigError
 from singer_sdk.helpers._catalog import get_selected_schema
 from singer_sdk.helpers._flattening import (
-    FlatteningOptions,
     flatten_record,
     flatten_schema,
     get_flattening_options,
@@ -31,6 +30,7 @@ from singer_sdk.helpers._flattening import (
 if t.TYPE_CHECKING:
     from faker import Faker
 
+    from singer_sdk.helpers._flattening import FlatteningOptions
     from singer_sdk.singerlib.catalog import Catalog
 
 

--- a/singer_sdk/mapper_base.py
+++ b/singer_sdk/mapper_base.py
@@ -7,13 +7,14 @@ import typing as t
 
 import click
 
-from singer_sdk.helpers.capabilities import CapabilitiesEnum, PluginCapabilities
+from singer_sdk.helpers.capabilities import PluginCapabilities
 from singer_sdk.plugin_base import BaseSingerReader, BaseSingerWriter, _ConfigInput
 
 if t.TYPE_CHECKING:
     from pathlib import PurePath
 
     import singer_sdk.singerlib as singer
+    from singer_sdk.helpers.capabilities import CapabilitiesEnum
     from singer_sdk.singerlib.encoding.base import (
         GenericSingerReader,
         GenericSingerWriter,

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -14,7 +14,7 @@ import typing as t
 import warnings
 from importlib import metadata
 from pathlib import Path, PurePath
-from types import FrameType, MappingProxyType
+from types import MappingProxyType
 
 import click
 
@@ -32,7 +32,6 @@ from singer_sdk.helpers._util import read_json_file
 from singer_sdk.helpers.capabilities import (
     FLATTENING_CONFIG,
     STREAM_MAPS_CONFIG,
-    CapabilitiesEnum,
     PluginCapabilities,
 )
 from singer_sdk.io_base import SingerMessageType, SingerReader, SingerWriter
@@ -43,8 +42,11 @@ from singer_sdk.typing import (
 )
 
 if t.TYPE_CHECKING:
+    from types import FrameType
+
     from jsonschema import ValidationError
 
+    from singer_sdk.helpers.capabilities import CapabilitiesEnum
     from singer_sdk.helpers.types import StrPath
     from singer_sdk.singerlib.encoding.base import (
         GenericSingerReader,

--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -10,7 +10,6 @@ import sys
 import time
 import typing as t
 from functools import cached_property
-from gzip import GzipFile
 from gzip import open as gzip_open
 from types import MappingProxyType
 
@@ -22,12 +21,7 @@ from singer_sdk.exceptions import (
     InvalidRecord,
     MissingKeyPropertiesError,
 )
-from singer_sdk.helpers._batch import (
-    BaseBatchFileEncoding,
-    BatchConfig,
-    BatchFileFormat,
-    StorageTarget,
-)
+from singer_sdk.helpers._batch import BatchConfig, BatchFileFormat, StorageTarget
 from singer_sdk.helpers._compat import (
     date_fromisoformat,
     datetime_fromisoformat,
@@ -47,8 +41,10 @@ else:
     from typing_extensions import override
 
 if t.TYPE_CHECKING:
+    from gzip import GzipFile
     from logging import Logger
 
+    from singer_sdk.helpers._batch import BaseBatchFileEncoding
     from singer_sdk.target_base import Target
 
 

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -23,11 +23,7 @@ from singer_sdk.exceptions import (
     InvalidStreamSortException,
     MaxRecordsLimitException,
 )
-from singer_sdk.helpers._batch import (
-    BaseBatchFileEncoding,
-    BatchConfig,
-    SDKBatchMessage,
-)
+from singer_sdk.helpers._batch import BatchConfig, SDKBatchMessage
 from singer_sdk.helpers._catalog import pop_deselected_record_properties
 from singer_sdk.helpers._compat import (
     SingerSDKDeprecationWarning,
@@ -52,13 +48,15 @@ from singer_sdk.helpers._typing import (
     is_datetime_type,
 )
 from singer_sdk.helpers._util import utc_now
-from singer_sdk.mapper import RemoveRecordTransform, SameRecordTransform, StreamMap
+from singer_sdk.mapper import RemoveRecordTransform, SameRecordTransform
 
 if t.TYPE_CHECKING:
     import logging
 
     from singer_sdk.helpers import types
+    from singer_sdk.helpers._batch import BaseBatchFileEncoding
     from singer_sdk.helpers._compat import Traversable
+    from singer_sdk.mapper import StreamMap
     from singer_sdk.singerlib.catalog import StreamMetadata
     from singer_sdk.tap_base import Tap
 

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -22,7 +22,6 @@ from singer_sdk.exceptions import FatalAPIError, RetriableAPIError
 from singer_sdk.helpers._compat import SingerSDKDeprecationWarning
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk.pagination import (
-    BaseAPIPaginator,
     JSONPathPaginator,
     LegacyStreamPaginator,
     SimpleHeaderPaginator,
@@ -37,6 +36,7 @@ if t.TYPE_CHECKING:
     from backoff.types import Details
 
     from singer_sdk.helpers.types import Auth, Context, RequestFunc
+    from singer_sdk.pagination import BaseAPIPaginator
     from singer_sdk.singerlib import Schema
     from singer_sdk.tap_base import Tap
 

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 import singer_sdk.helpers._catalog as catalog
 from singer_sdk.connectors import SQLConnector
-from singer_sdk.singerlib import CatalogEntry, MetadataMapping
+from singer_sdk.singerlib import CatalogEntry
 from singer_sdk.streams.core import REPLICATION_INCREMENTAL, Stream
 
 if t.TYPE_CHECKING:
@@ -18,6 +18,7 @@ if t.TYPE_CHECKING:
 
     from singer_sdk.connectors.sql import FullyQualifiedName
     from singer_sdk.helpers.types import Context, Record
+    from singer_sdk.singerlib import MetadataMapping
     from singer_sdk.tap_base import Tap
 
 

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -23,7 +23,6 @@ from singer_sdk.helpers._util import dump_json, load_json, read_json_file
 from singer_sdk.helpers.capabilities import (
     BATCH_CONFIG,
     SQL_TAP_USE_SINGER_DECIMAL,
-    CapabilitiesEnum,
     PluginCapabilities,
     TapCapabilities,
 )
@@ -37,6 +36,7 @@ if t.TYPE_CHECKING:
 
     from singer_sdk.connectors import SQLConnector
     from singer_sdk.helpers import types
+    from singer_sdk.helpers.capabilities import CapabilitiesEnum
     from singer_sdk.mapper import PluginMapper
     from singer_sdk.singerlib.encoding.base import GenericSingerWriter
     from singer_sdk.streams import SQLStream, Stream

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -23,7 +23,6 @@ from singer_sdk.helpers.capabilities import (
     TARGET_LOAD_METHOD_CONFIG,
     TARGET_SCHEMA_CONFIG,
     TARGET_VALIDATE_RECORDS_CONFIG,
-    CapabilitiesEnum,
     PluginCapabilities,
     TargetCapabilities,
 )
@@ -36,6 +35,7 @@ if t.TYPE_CHECKING:
     from types import FrameType
 
     from singer_sdk.connectors import SQLConnector
+    from singer_sdk.helpers.capabilities import CapabilitiesEnum
     from singer_sdk.mapper import PluginMapper
     from singer_sdk.singerlib.encoding.base import GenericSingerReader
     from singer_sdk.sinks import Sink, SQLSink

--- a/singer_sdk/testing/factory.py
+++ b/singer_sdk/testing/factory.py
@@ -10,7 +10,6 @@ import pytest
 from .config import SuiteConfig
 from .runners import TapTestRunner, TargetTestRunner
 from .suites import (
-    SingerTestSuite,
     tap_stream_attribute_tests,
     tap_stream_tests,
     tap_tests,
@@ -24,6 +23,8 @@ if t.TYPE_CHECKING:
         StreamTestTemplate,
         TapTestTemplate,
     )
+
+    from .suites import SingerTestSuite
 
 
 class StreamTestParams(t.NamedTuple):

--- a/singer_sdk/testing/tap_tests.py
+++ b/singer_sdk/testing/tap_tests.py
@@ -9,13 +9,13 @@ import pytest
 from jsonschema.exceptions import SchemaError
 
 import singer_sdk.helpers._typing as th
-from singer_sdk import Tap
 from singer_sdk.helpers._compat import datetime_fromisoformat
 from singer_sdk.typing import DEFAULT_JSONSCHEMA_VALIDATOR
 
 from .templates import AttributeTestTemplate, StreamTestTemplate, TapTestTemplate
 
 if t.TYPE_CHECKING:
+    from singer_sdk import Tap
     from singer_sdk.streams.core import Stream
 
 

--- a/singer_sdk/testing/templates.py
+++ b/singer_sdk/testing/templates.py
@@ -9,11 +9,12 @@ import warnings
 from functools import cached_property
 
 from singer_sdk.testing import target_test_streams
-from singer_sdk.testing.runners import SingerTestRunner, TapTestRunner, TargetTestRunner
+from singer_sdk.testing.runners import SingerTestRunner, TargetTestRunner
 
 if t.TYPE_CHECKING:
     from singer_sdk.helpers._compat import Traversable
     from singer_sdk.streams import Stream
+    from singer_sdk.testing.runners import TapTestRunner
 
     from .config import SuiteConfig
 

--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -56,7 +56,7 @@ import json
 import typing as t
 
 import sqlalchemy.types
-from jsonschema import ValidationError, validators
+from jsonschema import validators
 
 from singer_sdk.helpers._compat import SingerSDKDeprecationWarning, deprecated
 from singer_sdk.helpers._typing import (
@@ -67,6 +67,7 @@ from singer_sdk.helpers._typing import (
 )
 
 if t.TYPE_CHECKING:
+    from jsonschema import ValidationError
     from jsonschema.protocols import Validator
 
 __all__ = [

--- a/tests/core/rest/test_authenticators.py
+++ b/tests/core/rest/test_authenticators.py
@@ -8,11 +8,7 @@ import typing as t
 import jwt
 import pytest
 import time_machine
-from cryptography.hazmat.primitives.asymmetric.rsa import (
-    RSAPrivateKey,
-    RSAPublicKey,
-    generate_private_key,
-)
+from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
     NoEncryption,
@@ -29,6 +25,10 @@ from singer_sdk.authenticators import (
 
 if t.TYPE_CHECKING:
     import requests_mock
+    from cryptography.hazmat.primitives.asymmetric.rsa import (
+        RSAPrivateKey,
+        RSAPublicKey,
+    )
 
     from singer_sdk.streams import RESTStream
     from singer_sdk.tap_base import Tap

--- a/tests/core/rest/test_pagination.py
+++ b/tests/core/rest/test_pagination.py
@@ -7,7 +7,7 @@ import typing as t
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-from requests import PreparedRequest, Response
+from requests import Response
 
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk.pagination import (
@@ -24,6 +24,8 @@ from singer_sdk.pagination import (
 from singer_sdk.streams.rest import RESTStream
 
 if t.TYPE_CHECKING:
+    from requests import PreparedRequest
+
     from singer_sdk.tap_base import Tap
 
 

--- a/tests/core/sinks/test_type_checker.py
+++ b/tests/core/sinks/test_type_checker.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import sys
+import typing as t
 
 import pytest
 
-from singer_sdk.sinks.core import BaseJSONSchemaValidator, InvalidJSONSchema, Sink
+from singer_sdk.sinks.core import InvalidJSONSchema, Sink
 from singer_sdk.target_base import Target
+
+if t.TYPE_CHECKING:
+    from singer_sdk.sinks.core import BaseJSONSchemaValidator
 
 if sys.version_info >= (3, 12):
     from typing import override  # noqa: ICN003

--- a/tests/core/targets/test_target_sql.py
+++ b/tests/core/targets/test_target_sql.py
@@ -4,8 +4,11 @@ import typing as t
 
 import pytest
 
-from singer_sdk.helpers.capabilities import CapabilitiesEnum, TargetCapabilities
+from singer_sdk.helpers.capabilities import TargetCapabilities
 from singer_sdk.target_base import SQLTarget
+
+if t.TYPE_CHECKING:
+    from singer_sdk.helpers.capabilities import CapabilitiesEnum
 
 
 class SQLTargetMock(SQLTarget):

--- a/tests/core/test_jsonschema_helpers.py
+++ b/tests/core/test_jsonschema_helpers.py
@@ -42,7 +42,6 @@ from singer_sdk.typing import (
     IPv4Type,
     IPv6Type,
     JSONPointerType,
-    JSONTypeHelper,
     ObjectType,
     PropertiesList,
     Property,
@@ -62,6 +61,7 @@ if t.TYPE_CHECKING:
     from pytest_snapshot.plugin import Snapshot
 
     from singer_sdk.streams.core import Stream
+    from singer_sdk.typing import JSONTypeHelper
 
 TYPE_FN_CHECKS: set[t.Callable] = {
     is_array_type,

--- a/tests/packages/test_tap_csv.py
+++ b/tests/packages/test_tap_csv.py
@@ -6,10 +6,12 @@ import typing as t
 import pytest
 from tap_csv.tap import TapCSV
 
-from singer_sdk.testing import SuiteConfig, TapTestRunner, get_tap_test_class
+from singer_sdk.testing import SuiteConfig, get_tap_test_class
 
 if t.TYPE_CHECKING:
     from tap_csv.client import CSVStream
+
+    from singer_sdk.testing import TapTestRunner
 
 _TestCSVMerge = get_tap_test_class(
     tap_class=TapCSV,

--- a/tests/singerlib/test_catalog.py
+++ b/tests/singerlib/test_catalog.py
@@ -181,7 +181,10 @@ def test_catalog_parsing():
     assert catalog.streams[0].database == "app_db"
     assert catalog.streams[0].row_count == 10000
     assert catalog.streams[0].stream_alias == "test_alias"
-    assert catalog.get_stream("test").tap_stream_id == "test"
+
+    test_stream = catalog.get_stream("test")
+    assert test_stream is not None
+    assert test_stream.tap_stream_id == "test"
     assert catalog["test"].metadata.to_list() == catalog_dict["streams"][0]["metadata"]
     assert catalog["test"].tap_stream_id == catalog_dict["streams"][0]["tap_stream_id"]
     assert catalog["test"].schema.to_dict() == {"type": "object"}

--- a/tests/singerlib/test_schema.py
+++ b/tests/singerlib/test_schema.py
@@ -461,6 +461,7 @@ def test_schema_from_dict_simple():
     schema_plus = Schema.from_dict(simple_schema)
     assert schema_plus.to_dict() == simple_schema
     assert schema_plus.required == ["latitude", "longitude"]
+    assert schema_plus.properties is not None
     assert isinstance(schema_plus.properties["latitude"], Schema)
     latitude = schema_plus.properties["latitude"]
     assert latitude.type == "number"
@@ -474,6 +475,7 @@ def test_schema_from_dict_with_items():
     }
     schema_plus = Schema.from_dict(schema)
     assert schema_plus.to_dict() == schema
+    assert schema_plus.properties is not None
     assert isinstance(schema_plus.properties["fruits"], Schema)
     fruits = schema_plus.properties["fruits"]
     assert isinstance(fruits.items, Schema)


### PR DESCRIPTION
## Summary by Sourcery

Bump Ruff to 0.13.0 and update code and template configurations to comply with new lint rules

Enhancements:
- Refactor imports to use typing.TYPE_CHECKING blocks for type-only imports across modules

Build:
- Bump ruff pre-commit hook to v0.13.0 and uv-pre-commit to v0.8.16
- Add [tool.ruff] sections with line-length, required-version  3E=0.13, and future-annotations in root and cookiecutter pyproject.toml files

Tests:
- Adjust tests to import schema and helper types under TYPE_CHECKING and add missing assertions

Chores:
- Update cookiecutter templates and SQL client signatures to satisfy future-annotation linting rules