### PR TITLE
docs: Clarify that JSONL batch files should contain raw records and not Singer `RECORD` messages

### DIFF
--- a/docs/batch.md
+++ b/docs/batch.md
@@ -56,6 +56,28 @@ AWS S3
 
 The `encoding` field is used to specify the format and compression of the batch files. Currently `jsonl`, `gzip` and `parquet` are supported.
 
+#### JSONL Batch File Format
+
+When using the `jsonl` encoding format, batch files should contain **raw JSON records only**, with one record per line. They should **NOT** contain Singer protocol `RECORD` messages.
+
+**Correct format** (raw JSON records):
+
+```jsonl
+{"id": 1, "name": "Alice", "email": "alice@example.com"}
+{"id": 2, "name": "Bob", "email": "bob@example.com"}
+{"id": 3, "name": "Charlie", "email": "charlie@example.com"}
+```
+
+**Incorrect format** (Singer RECORD messages):
+
+```jsonl
+{"type": "RECORD", "stream": "users", "record": {"id": 1, "name": "Alice", "email": "alice@example.com"}}
+{"type": "RECORD", "stream": "users", "record": {"id": 2, "name": "Bob", "email": "bob@example.com"}}
+{"type": "RECORD", "stream": "users", "record": {"id": 3, "name": "Charlie", "email": "charlie@example.com"}}
+```
+
+The Singer protocol messages (like `RECORD`, `SCHEMA`, `STATE`, and `BATCH`) are used for communication between taps and targets, but the batch files themselves contain only the record data.
+
 ### `manifest`
 
 The `manifest` field is used to specify the paths to the batch files. The paths are relative to the `root` directory specified in the [`batch_config`](#batch-configuration) storage configuration.

--- a/singer_sdk/contrib/batch_encoder_jsonl.py
+++ b/singer_sdk/contrib/batch_encoder_jsonl.py
@@ -13,7 +13,11 @@ __all__ = ["JSONLinesBatcher"]
 
 
 class JSONLinesBatcher(BaseBatcher):
-    """JSON Lines Record Batcher."""
+    """JSON Lines Record Batcher.
+
+    Writes raw JSON records to JSONL batch files, with one record per line.
+    The batch files contain only the record data, not Singer protocol messages.
+    """
 
     def get_batches(
         self,
@@ -21,8 +25,10 @@ class JSONLinesBatcher(BaseBatcher):
     ) -> t.Iterator[list[str]]:
         """Yield manifest of batches.
 
+        Creates JSONL batch files containing raw JSON records (one per line).
+
         Args:
-            records: The records to batch.
+            records: The raw record dictionaries to batch.
 
         Yields:
             A list of file paths (called a manifest).

--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -760,6 +760,9 @@ class Sink(metaclass=abc.ABCMeta):  # noqa: PLR0904
     ) -> None:
         """Process a batch file with the given batch context.
 
+        For JSONL-encoded batch files, expects raw JSON records (one per line),
+        not Singer protocol messages.
+
         Args:
             encoding: The batch file encoding.
             files: The batch files to process.


### PR DESCRIPTION
## Summary by Sourcery

Clarify that JSONL-encoded batch files must contain raw JSON records only and not Singer protocol messages.

Enhancements:
- Add a dedicated section in batch.md describing the JSONL batch file format with correct and incorrect examples
- Update JSONLinesBatcher docstring to emphasize writing raw JSON records per line
- Update process_batch_files docstring to note that JSONL files expect raw record data, not Singer messages

Documentation:
- Document JSONL batch file format and provide usage examples in the batch guide