### PR TITLE
docs: Document how to cast values to different data types in inline stream maps

### DIFF
--- a/docs/batch.md
+++ b/docs/batch.md
@@ -62,7 +62,7 @@ When using the `jsonl` encoding format, batch files should contain **raw JSON re
 
 **Correct format** (raw JSON records):
 
-```jsonl
+```json
 {"id": 1, "name": "Alice", "email": "alice@example.com"}
 {"id": 2, "name": "Bob", "email": "bob@example.com"}
 {"id": 3, "name": "Charlie", "email": "charlie@example.com"}
@@ -70,7 +70,7 @@ When using the `jsonl` encoding format, batch files should contain **raw JSON re
 
 **Incorrect format** (Singer RECORD messages):
 
-```jsonl
+```json
 {"type": "RECORD", "stream": "users", "record": {"id": 1, "name": "Alice", "email": "alice@example.com"}}
 {"type": "RECORD", "stream": "users", "record": {"id": 2, "name": "Bob", "email": "bob@example.com"}}
 {"type": "RECORD", "stream": "users", "record": {"id": 3, "name": "Charlie", "email": "charlie@example.com"}}


### PR DESCRIPTION
## Summary by Sourcery

Document explicit type casting for inline stream maps with supported functions, usage scenarios, and examples, and correct code block languages in batch documentation.

Documentation:
- Add a Type Casting section to stream_maps.md covering int(), float(), str(), and bool() functions with examples and usage guidelines
- Update code block language in batch.md from jsonl to json for correct syntax highlighting