### PR TITLE
refactor: Make the deprecation warning in `singer_sdk.sinks.sql` more specific

### DIFF
--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -6,18 +6,34 @@
 
 from __future__ import annotations
 
+import typing as t
 import warnings
 
 from singer_sdk.helpers._compat import SingerSDKDeprecationWarning
 
-warnings.warn(
-    "Importing from singer_sdk.sinks.sql is deprecated. "
-    "Please import from singer_sdk.sql instead.",
-    SingerSDKDeprecationWarning,
-    stacklevel=2,
-)
 
-__all__ = ["SQLSink"]
+def __getattr__(name: str) -> t.Any:  # noqa: ANN401
+    """Provide backward compatibility for moved SQL classes.
 
-# Re-export for backward compatibility
-from singer_sdk.sql.sink import SQLSink  # noqa: E402
+    Args:
+        name: The name of the attribute to import.
+
+    Returns:
+        The imported attribute.
+
+    Raises:
+        AttributeError: If the attribute is not found.
+    """
+    if name == "SQLSink":
+        warnings.warn(
+            f"Importing {name} from singer_sdk.sinks.sql is deprecated. "
+            f"Please import from singer_sdk.sql instead.",
+            SingerSDKDeprecationWarning,
+            stacklevel=2,
+        )
+        from singer_sdk.sql import SQLSink  # noqa: PLC0415
+
+        return SQLSink
+
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update deprecation warning in singer_sdk.sinks.sql to reference the deprecated SQL sink class and recommend its replacement