### PR TITLE
refactor: Remove `metrics_log_level` setting in favor of application log level

### DIFF
--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -28,7 +28,6 @@ if t.TYPE_CHECKING:
 
 DEFAULT_LOG_INTERVAL = 60.0
 METRICS_LOGGER_NAME = __name__
-METRICS_LOG_LEVEL_SETTING = "metrics_log_level"
 
 _TVal = t.TypeVar("_TVal")
 

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -270,20 +270,7 @@ class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
             self.logger.info("Skipping parse of env var settings...")
         self._config = config_dict
         self.metrics_logger = metrics.get_metrics_logger()
-        if metrics_level := self.config.get(
-            metrics.METRICS_LOG_LEVEL_SETTING,
-        ):  # pragma: no cover
-            self.metrics_logger.setLevel(metrics_level.upper())
-            warnings.warn(
-                f"Using {metrics.METRICS_LOG_LEVEL_SETTING} to set metrics log level "
-                "is deprecated and will be removed by September 2025. "
-                "Please use the logging level environment variables "
-                "or a custom logging configuration file.",
-                SingerSDKDeprecationWarning,
-                stacklevel=2,
-            )
-        else:
-            self.metrics_logger.setLevel(_plugin_log_level(plugin_name=self.name))
+        self.metrics_logger.setLevel(_plugin_log_level(plugin_name=self.name))
 
         self._validate_config(raise_errors=validate_config)
         self._mapper: PluginMapper | None = None


### PR DESCRIPTION
## Summary by Sourcery

Remove the deprecated metrics_log_level configuration in favor of using the application log level for metrics logging

Enhancements:
- Remove the deprecated metrics_log_level setting and associated deprecation warning
- Simplify metrics logger initialization to always use the plugin's log level
- Delete the METRICS_LOG_LEVEL_SETTING constant from metrics module