### PR TITLE
fix: Move context dictionary outside of `Beginning incremental sync` and into a structured field

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -46,11 +46,12 @@ jobs:
     - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
         architecture: x64
+        python-version: "3.13"
 
     - name: Install uv
       uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
       with:
-        version: ">=0.8,<0.9"
+        version: ">=0.9,<0.10"
 
     - name: Install dependencies
       run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ build:
       - uv sync --frozen --no-dev --group docs
     build:
       html:
-        - uv run sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
+        - uv run --no-sync sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
 
 sphinx:
   builder: html

--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -200,6 +200,14 @@ class Meter(metaclass=abc.ABCMeta):
         Args:
             value: A context dictionary.
         """
+        self.with_context(value)
+
+    def with_context(self, value: types.Context | None) -> None:
+        """Set the context for this meter.
+
+        Args:
+            value: A context dictionary.
+        """
         if value is None:
             self.tags.pop(Tag.CONTEXT, None)
         else:


### PR DESCRIPTION
## Summary by Sourcery

Refactor the sync start log to leverage structured logging for context data, add `faker` to test requirements, and update related snapshots and lockfile accordingly

Enhancements:
- Use structured logging to attach the context dictionary as an `extra` field instead of embedding it in the sync start message

Build:
- Add `faker` to the testing dependencies

Tests:
- Refresh snapshot logs to align with the new structured logging output

Chores:
- Update the lock file to incorporate the new dependency