### PR TITLE
chore: Use colors from meltano.com for readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,29 +19,26 @@ ______________________________________________________________________
 
 <div align="center">
   <a href="https://meltano.com/slack">
-    <img alt="Meltano Community Slack" src="https://img.shields.io/badge/Slack-Join%20the%20Community-blue?logo=slack"/>
+    <img alt="Meltano Community Slack" src="https://img.shields.io/badge/Slack-Join%20the%20Community-blue?logo=slack&labelColor=471E80&color=110B1E"/>
   </a>
   <a href="https://pypi.org/project/singer-sdk">
-   <img alt="Python Versions" src="https://img.shields.io/pypi/pyversions/singer-sdk"/>
+   <img alt="Python Versions" src="https://img.shields.io/pypi/pyversions/singer-sdk?label=Python%20Versions&labelColor=471E80&color=110B1E"/>
   </a>
   <a href="https://pypi.org/project/singer-sdk">
-   <img alt="Downloads" src="https://img.shields.io/pypi/dw/singer-sdk?color=blue"/>
+   <img alt="Downloads" src="https://img.shields.io/pypi/dw/singer-sdk?label=Downloads&labelColor=471E80&color=110B1E"/>
   </a>
   </br>
   <a href="https://pypi.org/project/singer-sdk">
-   <img alt="PyPI Version" src="https://img.shields.io/pypi/v/singer-sdk?color=blue"/>
+   <img alt="PyPI Version" src="https://img.shields.io/pypi/v/singer-sdk?label=PyPI%20Version&labelColor=471E80&color=110B1E"/>
   </a>
-  <a href="https://sdk.meltano.com/en/latest/?badge=latest">
-   <img alt="Documentation Status" src="https://readthedocs.org/projects/meltano-sdk/badge/?version=latest"/>
+  <a href="https://sdk.meltano.com/en/latest">
+   <img alt="Read the Docs (version)" src="https://img.shields.io/readthedocs/meltano-sdk/latest?label=Docs&labelColor=471E80&color=110B1E">
   </a>
   <a href="https://codecov.io/gh/meltano/sdk">
-   <img alt="codecov" src="https://codecov.io/gh/meltano/sdk/branch/main/graph/badge.svg?token=kS1zkemAgo"/>
-  </a>
-  <a href="https://results.pre-commit.ci/latest/github/meltano/sdk/main">
-   <img alt="pre-commit.ci status" src="https://results.pre-commit.ci/badge/github/meltano/sdk/main.svg"/>
+   <img alt="Codecov" src="https://img.shields.io/codecov/c/github/meltano/sdk?label=Coverage&labelColor=471E80&color=110B1E">
   </a>
   <a href="https://github.com/astral-sh/uv">
-   <img alt="uv" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json"/>
+   <img alt="uv" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json&labelColor=471E80&color=110B1E"/>
   </a>
 </div>
 
@@ -56,7 +53,7 @@ capabilities and bug fixes, simply by updating your SDK dependency to the latest
 
 ## Meltano
 
-*Not familiar with Meltano?* [Meltano](https://docs.meltano.com/getting-started/meltano-at-a-glance) is your CLI for ELT+ that:
+_Not familiar with Meltano?_ [Meltano](https://docs.meltano.com/getting-started/meltano-at-a-glance) is your CLI for ELT+ that:
 
 - **Starts simple**: Meltano is pip-installable and comes in a prepackaged docker container, you can have your first ELT pipeline running within minutes.
 - **Has DataOps out-of-the-box**: Meltano provides tools that make DataOps best practices easy to use in every project.


### PR DESCRIPTION
## Summary by Sourcery

Unify README badges with Meltano brand colors and standardize their labels and endpoints

Documentation:
- Update all README shields to use Meltano brand colors by adding labelColor and color parameters
- Replace Read the Docs and Codecov badges with shields.io endpoints
- Standardize alt text and URL formatting for all badges

Chores:
- Fix italic formatting for the "Not familiar with Meltano?" line