### PR TITLE
fix(taps,targets,mappers): Preserve properties with empty JSON schema when flattening them

### DIFF
--- a/singer_sdk/helpers/_flattening.py
+++ b/singer_sdk/helpers/_flattening.py
@@ -351,6 +351,10 @@ def _flatten_schema(  # noqa: C901, PLR0912
             elif next(iter(field_schema.values()))[0]["type"] == "object":
                 next(iter(field_schema.values()))[0]["type"] = ["null", "object"]
                 items.append((new_key, next(iter(field_schema.values()))[0]))
+        else:
+            # Handle typeless properties (e.g., "PropertyName": {})
+            # Treat them as string type to allow JSON serialization
+            items.append((new_key, {"type": ["null", "string"]}))
 
     # Sort and check for duplicates
     def _key_func(item: tuple[str, dict]) -> str:


### PR DESCRIPTION
## Summary by Sourcery

Preserve properties with empty JSON schema when flattening by converting them to string to avoid dropping typeless fields

Bug Fixes:
- Retain typeless (empty schema) properties during schema flattening and assign them a string type

Tests:
- Add test to ensure typeless properties are preserved and typed as string after flattening