### PR TITLE
feat: Add new IDN/IRI JSON Schema types

### DIFF
--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -81,8 +81,12 @@ __all__ = [
     "DurationType",
     "EmailType",
     "HostnameType",
+    "IDNEmailType",
+    "IDNHostnameType",
     "IPv4Type",
     "IPv6Type",
+    "IRIReferenceType",
+    "IRIType",
     "IntegerType",
     "JSONPointerType",
     "JSONTypeHelper",
@@ -366,10 +370,22 @@ class EmailType(StringType):
     string_format = "email"
 
 
+class IDNEmailType(StringType):
+    """Internationalized email type."""
+
+    string_format = "idn-email"
+
+
 class HostnameType(StringType):
     """Hostname type."""
 
     string_format = "hostname"
+
+
+class IDNHostnameType(StringType):
+    """Internationalized hostname type."""
+
+    string_format = "idn-hostname"
 
 
 class IPv4Type(StringType):
@@ -399,10 +415,22 @@ class URIType(StringType):
     string_format = "uri"
 
 
+class IRIType(StringType):
+    """IRI type."""
+
+    string_format = "iri"
+
+
 class URIReferenceType(StringType):
     """URIReference type."""
 
     string_format = "uri-reference"
+
+
+class IRIReferenceType(StringType):
+    """IRIReference type."""
+
+    string_format = "iri-reference"
 
 
 class URITemplateType(StringType):

--- a/tests/core/test_jsonschema_helpers.py
+++ b/tests/core/test_jsonschema_helpers.py
@@ -38,9 +38,13 @@ from singer_sdk.typing import (
     DurationType,
     EmailType,
     HostnameType,
+    IDNEmailType,
+    IDNHostnameType,
     IntegerType,
     IPv4Type,
     IPv6Type,
+    IRIReferenceType,
+    IRIType,
     JSONPointerType,
     ObjectType,
     PropertiesList,
@@ -305,10 +309,24 @@ def test_property_title():
             },
         ),
         (
+            IDNEmailType,
+            {
+                "type": ["string"],
+                "format": "idn-email",
+            },
+        ),
+        (
             HostnameType,
             {
                 "type": ["string"],
                 "format": "hostname",
+            },
+        ),
+        (
+            IDNHostnameType,
+            {
+                "type": ["string"],
+                "format": "idn-hostname",
             },
         ),
         (
@@ -340,10 +358,24 @@ def test_property_title():
             },
         ),
         (
+            IRIType,
+            {
+                "type": ["string"],
+                "format": "iri",
+            },
+        ),
+        (
             URIReferenceType,
             {
                 "type": ["string"],
                 "format": "uri-reference",
+            },
+        ),
+        (
+            IRIReferenceType,
+            {
+                "type": ["string"],
+                "format": "iri-reference",
             },
         ),
         (


### PR DESCRIPTION
Closes https://github.com/meltano/sdk/issues/337

## Summary by Sourcery

Introduce new JSON Schema string types to support internationalized domain names (IDNs) and IRIs in the typing module and update tests accordingly

New Features:
- Add IDNEmailType and IDNHostnameType JSON schema types for internationalized email and hostname formats
- Add IRIType and IRIReferenceType JSON schema types for IRI and IRI-reference formats

Tests:
- Extend JSON schema helper tests to validate idn-email, idn-hostname, iri, and iri-reference formats