### PR TITLE
feat(taps): Introduced method in `Tap` class to convert input catalog to `Stream` objects, without discovery

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/non-sql-tap.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/non-sql-tap.py
@@ -15,6 +15,9 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import override
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
 
 class Tap{{ cookiecutter.source_name }}(Tap):
     """Singer tap for {{ cookiecutter.source_name }}."""
@@ -105,6 +108,7 @@ class Tap{{ cookiecutter.source_name }}(Tap):
             streams.GroupsStream(self),
             streams.UsersStream(self),
         ]
+{%- endif %}
 
 
 if __name__ == "__main__":

--- a/singer_sdk/singerlib/catalog.py
+++ b/singer_sdk/singerlib/catalog.py
@@ -440,3 +440,15 @@ class Catalog(dict[str, CatalogEntry]):  # noqa: FURB189
             The stream entry if found, otherwise None.
         """
         return self.get(stream_id)
+
+    def has_stream_selected(self, stream_id: str) -> bool:
+        """Returns true if the stream is selected.
+
+        Args:
+            stream_id: The ID/name of the stream.
+        """
+        if stream := self.get_stream(stream_id):
+            mask = stream.metadata.resolve_selection()
+            return mask[()]
+
+        return False

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -416,13 +416,13 @@ class Tap(BaseSingerWriter, abc.ABC):  # noqa: PLR0904
     def load_streams_from_catalog(self, catalog: Catalog) -> Iterable[Stream]:  # noqa: ARG002
         """Recreate streams from the input catalog.
 
+        Note:
+            The `catalog` argument is currently unused. For backwards compatibility,
+            this method calls `self.load_streams()`.
+
         Returns:
             Iterable[Stream]: An iterable of Stream objects recreated from the input
                 catalog.
-        For backwards compatibility calls `self.load_streams()`
-
-        Returns:
-            A mapping of names to streams, using provided catalog.
         """
         return self.load_streams()
 

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -31,6 +31,7 @@ from singer_sdk.plugin_base import BaseSingerWriter, PluginBase, _ConfigInput
 from singer_sdk.singerlib import Catalog
 
 if t.TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import PurePath
     from types import FrameType
 
@@ -164,13 +165,14 @@ class Tap(BaseSingerWriter, abc.ABC):  # noqa: PLR0904
             A mapping of names to streams, using discovery or a provided catalog.
         """
         if self._streams is None:
-            self._streams = {}
             input_catalog = self.input_catalog
-
-            for stream in self.load_streams():
-                if input_catalog is not None:
+            if input_catalog is None:
+                self._streams = {stream.name: stream for stream in self.load_streams()}
+            else:
+                self._streams = {}
+                for stream in self.load_streams_from_catalog(input_catalog):
                     stream.apply_catalog(input_catalog)
-                self._streams[stream.name] = stream
+                    self._streams[stream.name] = stream
         return self._streams
 
     @property
@@ -410,6 +412,19 @@ class Tap(BaseSingerWriter, abc.ABC):  # noqa: PLR0904
             key=lambda x: x.name,
             reverse=False,
         )
+
+    def load_streams_from_catalog(self, catalog: Catalog) -> Iterable[Stream]:  # noqa: ARG002
+        """Recreate streams from the input catalog.
+
+        Returns:
+            Iterable[Stream]: An iterable of Stream objects recreated from the input
+                catalog.
+        For backwards compatibility calls `self.load_streams()`
+
+        Returns:
+            A mapping of names to streams, using provided catalog.
+        """
+        return self.load_streams()
 
     # Bookmarks and state management
 


### PR DESCRIPTION
This clarifies whether the tap should perform discovery or use the input catalog, the two being mutually exclusive.

Supersedes #3084

## Summary by Sourcery

Provide a clear separation between discovery and catalog-driven stream loading by adding load_streams_from_catalog and updating streams property, and enhance Catalog with a has_stream_selected helper

New Features:
- Introduce load_streams_from_catalog method in Tap to recreate streams from a provided catalog without discovery
- Update Tap.streams property to choose between discovery and input catalog processing
- Add has_stream_selected method to Catalog for checking if a stream is selected

Enhancements:
- Add Iterable import under TYPE_CHECKING in Tap and template for consistent typing