### PR TITLE
packaging: Fix `python_version` marker in `backoff` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 
 dependencies = [
-    "backoff>=2.2.0,<4",
+    'backoff>=2.2.0; python_version<"4"',
     'backports-datetime-fromisoformat>=2.0.1; python_version<"3.11"',
     "click>=8.2,<9",
     "fsspec>=2024.9.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2372,7 +2372,7 @@ wheels = [
 name = "singer-sdk"
 source = { editable = "." }
 dependencies = [
-    { name = "backoff" },
+    { name = "backoff", marker = "python_full_version < '4'" },
     { name = "backports-datetime-fromisoformat", marker = "python_full_version < '3.11'" },
     { name = "click" },
     { name = "fsspec" },
@@ -2525,7 +2525,7 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "backoff", specifier = ">=2.2.0,<4" },
+    { name = "backoff", marker = "python_full_version < '4'", specifier = ">=2.2.0" },
     { name = "backports-datetime-fromisoformat", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "click", specifier = ">=8.2,<9" },
     { name = "cryptography", marker = "extra == 'jwt'", specifier = ">=3.4.6" },


### PR DESCRIPTION
## Summary by Sourcery

Correct the packaging configuration to use the proper Python version marker for the backoff dependency and update the lockfile accordingly.

Bug Fixes:
- Fix python_version marker for backoff dependency to apply only on Python versions below 4

Build:
- Regenerate uv.lock after updating dependency marker