### PR TITLE
docs: Document that multiple state messages can be output from a single target run

### DIFF
--- a/docs/implementation/state.md
+++ b/docs/implementation/state.md
@@ -42,6 +42,24 @@ The SDK will automatically generate and emit STATE messages according to the con
 `Stream.STATE_MSG_FREQUENCY`, which designates how many RECORD messages should be processed
 before an updated STATE message should be emitted.
 
+## Target State Output
+
+Targets write state payloads to stdout whenever they commit data to the target system. This happens:
+
+- When a new STATE message is received from the tap (triggering a sink drain, as described in [Sinks](../sinks.md))
+- When records exceed the maximum age threshold (default: 5 minutes)
+- When the sync completes
+
+This means targets emit **multiple state payloads** during long-running syncs, not just one at completion. Each payload represents the furthest point of confirmed progress.
+
+To capture the final state for use in subsequent runs:
+
+```bash
+tap | target | tail -n 1 > state.json
+```
+
+The last state payload represents the last successfully committed checkpoint, providing fault tolerance if the sync is interrupted.
+
 ## Backwards Compatibility
 
 While the exact specification of STATE messages may change between versions, it is

--- a/docs/sinks.md
+++ b/docs/sinks.md
@@ -13,6 +13,8 @@ This is the default, where only one sink is active for each incoming stream name
 - In the case that a sink is archived because of a superseding STATE message, all
   prior version(s) of the stream's sink are guaranteed to be drained in creation order.
 
+_Note: Targets write state payloads to stdout whenever sinks drain. See [Target State Output](implementation/state.md#target-state-output) for details on capturing the final state._
+
 ### Database sink example
 
 A database-type target where each stream will land in a dedicated table. Each sink is of the same class, with a different target table based on stream_name.


### PR DESCRIPTION
## Summary by Sourcery

Document that targets emit multiple state messages during a single run and provide instructions for capturing the final checkpoint.

Documentation:
- Add Target State Output section detailing when targets emit state payloads (on new state receipt, record age threshold, and sync completion)
- Show how to capture the final state payload using `tail -n 1`
- Add a note in sinks documentation linking to the Target State Output section