### PR TITLE
fix(templates): Fix class docstrings in tap, target and mapper templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/{{cookiecutter.library_name}}/mapper.py
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/{{cookiecutter.library_name}}/mapper.py
@@ -20,7 +20,7 @@ if t.TYPE_CHECKING:
 
 
 class {{ cookiecutter.name }}Mapper(InlineMapper):
-    """Sample mapper for {{ cookiecutter.name }}."""
+    """Mapper for {{ cookiecutter.name }}."""
 
     name = "{{ cookiecutter.mapper_id }}"
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/non-sql-tap.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/non-sql-tap.py
@@ -17,7 +17,7 @@ else:
 
 
 class Tap{{ cookiecutter.source_name }}(Tap):
-    """{{ cookiecutter.source_name }} tap class."""
+    """Singer tap for {{ cookiecutter.source_name }}."""
 
     name = "{{ cookiecutter.tap_id }}"
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-tap.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-tap.py
@@ -9,7 +9,7 @@ from {{ cookiecutter.library_name }}.client import {{ cookiecutter.source_name }
 
 
 class Tap{{ cookiecutter.source_name }}(SQLTap):
-    """{{ cookiecutter.source_name }} tap class."""
+    """Singer tap for {{ cookiecutter.source_name }}."""
 
     name = "{{ cookiecutter.tap_id }}"
 

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/target.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/target.py
@@ -13,7 +13,7 @@ from {{ cookiecutter.library_name }}.sinks import (
 
 
 class Target{{ cookiecutter.destination_name }}({{ target_class }}):
-    """Sample target for {{ cookiecutter.destination_name }}."""
+    """Target for {{ cookiecutter.destination_name }}."""
 
     name = "{{ cookiecutter.target_id }}"
 


### PR DESCRIPTION
## Summary by Sourcery

Update class docstrings in cookiecutter mapper, tap, and target templates for improved consistency and clarity.

Documentation:
- Standardize mapper class docstrings to 'Mapper for <Name>'.
- Clarify tap class docstrings to 'Singer tap for <SourceName>' in both non-SQL and SQL templates.
- Refine target class docstrings to 'Target for <DestinationName>'.