### PR TITLE
chore: Remove unused `pytest-subtest`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,6 @@ testing = [
     "pytest-benchmark>=4.0.0",
     "pytest-github-actions-annotate-failures>=0.3.0",
     "pytest-snapshot>=0.9.0",
-    "pytest-subtests>=0.13.1",
     "pytz>=2022.2.1",
     "requests-cache>=1.2.1",
     "requests-mock>=1.10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1952,19 +1952,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-subtests"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/d9/20097971a8d315e011e055d512fa120fd6be3bdb8f4b3aa3e3c6bf77bebc/pytest_subtests-0.15.0.tar.gz", hash = "sha256:cb495bde05551b784b8f0b8adfaa27edb4131469a27c339b80fd8d6ba33f887c", size = 18525, upload-time = "2025-10-20T16:26:18.358Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/64/bba465299b37448b4c1b84c7a04178399ac22d47b3dc5db1874fe55a2bd3/pytest_subtests-0.15.0-py3-none-any.whl", hash = "sha256:da2d0ce348e1f8d831d5a40d81e3aeac439fec50bd5251cbb7791402696a9493", size = 9185, upload-time = "2025-10-20T16:26:17.239Z" },
-]
-
-[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2429,7 +2416,6 @@ benchmark = [
     { name = "pytest-codspeed" },
     { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-snapshot" },
-    { name = "pytest-subtests" },
     { name = "pytz" },
     { name = "requests-cache" },
     { name = "requests-mock" },
@@ -2450,7 +2436,6 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-snapshot" },
-    { name = "pytest-subtests" },
     { name = "pytz" },
     { name = "requests-cache" },
     { name = "requests-mock" },
@@ -2504,7 +2489,6 @@ testing = [
     { name = "pytest-benchmark" },
     { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-snapshot" },
-    { name = "pytest-subtests" },
     { name = "pytz" },
     { name = "requests-cache" },
     { name = "requests-mock" },
@@ -2565,7 +2549,6 @@ benchmark = [
     { name = "pytest-codspeed", specifier = ">=2.2.0,!=4.1.0" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "pytest-snapshot", specifier = ">=0.9.0" },
-    { name = "pytest-subtests", specifier = ">=0.13.1" },
     { name = "pytz", specifier = ">=2022.2.1" },
     { name = "requests-cache", specifier = ">=1.2.1" },
     { name = "requests-mock", specifier = ">=1.10.0" },
@@ -2586,7 +2569,6 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "pytest-snapshot", specifier = ">=0.9.0" },
-    { name = "pytest-subtests", specifier = ">=0.13.1" },
     { name = "pytz", specifier = ">=2022.2.1" },
     { name = "requests-cache", specifier = ">=1.2.1" },
     { name = "requests-mock", specifier = ">=1.10.0" },
@@ -2636,7 +2618,6 @@ testing = [
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "pytest-snapshot", specifier = ">=0.9.0" },
-    { name = "pytest-subtests", specifier = ">=0.13.1" },
     { name = "pytz", specifier = ">=2022.2.1" },
     { name = "requests-cache", specifier = ">=1.2.1" },
     { name = "requests-mock", specifier = ">=1.10.0" },


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Delete the pytest-subtests entry from the testing dependencies in pyproject.toml