### PR TITLE
docs: Fix code examples in SQL target guide

### DIFF
--- a/docs/guides/sql-target.md
+++ b/docs/guides/sql-target.md
@@ -11,20 +11,20 @@ If the default [`JSONSchemaToSQL`](connectors.sql.JSONSchemaToSQL) instance does
 ```python
 import functools
 
-import sqlalchemy as sa
 from singer_sdk import typing as th
 from singer_sdk.connectors import JSONSchemaToSQL, SQLConnector
+from sqlalchemy.types import VARCHAR
 
 from my_sqlalchemy_dialect import VectorType
 
 
-def custom_array_to_sql(jsonschema: dict) -> VectorType | sa.types.VARCHAR:
+def custom_array_to_sql(jsonschema: dict) -> VectorType | VARCHAR:
     """Custom mapping for arrays of numbers."""
     if items := jsonschema.get("items"):
         if items.get("type") == "number":
             return VectorType()
 
-    return sa.types.VARCHAR()
+    return VARCHAR()
 
 
 class MyConnector(SQLConnector):
@@ -62,14 +62,14 @@ class MyConnector(SQLConnector):
 You can register new type handlers for the `x-sql-datatype` extension:
 
 ```python
-from my_sqlalchemy_dialect import URI
+from sqlalchemy.types import SMALLINT
 
 
 class MyConnector(SQLConnector):
     @functools.cached_property
     def jsonschema_to_sql(self):
         to_sql = JSONSchemaToSQL()
-        to_sql.register_sql_datatype_handler("smallint", sa.types.SMALLINT)
+        to_sql.register_sql_datatype_handler("smallint", SMALLINT)
         return to_sql
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,7 +139,7 @@ class SQLConnectorMock(SQLConnector):
     """A Mock SQLConnector class."""
 
 
-class SQLSinkMock(SQLSink[SQLConnectorMock]):
+class SQLSinkMock(SQLSink):
     """A mock Sink class."""
 
     name = "sql-sink-mock"

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -9,7 +9,7 @@ import logging
 import typing as t
 
 import pytest
-import sqlalchemy as sa
+from sqlalchemy import types
 
 from singer_sdk.helpers._typing import (
     TypeConformanceLevel,
@@ -60,7 +60,7 @@ def test_simple_schema_conforms_types():
 
 def test_primitive_arrays_are_conformed():
     schema = PropertiesList(
-        Property("list", ArrayType(BooleanType)),
+        Property("list", ArrayType(BooleanType())),
     ).to_dict()
 
     record = {
@@ -83,7 +83,7 @@ def test_only_root_fields_are_conformed_for_root_level():
     schema = PropertiesList(
         Property("primitive", BooleanType),
         Property("object", PropertiesList(Property("value", BooleanType))),
-        Property("list", ArrayType(BooleanType)),
+        Property("list", ArrayType(BooleanType())),
     ).to_dict()
 
     record = {
@@ -112,7 +112,7 @@ def test_no_fields_are_conformed_for_none_level():
     schema = PropertiesList(
         Property("primitive", BooleanType),
         Property("object", PropertiesList(Property("value", BooleanType))),
-        Property("list", ArrayType(BooleanType)),
+        Property("list", ArrayType(BooleanType())),
     ).to_dict()
 
     record = {
@@ -408,27 +408,21 @@ def test_conform_primitives(value: t.Any, type_dict: dict, expected: t.Any):
 @pytest.mark.parametrize(
     "jsonschema_type,expected",
     [
-        ({"type": ["string", "null"]}, sa.types.VARCHAR),
-        ({"type": ["integer", "null"]}, sa.types.INTEGER),
-        ({"type": ["number", "null"]}, sa.types.DECIMAL),
-        ({"type": ["boolean", "null"]}, sa.types.BOOLEAN),
-        ({"type": "object", "properties": {}}, sa.types.VARCHAR),
-        ({"type": "array"}, sa.types.VARCHAR),
-        ({"format": "date", "type": ["string", "null"]}, sa.types.DATE),
-        ({"format": "time", "type": ["string", "null"]}, sa.types.TIME),
-        (
-            {"format": "date-time", "type": ["string", "null"]},
-            sa.types.DATETIME,
-        ),
+        ({"type": ["string", "null"]}, types.VARCHAR),
+        ({"type": ["integer", "null"]}, types.INTEGER),
+        ({"type": ["number", "null"]}, types.DECIMAL),
+        ({"type": ["boolean", "null"]}, types.BOOLEAN),
+        ({"type": "object", "properties": {}}, types.VARCHAR),
+        ({"type": "array"}, types.VARCHAR),
+        ({"format": "date", "type": ["string", "null"]}, types.DATE),
+        ({"format": "time", "type": ["string", "null"]}, types.TIME),
+        ({"format": "date-time", "type": ["string", "null"]}, types.DATETIME),
         (
             {"anyOf": [{"type": "string", "format": "date-time"}, {"type": "null"}]},
-            sa.types.DATETIME,
+            types.DATETIME,
         ),
-        ({"anyOf": [{"type": "integer"}, {"type": "null"}]}, sa.types.INTEGER),
-        (
-            {"type": ["array", "object", "boolean", "null"]},
-            sa.types.VARCHAR,
-        ),
+        ({"anyOf": [{"type": "integer"}, {"type": "null"}]}, types.INTEGER),
+        ({"type": ["array", "object", "boolean", "null"]}, types.VARCHAR),
     ],
 )
 def test_to_sql_type(jsonschema_type, expected):
@@ -468,7 +462,7 @@ def test_append_null(type_dict: dict, expected: dict):
 def test_iterate_properties_list():
     primitive_property = Property("primitive", BooleanType)
     object_property = Property("object", PropertiesList(Property("value", BooleanType)))
-    list_property = Property("list", ArrayType(BooleanType))
+    list_property = Property("list", ArrayType(BooleanType()))
 
     properties_list = PropertiesList(primitive_property, object_property, list_property)
 


### PR DESCRIPTION
## Summary by Sourcery

Fix code examples in the SQL target guide and align test and mock implementations with proper SQL type instantiation and imports.

Bug Fixes:
- Instantiate BooleanType in ArrayType usage within tests instead of passing the class
- Replace sa.types.* references in tests with the `types` alias

Enhancements:
- Remove the generic parameter from SQLSinkMock definition

Documentation:
- Update SQL target guide examples to import VARCHAR and SMALLINT directly from sqlalchemy.types
- Return instantiated type objects (e.g., VARCHAR(), SMALLINT) instead of using `sa.types`

Tests:
- Adjust test_typing to use BooleanType() and the `types` alias for SQL types
- Update SQLSinkMock in conftest to inherit from SQLSink without generics