### PR TITLE
packaging: Require Pytest 9+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ parquet = [
 ]
 
 testing = [
-    "pytest>=7.5",
+    "pytest>=9",
 ]
 
 faker = [
@@ -106,7 +106,7 @@ dev = [
 docs = [
     "furo>=2024.5.6",
     "myst-parser>=3",
-    "pytest>=8",
+    "pytest>=9",
     "sphinx>=7",
     "sphinx-copybutton>=0.5.2",
     "sphinx-inline-tabs>=2023.4.21",
@@ -131,7 +131,7 @@ packages = [
 testing = [
     "coverage[toml]>=7.9",
     "fastjsonschema>=2.19.1",
-    "pytest>=7.2.1",
+    "pytest>=9",
     "pytest-benchmark>=4.0.0",
     "pytest-github-actions-annotate-failures>=0.3.0",
     "pytest-snapshot>=0.9.0",
@@ -178,7 +178,7 @@ include = [
 fallback-version = "0.0.0"
 source = "vcs"
 
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = [
     "--durations=10",
     "-m",
@@ -188,15 +188,15 @@ addopts = [
     "--strict-markers",
 ]
 filterwarnings = [
-    "error",
-    "once:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning",  # https://github.com/litl/backoff/pull/220
-    "once:No records were available to test:UserWarning",
+    'error',
+    '''once:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning''',  # https://github.com/litl/backoff/pull/220
+    'once:No records were available to test:UserWarning',
     # https://github.com/meltano/sdk/issues/1354
-    "ignore:The function singer_sdk.testing.get_standard_tap_tests is deprecated:DeprecationWarning",
+    'ignore:The function singer_sdk.testing.get_standard_tap_tests is deprecated:DeprecationWarning',
     # TODO: Address this SQLite warning in Python 3.13+
-    "ignore::ResourceWarning",
+    'ignore::ResourceWarning',
     # Our own warnings
-    "once::singer_sdk.helpers._compat.SingerSDKDeprecationWarning",
+    'once::singer_sdk.helpers._compat.SingerSDKDeprecationWarning',
 ]
 log_cli_level = "INFO"
 log_format = "%(levelname)s %(name)s %(message)s"
@@ -209,9 +209,9 @@ markers = [
     "darwin: Tests that only run on Darwin",
     "snapshot: Tests that use pytest-snapshot",
 ]
-minversion = "7"
+minversion = "9"
 testpaths = ["tests"]
-norecursedirs = "cookiecutter"
+norecursedirs = ["cookiecutter"]
 xfail_strict = false
 
 [tool.commitizen]

--- a/tests/core/configuration/test_dict_config.py
+++ b/tests/core/configuration/test_dict_config.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-import typing as t
 from pathlib import Path
 
 import pytest
@@ -10,16 +9,13 @@ import pytest
 import singer_sdk.typing as th
 from singer_sdk.configuration._dict_config import parse_environment_config
 
-if t.TYPE_CHECKING:
-    from pytest_subtests import SubTests
-
 CONFIG_JSONSCHEMA = th.PropertiesList(
     th.Property("prop1", th.StringType, required=True),
     th.Property("prop2", th.StringType),
-    th.Property("prop3", th.ArrayType(th.StringType)),
+    th.Property("prop3", th.ArrayType(th.StringType())),
     th.Property("prop4", th.IntegerType),
     th.Property("prop5", th.BooleanType),
-    th.Property("prop6", th.ArrayType(th.IntegerType)),
+    th.Property("prop6", th.ArrayType(th.IntegerType())),
     th.Property(
         "prop7",
         th.ObjectType(
@@ -50,7 +46,7 @@ def config_file2(tmpdir) -> str:
 
 def test_get_env_var_config(
     monkeypatch: pytest.MonkeyPatch,
-    subtests: SubTests,
+    subtests: pytest.Subtests,
     caplog: pytest.LogCaptureFixture,
 ):
     """Test settings parsing from environment variables."""

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -37,8 +37,6 @@ else:
 if t.TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from pytest_subtests.plugin import SubTests
-
 
 @pytest.fixture(scope="session")
 def resolved_user_schema() -> dict[str, t.Any]:
@@ -729,7 +727,7 @@ class TestOpenAPISchemaNormalization:
         self,
         tmp_path: Path,
         openapi: dict[str, t.Any],
-        subtests: SubTests,
+        subtests: pytest.Subtests,
     ):
         """Test that nullable attributes are converted to type arrays."""
         openapi_file = tmp_path / "openapi.json"

--- a/uv.lock
+++ b/uv.lock
@@ -808,7 +808,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -2541,7 +2541,7 @@ requires-dist = [
     { name = "paramiko", marker = "extra == 'ssh'", specifier = ">=3.3.0" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15" },
     { name = "pyjwt", marker = "extra == 'jwt'", specifier = ">=2.4.0" },
-    { name = "pytest", marker = "extra == 'testing'", specifier = ">=7.5" },
+    { name = "pytest", marker = "extra == 'testing'", specifier = ">=9" },
     { name = "python-dotenv", specifier = ">=0.20" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "referencing", specifier = ">=0.30.0" },
@@ -2560,7 +2560,7 @@ provides-extras = ["faker", "jwt", "msgspec", "parquet", "s3", "sql", "ssh", "te
 benchmark = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.9" },
     { name = "fastjsonschema", specifier = ">=2.19.1" },
-    { name = "pytest", specifier = ">=7.2.1" },
+    { name = "pytest", specifier = ">=9" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-codspeed", specifier = ">=2.2.0,!=4.1.0" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
@@ -2582,8 +2582,7 @@ dev = [
     { name = "mypy", specifier = ">=1.17" },
     { name = "myst-parser", specifier = ">=3" },
     { name = "pyarrow-stubs", specifier = ">=19.1" },
-    { name = "pytest", specifier = ">=7.2.1" },
-    { name = "pytest", specifier = ">=8" },
+    { name = "pytest", specifier = ">=9" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "pytest-snapshot", specifier = ">=0.9.0" },
@@ -2609,7 +2608,7 @@ dev = [
 docs = [
     { name = "furo", specifier = ">=2024.5.6" },
     { name = "myst-parser", specifier = ">=3" },
-    { name = "pytest", specifier = ">=8" },
+    { name = "pytest", specifier = ">=9" },
     { name = "sphinx", specifier = ">=7" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-inline-tabs", specifier = ">=2023.4.21" },
@@ -2633,7 +2632,7 @@ packages = [
 testing = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.9" },
     { name = "fastjsonschema", specifier = ">=2.19.1" },
-    { name = "pytest", specifier = ">=7.2.1" },
+    { name = "pytest", specifier = ">=9" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "pytest-snapshot", specifier = ">=0.9.0" },


### PR DESCRIPTION
## Summary by Sourcery

Require pytest 9+ across all dependency groups, update pytest configuration settings in pyproject.toml, and adjust tests to align with the new pytest and pytest-subtests APIs.

Enhancements:
- Bump pytest version requirement to >=9 in testing, docs, and package dependencies
- Rename pytest configuration section in pyproject.toml, raise minversion to 9, and standardize option formats (filterwarnings quoting and norecursedirs syntax)

Tests:
- Remove deprecated pytest_subtests imports and switch to pytest.Subtests for subtests fixtures
- Instantiate type classes in ArrayType calls within test schemas

Chores:
- Regenerate uv.lock to reflect updated dependencies