### PR TITLE
ci: Run CodSpeed on Python 3.13

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -46,11 +46,12 @@ jobs:
     - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
         architecture: x64
+        python-version: "3.13"
 
     - name: Install uv
       uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
       with:
-        version: ">=0.8,<0.9"
+        version: ">=0.9,<0.10"
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary by Sourcery

Update the CodSpeed GitHub Actions workflow to run on Python 3.13 and tighten the uv dependency version range.

CI:
- Enable Python 3.13 in the CodSpeed workflow
- Bump uv installation version range to >=0.9,<0.10