### PR TITLE
refactor(templates): Use `typing.override` in mapper and tap templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     {%- else %}
     "singer-sdk~=0.48.1",
     {%- endif %}
+    "typing-extensions>=4.5.0; python_version < '3.13'",
 ]
 
 [project.optional-dependencies]

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/{{cookiecutter.library_name}}/mapper.py
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/{{cookiecutter.library_name}}/mapper.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 
 import singer_sdk.typing as th
 from singer_sdk import singerlib as singer
 from singer_sdk.mapper import PluginMapper
 from singer_sdk.mapper_base import InlineMapper
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from pathlib import PurePath
@@ -53,6 +59,7 @@ class {{ cookiecutter.name }}Mapper(InlineMapper):
 
         self.mapper = PluginMapper(plugin_config=dict(self.config), logger=self.logger)
 
+    @override
     def map_schema_message(self, message_dict: dict) -> t.Iterable[singer.Message]:
         """Map a schema message to zero or more new messages.
 
@@ -61,6 +68,7 @@ class {{ cookiecutter.name }}Mapper(InlineMapper):
         """
         yield singer.SchemaMessage.from_dict(message_dict)
 
+    @override
     def map_record_message(
         self,
         message_dict: dict,
@@ -72,6 +80,7 @@ class {{ cookiecutter.name }}Mapper(InlineMapper):
         """
         yield singer.RecordMessage.from_dict(message_dict)
 
+    @override
     def map_state_message(self, message_dict: dict) -> t.Iterable[singer.Message]:
         """Map a state message to zero or more new messages.
 
@@ -80,6 +89,7 @@ class {{ cookiecutter.name }}Mapper(InlineMapper):
         """
         yield singer.StateMessage.from_dict(message_dict)
 
+    @override
     def map_activate_version_message(
         self,
         message_dict: dict,

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     {%- if cookiecutter.stream_type == "SQL" %}
     "sqlalchemy~=2.0.36",
     {%- endif %}
+    "typing-extensions>=4.5.0; python_version < '3.13'",
 ]
 
 [project.optional-dependencies]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/auth.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/auth.py
@@ -8,7 +8,14 @@ from __future__ import annotations
 
 {%- elif cookiecutter.auth_method == "OAuth2" %}
 
+import sys
+
 from singer_sdk.authenticators import OAuthAuthenticator, SingletonMeta
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 
 # The SingletonMeta metaclass makes your streams reuse the same authenticator instance.
@@ -16,6 +23,7 @@ from singer_sdk.authenticators import OAuthAuthenticator, SingletonMeta
 class {{ cookiecutter.source_name }}Authenticator(OAuthAuthenticator, metaclass=SingletonMeta):
     """Authenticator class for {{ cookiecutter.source_name }}."""
 
+    @override
     @property
     def oauth_request_body(self) -> dict:
         """Define the OAuth request body for the AutomaticTestTap API.

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/graphql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/graphql-client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import decimal
+import sys
 import typing as t
 
 import requests  # noqa: TC002
@@ -13,6 +14,11 @@ from singer_sdk.streams import {{ cookiecutter.stream_type }}Stream
 from {{ cookiecutter.library_name }}.auth import {{ cookiecutter.source_name }}Authenticator
 {%- endif %}
 
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     from singer_sdk.helpers.types import Context
 
@@ -20,6 +26,7 @@ if t.TYPE_CHECKING:
 class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream):
     """{{ cookiecutter.source_name }} stream class."""
 
+    @override
     @property
     def url_base(self) -> str:
         """Return the API URL root, configurable via tap settings."""
@@ -28,6 +35,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
 
 {%- if cookiecutter.auth_method in ("OAuth2", "JWT") %}
 
+    @override
     @property
     def authenticator(self) -> {{ cookiecutter.source_name }}Authenticator:
         """Return a new authenticator object.
@@ -39,6 +47,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
 
 {%- endif %}
 
+    @override
     @property
     def http_headers(self) -> dict:
         """Return the http headers needed.
@@ -52,6 +61,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
 {%- endif %}
         return {}
 
+    @override
     def parse_response(self, response: requests.Response) -> t.Iterable[dict]:
         """Parse the response and return an iterator of result records.
 
@@ -65,10 +75,11 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         resp_json = response.json(parse_float=decimal.Decimal)
         yield from resp_json.get("<TODO>")
 
+    @override
     def post_process(
         self,
         row: dict,
-        context: Context | None = None,  # noqa: ARG002
+        context: Context | None = None,
     ) -> dict | None:
         """As needed, append or transform raw data to match expected structure.
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/non-sql-tap.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/non-sql-tap.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import sys
+
 from singer_sdk import Tap
 from singer_sdk import typing as th  # JSON schema typing helpers
 
 # TODO: Import your custom stream types here:
 from {{ cookiecutter.library_name }} import streams
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 
 class Tap{{ cookiecutter.source_name }}(Tap):
@@ -55,6 +62,7 @@ class Tap{{ cookiecutter.source_name }}(Tap):
         {%- endif %}
     ).to_dict()
 
+    @override
     def discover_streams(self) -> list[streams.{{ cookiecutter.source_name }}Stream]:
         """Return a list of discovered streams.
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/other-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/other-client.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import sys
 import typing as t
 
 from singer_sdk.streams import Stream
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from singer_sdk.helpers.types import Context
@@ -13,6 +19,7 @@ if t.TYPE_CHECKING:
 class {{ cookiecutter.source_name }}Stream(Stream):
     """Stream class for {{ cookiecutter.source_name }} streams."""
 
+    @override
     def get_records(
         self,
         context: Context | None,

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import decimal
+import sys
 import typing as t
 {% if cookiecutter.auth_method in ("OAuth2", "JWT") -%}
 from functools import cached_property
@@ -41,6 +42,11 @@ from {{ cookiecutter.library_name }}.auth import {{ cookiecutter.source_name }}A
 
 {% endif -%}
 
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     import requests
     {%- if cookiecutter.auth_method in ("OAuth2", "JWT") %}
@@ -63,6 +69,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     # Update this value if necessary or override `get_new_paginator`.
     next_page_token_jsonpath = "$.next_page"  # noqa: S105
 
+    @override
     @property
     def url_base(self) -> str:
         """Return the API URL root, configurable via tap settings."""
@@ -71,6 +78,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
 
 {%- if cookiecutter.auth_method in ("OAuth2", "JWT") %}
 
+    @override
     @cached_property
     def authenticator(self) -> Auth:
         """Return a new authenticator object.
@@ -82,6 +90,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
 
 {%- elif cookiecutter.auth_method == "API Key" %}
 
+    @override
     @property
     def authenticator(self) -> APIKeyAuthenticator:
         """Return a new authenticator object.
@@ -98,6 +107,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
 
 {%- elif cookiecutter.auth_method == "Bearer Token" %}
 
+    @override
     @property
     def authenticator(self) -> BearerTokenAuthenticator:
         """Return a new authenticator object.
@@ -112,6 +122,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
 
 {%- elif cookiecutter.auth_method == "Basic Auth" %}
 
+    @override
     @property
     def authenticator(self) -> HTTPBasicAuth:
         """Return a new authenticator object.
@@ -127,6 +138,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
 {%- endif %}
 
     @property
+    @override
     def http_headers(self) -> dict:
         """Return the http headers needed.
 
@@ -139,6 +151,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
 {%- endif %}
         return {}
 
+    @override
     def get_new_paginator(self) -> BaseAPIPaginator | None:
         """Create a new pagination helper instance.
 
@@ -155,10 +168,11 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """
         return super().get_new_paginator()
 
+    @override
     def get_url_params(
         self,
-        context: Context | None,  # noqa: ARG002
-        next_page_token: t.Any | None,  # noqa: ANN401
+        context: Context | None,
+        next_page_token: t.Any | None,
     ) -> dict[str, t.Any]:
         """Return a dictionary of values to be used in URL parameterization.
 
@@ -177,10 +191,11 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
             params["order_by"] = self.replication_key
         return params
 
+    @override
     def prepare_request_payload(
         self,
-        context: Context | None,  # noqa: ARG002
-        next_page_token: t.Any | None,  # noqa: ARG002, ANN401
+        context: Context | None,
+        next_page_token: t.Any | None,
     ) -> dict | None:
         """Prepare the data payload for the REST API request.
 
@@ -196,6 +211,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         # TODO: Delete this method if no payload is required. (Most REST APIs.)
         return None
 
+    @override
     def parse_response(self, response: requests.Response) -> t.Iterable[dict]:
         """Parse the response and return an iterator of result records.
 
@@ -211,10 +227,11 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
             input=response.json(parse_float=decimal.Decimal),
         )
 
+    @override
     def post_process(
         self,
         row: dict,
-        context: Context | None = None,  # noqa: ARG002
+        context: Context | None = None,
     ) -> dict | None:
         """As needed, append or transform raw data to match expected structure.
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
@@ -6,12 +6,18 @@ This includes {{ cookiecutter.source_name }}Stream and {{ cookiecutter.source_na
 from __future__ import annotations
 
 import functools
+import sys
 import typing as t
 
 import sqlalchemy
 from singer_sdk import SQLConnector, SQLStream
 from singer_sdk.connectors.sql import SQLToJSONSchema
 from singer_sdk.helpers._typing import TypeConformanceLevel
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from singer_sdk.helpers.types import Context
@@ -37,6 +43,7 @@ class {{ cookiecutter.source_name }}SQLToJSONSchema(SQLToJSONSchema):
         super().__init__(**kwargs)
         self.custom_config_option = custom_config_option
 
+    @override
     @classmethod
     def from_config(cls, config: dict) -> {{ cookiecutter.source_name }}SQLToJSONSchema:
         """Instantiate the SQL to JSON Schema converter from a config dictionary.
@@ -54,6 +61,7 @@ class {{ cookiecutter.source_name }}SQLToJSONSchema(SQLToJSONSchema):
             custom_config_option=config.get("custom_config_option", False),
         )
 
+    @override
     @functools.singledispatchmethod
     def to_jsonschema(self, column_type: t.Any) -> dict:
         """Customize the JSON Schema for {{ cookiecutter.source_name }} types.
@@ -94,6 +102,7 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
     # Custom SQL to JSON Schema converter
     sql_to_jsonschema_converter = {{ cookiecutter.source_name }}SQLToJSONSchema
 
+    @override
     def get_sqlalchemy_url(self, config: dict) -> str:
         """Concatenate a SQLAlchemy URL for use in connecting to the source.
 
@@ -115,6 +124,7 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
             f"s3_staging_dir={config['s3_staging_dir']}"
         )
 
+    @override
     def get_schema_names(self, engine: Engine, inspected: Inspector) -> list[str]:
         """Return a list of schema names in DB, or overrides with user-provided values.
 
@@ -130,9 +140,10 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
         """
         return super().get_schema_names(engine, inspected)
 
+    @override
     def to_jsonschema_type(
         self,
-        from_type: str | sqlalchemy.types.TypeEngine | type[sqlalchemy.types.TypeEngine],
+        sql_type: str | sqlalchemy.types.TypeEngine | type[sqlalchemy.types.TypeEngine],
     ) -> dict:
         """Returns a JSON Schema equivalent for the given SQL type.
 
@@ -149,8 +160,9 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
         """
         # Optionally, add custom logic before calling the parent SQLConnector method.
         # You may delete this method if overrides are not needed.
-        return super().to_jsonschema_type(from_type)
+        return super().to_jsonschema_type(sql_type)
 
+    @override
     def to_sql_type(self, jsonschema_type: dict) -> sqlalchemy.types.TypeEngine:
         """Returns a JSON Schema equivalent for the given SQL type.
 
@@ -169,6 +181,7 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
 
     # Uncomment and customize these methods as needed for your specific database:
 
+    # @override
     # def get_object_names(
     #     self, engine: Engine, inspected: Inspector, schema_name: str
     # ) -> list[tuple[str, bool]]:
@@ -187,6 +200,7 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
     #     """
     #     return super().get_object_names(engine, inspected, schema_name)
 
+    # @override
     # def prepare_column(
     #     self, full_table_name: str, column_name: str, sql_type: sqlalchemy.types.TypeEngine
     # ) -> sqlalchemy.Column:
@@ -197,6 +211,7 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
     #     """
     #     return super().prepare_column(full_table_name, column_name, sql_type)
 
+    # @override
     # def create_engine(self) -> sqlalchemy.engine.Engine:
     #     """Create a SQLAlchemy engine for database connections.
     #
@@ -205,6 +220,7 @@ class {{ cookiecutter.source_name }}Connector(SQLConnector):
     #     """
     #     return super().create_engine()
 
+    # @override
     # def open_connection(self) -> sqlalchemy.engine.Connection:
     #     """Open a new database connection.
     #
@@ -232,6 +248,7 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
     # RECURSIVE: Recursively enforce types throughout nested structures
     TYPE_CONFORMANCE_LEVEL = TypeConformanceLevel.RECURSIVE
 
+    @override
     def apply_query_filters(
         self,
         query: sqlalchemy.sql.Select,
@@ -260,6 +277,7 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
 
         return query
 
+    @override
     def get_records(self, partition: Context | None) -> t.Iterable[dict[str, t.Any]]:
         """Return a generator of record-type dictionary objects.
 
@@ -302,6 +320,7 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
 
     # Uncomment and customize these methods as needed for your specific database:
 
+    # @override
     # def get_starting_replication_key_value(
     #     self, context: Context | None
     # ) -> t.Any | None:
@@ -313,6 +332,7 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
     #     """
     #     return super().get_starting_replication_key_value(context)
 
+    # @override
     # def post_process(self, row: dict, context: Context | None = None) -> dict | None:
     #     """Process a single record after it's been retrieved from the database.
     #
@@ -329,6 +349,7 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
     #     """
     #     return row
 
+    # @override
     # def validate_config(self) -> None:
     #     """Validate tap configuration.
     #
@@ -341,6 +362,7 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
     #     # if not self.config.get("custom_required_field"):
     #     #     raise ValueError("custom_required_field is required")
 
+    # @override
     # @property
     # def is_sorted(self) -> bool:
     #     """Indicate whether the stream is sorted by replication key.


### PR DESCRIPTION
## Summary by Sourcery

Refactor cookiecutter templates to apply the typing.override decorator to all overridden methods and conditionally import it from typing (for Python≥3.12) or typing_extensions (for earlier versions), and update project dependencies accordingly.

Enhancements:
- Add conditional import of override from typing or typing_extensions across REST, SQL, GraphQL, other client, and mapper templates
- Annotate all overridden methods with the `@override` decorator in template classes

Build:
- Include typing-extensions>=4.5.0 dependency for Python versions below 3.13 in tap and mapper pyproject.toml