### PR TITLE
ci: Add `--no-sync` to build command for RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ build:
       - uv sync --frozen --no-dev --group docs
     build:
       html:
-        - uv run sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
+        - uv run --no-sync sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
 
 sphinx:
   builder: html


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Include `--no-sync` flag in the `uv run sphinx-build` command within .readthedocs.yml