### PR TITLE
fix: Ensure plugins advertise `structured-logging` capability

### DIFF
--- a/singer_sdk/mapper_base.py
+++ b/singer_sdk/mapper_base.py
@@ -29,6 +29,7 @@ class InlineMapper(BaseSingerReader, BaseSingerWriter, metaclass=abc.ABCMeta):
         PluginCapabilities.ABOUT,
         PluginCapabilities.STREAM_MAPS,
         PluginCapabilities.FLATTENING,
+        PluginCapabilities.STRUCTURED_LOGGING,
     ]
 
     def __init__(

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -200,6 +200,7 @@ class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
     #: Developers may override this property in order to add or remove
     #: advertised capabilities for this plugin.
     capabilities: t.ClassVar[t.Sequence[CapabilitiesEnum]] = [
+        PluginCapabilities.ABOUT,
         PluginCapabilities.STREAM_MAPS,
         PluginCapabilities.FLATTENING,
         PluginCapabilities.BATCH,

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -74,6 +74,7 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         PluginCapabilities.STREAM_MAPS,
         PluginCapabilities.FLATTENING,
         PluginCapabilities.BATCH,
+        PluginCapabilities.STRUCTURED_LOGGING,
     ]
 
     # Constructor

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -66,6 +66,7 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
         PluginCapabilities.ABOUT,
         PluginCapabilities.STREAM_MAPS,
         PluginCapabilities.FLATTENING,
+        PluginCapabilities.STRUCTURED_LOGGING,
         TargetCapabilities.VALIDATE_RECORDS,
     ]
 

--- a/tests/core/test_target_base.py
+++ b/tests/core/test_target_base.py
@@ -67,6 +67,7 @@ def test_target_about_info():
         PluginCapabilities.ABOUT,
         PluginCapabilities.STREAM_MAPS,
         PluginCapabilities.FLATTENING,
+        PluginCapabilities.STRUCTURED_LOGGING,
         TargetCapabilities.VALIDATE_RECORDS,
         PluginCapabilities.BATCH,
     ]


### PR DESCRIPTION
Otherwise Meltano and the Hub can not pick it up