### PR TITLE
fix: Honor the `_LOG_REQUEST_METRICS` stream parameter

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -491,11 +491,14 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
         """TODO.
 
         Args:
-            endpoint: TODO
-            response: TODO
+            endpoint: The endpoint of the request.
+            response: The response object.
             context: Stream partition or context dictionary.
-            extra_tags: TODO
+            extra_tags: A dictionary of extra tags to add to the metric.
         """
+        if not self._LOG_REQUEST_METRICS:
+            return
+
         extra_tags = extra_tags or {}
         if context:
             extra_tags[metrics.Tag.CONTEXT] = context


### PR DESCRIPTION
Closes https://github.com/meltano/sdk/issues/2896.

## Summary by Sourcery

Honor the _LOG_REQUEST_METRICS flag when logging HTTP request metrics and add tests to verify metrics emission behavior

Bug Fixes:
- Add an early return in _write_request_duration_log to skip duration logging when _LOG_REQUEST_METRICS is False

Documentation:
- Update parameter descriptions in _write_request_duration_log docstring

Tests:
- Add tests to verify that enabling _LOG_REQUEST_METRICS produces both duration and count metrics
- Add tests to confirm that disabling _LOG_REQUEST_METRICS emits only the count metric