### PR TITLE
refactor: In target logs, put the sink name in a trailing position

### DIFF
--- a/singer_sdk/sql/target.py
+++ b/singer_sdk/sql/target.py
@@ -101,7 +101,7 @@ class SQLTarget(Target):
         Returns:
             A new sink for the stream.
         """
-        self.logger.debug("Initializing '%s' target sink...", self.name)
+        self.logger.debug("Initializing target sink '%s'...", self.name)
         sink_class = self.get_sink_class(stream_name=stream_name)
         sink = sink_class(
             target=self,

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -246,7 +246,7 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
         Returns:
             A new sink for the stream.
         """
-        self.logger.debug("Initializing '%s' target sink...", self.name)
+        self.logger.debug("Initializing target sink '%s'...", self.name)
         sink_class = self.get_sink_class(stream_name=stream_name)
         sink = sink_class(
             target=self,
@@ -258,7 +258,7 @@ class Target(BaseSingerReader, metaclass=abc.ABCMeta):
         try:
             sink.setup()
         except Exception:  # pragma: no cover
-            self.logger.error("Error initializing '%s' target sink", self.name)  # noqa: TRY400
+            self.logger.error("Error initializing target sink '%s'", self.name)  # noqa: TRY400
             raise
 
         self._sinks_active[stream_name] = sink


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Move sink name to the end of debug and error log messages in target_base and sql/target modules