### PR TITLE
chore: Configure Dependabot `cooldown`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 enable-beta-ecosystems: true
 updates:
-  - package-ecosystem: "uv"
+  - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: weekly
@@ -13,6 +13,8 @@ updates:
       runtime-dependencies:
         dependency-type: production
     versioning-strategy: lockfile-only
+    cooldown:
+      default-days: 7
   - package-ecosystem: pip
     directory: "/.github/workflows/resources"
     schedule:
@@ -23,6 +25,8 @@ updates:
       ci:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -32,3 +36,5 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/dependabot.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
         update-types:
           - "patch"
     versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -30,3 +32,5 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/dependabot.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
         update-types:
           - "patch"
     versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -30,3 +32,5 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/dependabot.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
         update-types:
           - "patch"
     versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -30,3 +32,5 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary by Sourcery

Configure Dependabot to respect a one-week cooldown period between update PRs across the main and template repositories

CI:
- Add a default 7-day cooldown to Dependabot updates for all package ecosystems and GitHub Actions in the root repository
- Propagate the same Dependabot cooldown configuration to all cookiecutter mapper, tap, and target templates

Chores:
- Remove unnecessary quotes around the uv package-ecosystem entry