### PR TITLE
fix(taps): Emit a log when requesting a new access token in OAuth taps

### DIFF
--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -636,6 +636,7 @@ class OAuthAuthenticator(APIAuthenticatorBase):
         Raises:
             RuntimeError: When OAuth login fails.
         """
+        self.logger.info("Requesting new access token")
         request_time = utc_now()
         auth_request_payload = self.oauth_request_payload
         token_response = requests.post(


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Log an info message when requesting a new OAuth access token