### PR TITLE
feat: Select streams for testing

### DIFF
--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -262,7 +262,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
     def run_sync_dry_run(
         self,
         dry_run_record_limit: int | None = 1,
-        streams: t.Iterable[Stream] | None = None,
+        streams: t.Iterable[Stream | str] | None = None,
     ) -> bool:
         """Run connection test.
 
@@ -279,15 +279,24 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         if streams is None:
             streams = self.streams.values()
 
-        for stream in streams:
+        selected_streams: list[Stream] = []
+
+        for stream_or_name in streams:
+            stream = (
+                self.streams[stream_or_name]
+                if isinstance(stream_or_name, str)
+                else stream_or_name
+            )
+
             if not stream.child_streams:  # pragma: no branch
                 # Initialize streams' record limits before beginning the sync test.
                 stream.ABORT_AT_RECORD_COUNT = dry_run_record_limit
 
             # Force selection of streams.
             stream.selected = True
+            selected_streams.append(stream)
 
-        for stream in streams:
+        for stream in selected_streams:
             if stream.parent_stream_type:
                 self.logger.debug(
                     "Child stream '%s' should be called by "

--- a/singer_sdk/testing/factory.py
+++ b/singer_sdk/testing/factory.py
@@ -17,6 +17,8 @@ from .suites import (
 )
 
 if t.TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from singer_sdk import Stream, Tap, Target
     from singer_sdk.testing.templates import (
         AttributeTestTemplate,
@@ -91,6 +93,7 @@ class TapTestClassFactory:
         include_stream_attribute_tests: bool = True,
         custom_suites: list | None = None,
         suite_config: SuiteConfig | None = None,
+        streams: Sequence[str] | None = None,
         **kwargs: t.Any,
     ) -> type[BaseTestClass]:
         """Get a new test class.
@@ -102,6 +105,9 @@ class TapTestClassFactory:
                 Include stream attribute tests in the test class.
             custom_suites: List of custom test suites to include in the test class.
             suite_config: SuiteConfig instance to be used when instantiating tests.
+            streams: Optional list of stream names to test. If provided, only the
+                specified streams will be tested during dry run execution. If omitted
+                or None, all available streams will be tested.
             kwargs: Default arguments to be passed to tap on create.
 
         Returns:
@@ -124,6 +130,7 @@ class TapTestClassFactory:
             tap_class=self.tap_class,
             config=self.config,
             suite_config=suite_config,
+            streams=streams,
             **kwargs,
         )
 
@@ -192,7 +199,17 @@ class TapTestClassFactory:
                 self._with_tap_tests(empty_test_class, suite)
 
             if suite.kind in {"tap_stream", "tap_stream_attribute"}:
-                streams = list(test_runner.new_tap().streams.values())
+                all_streams = list(test_runner.new_tap().streams.values())
+
+                # Filter streams if specific streams were requested
+                if test_runner.streams is not None:
+                    streams = [
+                        stream
+                        for stream in all_streams
+                        if stream.name in test_runner.streams
+                    ]
+                else:
+                    streams = all_streams
 
                 if suite.kind == "tap_stream":
                     self._with_stream_tests(empty_test_class, suite, streams)
@@ -396,6 +413,7 @@ def get_tap_test_class(
     include_stream_attribute_tests: bool = True,
     custom_suites: list | None = None,
     suite_config: SuiteConfig | None = None,
+    streams: Sequence[str] | None = None,
     **kwargs: t.Any,
 ) -> type[BaseTestClass]:
     """Get Tap Test Class.
@@ -408,10 +426,23 @@ def get_tap_test_class(
         include_stream_attribute_tests: Include Tap stream attribute tests.
         custom_suites: Custom test suites to add to standard tests.
         suite_config: SuiteConfig instance to pass to tests.
+        streams: Optional list of stream names to test. If provided, only the
+            specified streams will be tested during dry run execution. If omitted
+            or None, all available streams will be tested. This is useful for
+            focusing tests on specific streams or reducing test execution time.
         kwargs: Keyword arguments to pass to the TapRunner.
 
     Returns:
         A test class usable by pytest.
+
+    Example:
+        Test only specific streams::
+
+            TestMyTap = get_tap_test_class(
+                tap_class=MyTap,
+                config=SAMPLE_CONFIG,
+                streams=["users", "orders"],
+            )
     """
     factory = TapTestClassFactory(
         tap_class=tap_class,
@@ -423,6 +454,7 @@ def get_tap_test_class(
         include_tap_tests=include_tap_tests,
         include_stream_tests=include_stream_tests,
         include_stream_attribute_tests=include_stream_attribute_tests,
+        streams=streams,
         **kwargs,
     )
 

--- a/singer_sdk/testing/runners.py
+++ b/singer_sdk/testing/runners.py
@@ -14,6 +14,7 @@ from singer_sdk.plugin_base import PluginBase
 from singer_sdk.testing.config import SuiteConfig
 
 if t.TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
     from singer_sdk.helpers._compat import Traversable
@@ -96,6 +97,8 @@ class TapTestRunner(SingerTestRunner[Tap]):
         tap_class: type[Tap],
         config: dict | None = None,
         suite_config: SuiteConfig | None = None,
+        *,
+        streams: Sequence[str] | None = None,
         **kwargs: t.Any,
     ) -> None:
         """Initialize Tap instance.
@@ -105,6 +108,9 @@ class TapTestRunner(SingerTestRunner[Tap]):
             config: Config dict to pass to Tap class.
             suite_config (SuiteConfig): SuiteConfig instance to be used when
                 instantiating tests.
+            streams: Optional list of stream names to test. If provided, only the
+                specified streams will be tested during dry run execution. If omitted
+                or None, all available streams will be tested.
             kwargs: Default arguments to be passed to tap on create.
         """
         super().__init__(
@@ -113,6 +119,7 @@ class TapTestRunner(SingerTestRunner[Tap]):
             suite_config=suite_config,
             **kwargs,
         )
+        self.streams = streams
 
     def new_tap(self) -> Tap:
         """Get new Tap instance.
@@ -148,6 +155,7 @@ class TapTestRunner(SingerTestRunner[Tap]):
         new_tap = self.new_tap()
         return new_tap.run_sync_dry_run(
             dry_run_record_limit=self.suite_config.max_records_limit,
+            streams=self.streams,
         )
 
     def sync_all(self, **kwargs: t.Any) -> None:  # noqa: ARG002


### PR DESCRIPTION
## Summary
- Added comprehensive tests for the new `streams` parameter in `TapTestRunner`
- Fixed existing factory tests to accommodate the new parameter

## Test Coverage Added
- TapTestRunner initialization with streams parameter (list, tuple, empty, None)
- run_sync_dry_run method with streams parameter
- Integration test for complete workflow with streams
- Compatibility with other initialization arguments

## Changes Made
- **tests/core/testing/test_runners.py**: Added 7 new test methods for streams parameter
- **tests/core/testing/test_factory.py**: Updated 3 existing tests to include `streams=None` parameter

## Test Plan
- [x] All new tests pass
- [x] All existing tests in test_runners.py pass (38 tests total)
- [x] All existing tests in test_factory.py pass (23 tests total)
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Introduce a 'streams' parameter to TapTestRunner and propagate it through the testing factory and runner, extend run_sync_dry_run to filter streams by name or object, and add comprehensive tests for streams behavior.

New Features:
- Support passing a 'streams' parameter to TapTestRunner to limit which streams are processed during dry-run execution
- Expose the 'streams' parameter in testing factory functions new_test_class and get_tap_test_class

Enhancements:
- Extend TapBase.run_sync_dry_run to accept stream names or objects and select them correctly before running the dry run

Tests:
- Add unit tests for TapTestRunner initialization with streams as list, tuple, empty sequence, and None
- Add tests for run_sync_dry_run with and without streams parameter and with other kwargs
- Add an integration-style test covering a full TapTestRunner workflow using the streams parameter
- Update existing test_factory tests to include the new streams argument