### PR TITLE
docs: Update annotation of `backoff_wait_generator` in example

### DIFF
--- a/docs/code_samples.md
+++ b/docs/code_samples.md
@@ -334,7 +334,7 @@ Custom backoff and retry behaviour can be added by overriding the methods:
 For example, to use a constant retry:
 
 ```
-def backoff_wait_generator() -> Callable[..., Generator[int, Any, None]]:
+def backoff_wait_generator() -> Callable[..., Generator[float, Any, None]]:
     return backoff.constant(interval=10)
 ```
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update code_samples.md to change the return type of backoff_wait_generator from Generator[int, Any, None] to Generator[float, Any, None].