### PR TITLE
fix: Add setter method to deprecated `APIAuthenticatorBase.tap_name` property

### DIFF
--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -146,12 +146,13 @@ class APIAuthenticatorBase:
         category=SingerSDKDeprecationWarning,
     )
     def tap_name(self) -> str:
-        """Get tap name.
-
-        Returns:
-            The tap name.
-        """
+        """The tap name."""
         return self._tap_name  # pragma: no cover
+
+    @tap_name.setter
+    def tap_name(self, name: str) -> None:
+        """Set the tap name."""
+        self._tap_name = name
 
     @property
     @deprecated(


### PR DESCRIPTION
## Summary by Sourcery

Add a setter for the deprecated tap_name property to allow updating its value

Enhancements:
- Add tap_name.setter method to enable setting the deprecated tap_name property
- Simplify the tap_name getter docstring