### PR TITLE
ci: Run benchmarks on Python 3.14

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
         architecture: x64
-        python-version: "3.13"
+        python-version: "3.14"
 
     - name: Install uv
       uses: astral-sh/setup-uv@2ddd2b9cb38ad8efd50337e8ab201519a34c9f24 # v7.1.1


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Run benchmarks on Python 3.14 instead of 3.13 in the codspeed workflow.