### PR TITLE
ci: Use minimal GitHub action permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,9 +28,7 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      security-events: write # create security reports for the repo
 
     strategy:
       fail-fast: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -13,10 +13,7 @@ jobs:
     name: zizmor latest via PyPI
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
-      # required for workflows in private repositories
-      contents: read
-      actions: read
+      security-events: write # create security reports for the repo
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
## Summary by Sourcery

Restrict GitHub Actions workflows to the minimal permissions needed for security reporting

CI:
- Reduce permissions in zizmor.yml to only security-events: write
- Reduce permissions in codeql-analysis.yml to only security-events: write