### PR TITLE
chore: Unpin `singer-sdk` in local packages

### DIFF
--- a/packages/mapper-custom/pyproject.toml
+++ b/packages/mapper-custom/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
-    "singer-sdk~=0.49.0",
+    "singer-sdk",
 ]
 
 [project.scripts]

--- a/packages/tap-countries/pyproject.toml
+++ b/packages/tap-countries/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.10"
 dependencies = [
     "msgspec>=0.19.0",
     "requests-cache~=1.2.1",
-    "singer-sdk~=0.49.0",
+    "singer-sdk",
     "typing-extensions>=4.5.0; python_version < '3.12'",
 ]
 

--- a/packages/tap-csv/pyproject.toml
+++ b/packages/tap-csv/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
-    "singer-sdk~=0.49.0",
+    "singer-sdk",
 ]
 
 [project.scripts]

--- a/packages/tap-dummyjson/pyproject.toml
+++ b/packages/tap-dummyjson/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.10"
 dependencies = [
     "requests~=2.32.3",
     "requests-cache~=1.2.1",
-    "singer-sdk~=0.49.0",
+    "singer-sdk",
     "typing-extensions>=4.5.0; python_version < '3.12'",
 ]
 optional-dependencies.s3 = [

--- a/packages/tap-fake-people/pyproject.toml
+++ b/packages/tap-fake-people/pyproject.toml
@@ -21,7 +21,7 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "faker",
-    "singer-sdk~=0.49.0",
+    "singer-sdk",
     "typing-extensions>=4.5.0; python_version < '3.12'",
 ]
 

--- a/packages/tap-fundamentals/pyproject.toml
+++ b/packages/tap-fundamentals/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
-    "singer-sdk~=0.49.0",
+    "singer-sdk",
     "typing-extensions>=4.5.0; python_version < '3.12'",
 ]
 

--- a/packages/tap-gitlab/pyproject.toml
+++ b/packages/tap-gitlab/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
-    "singer-sdk~=0.49.0",
+    "singer-sdk",
     "typing-extensions>=4.5.0; python_version < '3.12'",
 ]
 

--- a/packages/tap-hostile/pyproject.toml
+++ b/packages/tap-hostile/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
-    "singer-sdk~=0.49.0",
+    "singer-sdk",
     "typing-extensions>=4.5.0; python_version < '3.12'",
 ]
 

--- a/packages/tap-sqlite/pyproject.toml
+++ b/packages/tap-sqlite/pyproject.toml
@@ -20,7 +20,7 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "msgspec>=0.19.0",
-    "singer-sdk~=0.49.0",
+    "singer-sdk",
     "sqlalchemy",
 ]
 

--- a/packages/target-csv/pyproject.toml
+++ b/packages/target-csv/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
-    "singer-sdk~=0.49.0",
+    "singer-sdk",
 ]
 
 [project.scripts]

--- a/packages/target-parquet/pyproject.toml
+++ b/packages/target-parquet/pyproject.toml
@@ -20,7 +20,7 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "pyarrow",
-    "singer-sdk~=0.49.0",
+    "singer-sdk",
 ]
 
 [project.scripts]

--- a/packages/target-sqlite/pyproject.toml
+++ b/packages/target-sqlite/pyproject.toml
@@ -20,7 +20,7 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "msgspec>=0.19.0",
-    "singer-sdk~=0.49.0",
+    "singer-sdk",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,7 +227,6 @@ version_files = [
     """cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml:^    "singer-sdk""",
     """cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml:^    "singer-sdk""",
     """cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml:^    "singer-sdk""",
-    """packages/*/pyproject.toml:^    "singer-sdk""",
     ".github/ISSUE_TEMPLATE/bug.yml:^      placeholder:",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -3026,14 +3026,14 @@ wheels = [
 
 [[package]]
 name = "types-requests"
-version = "2.32.4.20250809"
+version = "2.32.4.20250913"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/b0/9355adb86ec84d057fea765e4c49cce592aaf3d5117ce5609a95a7fc3dac/types_requests-2.32.4.20250809.tar.gz", hash = "sha256:d8060de1c8ee599311f56ff58010fb4902f462a1470802cf9f6ed27bc46c4df3", size = 23027, upload-time = "2025-08-09T03:17:10.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/27/489922f4505975b11de2b5ad07b4fe1dca0bca9be81a703f26c5f3acfce5/types_requests-2.32.4.20250913.tar.gz", hash = "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d", size = 23113, upload-time = "2025-09-13T02:40:02.309Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/6f/ec0012be842b1d888d46884ac5558fd62aeae1f0ec4f7a581433d890d4b5/types_requests-2.32.4.20250809-py3-none-any.whl", hash = "sha256:f73d1832fb519ece02c85b1f09d5f0dd3108938e7d47e7f94bbfa18a6782b163", size = 20644, upload-time = "2025-08-09T03:17:09.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/20/9a227ea57c1285986c4cf78400d0a91615d25b24e257fd9e2969606bdfae/types_requests-2.32.4.20250913-py3-none-any.whl", hash = "sha256:78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1", size = 20658, upload-time = "2025-09-13T02:40:01.115Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This should make it easier to add them to any project.

## Summary by Sourcery

Unpin singer-sdk dependency across all local packages for greater flexibility and update versioning files accordingly

Enhancements:
- Remove strict version requirement for singer-sdk in all packages

Chores:
- Remove singer-sdk version pin from packages’ pyproject.toml files
- Delete version_files entry for singer-sdk in root pyproject.toml
- Regenerate lockfile to reflect unpinned singer-sdk dependency