### PR TITLE
feat: Log response header names when backing off requests

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -277,6 +277,9 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
         if response.content:
             msg += f", content is {response.text}"
 
+        if response.headers:
+            msg += f", headers: {','.join(response.headers.keys())}"
+
         return msg
 
     def request_decorator(self, func: RequestFunc) -> RequestFunc:

--- a/tests/core/rest/test_failure.py
+++ b/tests/core/rest/test_failure.py
@@ -56,12 +56,13 @@ def custom_validation_stream(rest_tap):
 
 
 @pytest.mark.parametrize(
-    "status_code,reason,content,expectation",
+    "status_code,reason,content,headers,expectation",
     [
         (
             400,
             "Bad request",
             None,
+            {},
             pytest.raises(
                 FatalAPIError,
                 match=r"400 Client Error: Bad request for path: /dummy",
@@ -71,6 +72,7 @@ def custom_validation_stream(rest_tap):
             503,
             "Service Unavailable",
             None,
+            {},
             pytest.raises(
                 RetriableAPIError,
                 match=r"503 Server Error: Service Unavailable for path: /dummy",
@@ -80,6 +82,7 @@ def custom_validation_stream(rest_tap):
             521,  # Cloudflare custom status code higher than max(HTTPStatus)
             "Web Server Is Down",
             None,
+            {},
             pytest.raises(
                 RetriableAPIError,
                 match=r"521 Server Error: Web Server Is Down for path: /dummy",
@@ -89,6 +92,7 @@ def custom_validation_stream(rest_tap):
             429,
             "Too Many Requests",
             None,
+            {},
             pytest.raises(
                 RetriableAPIError,
                 match=r"429 Client Error: Too Many Requests for path: /dummy",
@@ -98,6 +102,7 @@ def custom_validation_stream(rest_tap):
             403,
             "Forbidden",
             b'{"error": "Your token does not have the required scopes"}',
+            {},
             pytest.raises(
                 FatalAPIError,
                 match=(
@@ -110,12 +115,23 @@ def custom_validation_stream(rest_tap):
             403,
             "Forbidden",
             b"",
+            {},
             pytest.raises(
                 FatalAPIError,
                 match=r"403 Client Error: Forbidden for path: /dummy",
             ),
         ),
-        (200, "OK", b"OK", nullcontext()),
+        (
+            429,
+            "Too Many Requests",
+            b"",
+            {"Retry-After": "10"},
+            pytest.raises(
+                RetriableAPIError,
+                match=r"429 Client Error: Too Many Requests for path: /dummy, headers: Retry-After",  # noqa: E501
+            ),
+        ),
+        (200, "OK", b"OK", {}, nullcontext()),
     ],
     ids=[
         "client-error",
@@ -124,6 +140,7 @@ def custom_validation_stream(rest_tap):
         "rate-limited",
         "forbidden-with-content",
         "forbidden-empty-content",
+        "rate-limited-with-headers",
         "ok",
     ],
 )
@@ -132,12 +149,14 @@ def test_status_code_validation(
     status_code: int,
     reason: str,
     content: bytes | None,
+    headers: dict[str, str],
     expectation,
 ):
     fake_response = requests.Response()
     fake_response.status_code = status_code
     fake_response.reason = reason
     fake_response._content = content
+    fake_response.headers.update(headers)
 
     with expectation:
         basic_rest_stream.validate_response(fake_response)


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Include response header names in the error message when backing off requests