### PR TITLE
refactor: Pass stream logger to the backoff handler

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -307,6 +307,7 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
             max_tries=self.backoff_max_tries,
             on_backoff=self.backoff_handler,
             jitter=self.backoff_jitter,
+            logger=self.logger,
         )(func)
         return decorator
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Pass the stream's logger to the backoff handler for retry logging