### PR TITLE
feat(mappers): Add `flattening_max_key_length` configuration option

### DIFF
--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -47,12 +47,23 @@ three distinct fields:
 - `user__last_name`
 - `user__id`
 
+#### Flattening Configuration Options
+
+When flattening is enabled, the following configuration options are available:
+
+- `flattening_enabled`: Set to `true` to enable schema flattening.
+- `flattening_max_depth`: The maximum depth of nested properties to flatten (required when flattening is enabled).
+- `flattening_max_key_length`: The maximum length of flattened key names (optional, defaults to 255 characters).
+
+When a flattened key would exceed the `flattening_max_key_length`, the SDK automatically abbreviates parent key names to keep the total length under the limit while preserving all the key components.
+
 #### Flattening Example
 
 ````{tab} meltano.yml
 ```yaml
 flattening_enabled: true
 flattening_max_depth: 1   # flatten only top-level properties
+flattening_max_key_length: 100  # optional, defaults to 255
 ```
 ````
 
@@ -60,7 +71,8 @@ flattening_max_depth: 1   # flatten only top-level properties
 ```json
 {
   "flattening_enabled": true,
-  "flattening_max_depth": 1
+  "flattening_max_depth": 1,
+  "flattening_max_key_length": 100
 }
 ```
 ````

--- a/singer_sdk/helpers/_flattening.py
+++ b/singer_sdk/helpers/_flattening.py
@@ -7,6 +7,7 @@ import itertools
 import re
 import typing as t
 from copy import deepcopy
+from dataclasses import KW_ONLY, dataclass
 
 import inflection
 
@@ -14,47 +15,75 @@ from singer_sdk.exceptions import ConfigValidationError
 from singer_sdk.singerlib.json import serialize_json
 
 DEFAULT_FLATTENING_SEPARATOR = "__"
+DEFAULT_MAX_KEY_LENGTH = 255
 
 
-class FlatteningOptions(t.NamedTuple):
+class PluginFlatteningConfig(t.TypedDict):
+    """Plugin flattening configuration."""
+
+    flattening_enabled: bool
+    flattening_max_depth: int
+    flattening_max_key_length: int
+
+
+@dataclass
+class FlatteningOptions:
     """A stream map which performs the flattening role."""
 
-    max_level: int
-    flattening_enabled: bool = True
+    _: KW_ONLY
+
+    enabled: bool
+    max_level: int = -1
     separator: str = DEFAULT_FLATTENING_SEPARATOR
+    max_key_length: int = DEFAULT_MAX_KEY_LENGTH
+
+    def __post_init__(self) -> None:
+        """Post-init validation."""
+        if self.enabled and self.max_level == -1:
+            msg = "Flattening is misconfigured"
+            raise ConfigValidationError(
+                msg,
+                errors=["flattening_max_depth is required when flattening is enabled"],
+            )
+
+    @classmethod
+    def from_dict(cls, data: PluginFlatteningConfig) -> FlatteningOptions:
+        kwargs: dict[str, t.Any] = {}
+        if (max_depth := data.get("flattening_max_depth")) is not None:
+            kwargs["max_level"] = max_depth
+
+        if (max_key_length := data.get("flattening_max_key_length")) is not None:
+            kwargs["max_key_length"] = max_key_length
+
+        return cls(enabled=data.get("flattening_enabled", False), **kwargs)
 
 
-def get_flattening_options(
-    plugin_config: t.Mapping,
-) -> FlatteningOptions | None:
+def get_flattening_options(plugin_config: PluginFlatteningConfig) -> FlatteningOptions:
     """Get flattening options, if flattening is enabled.
 
     Args:
         plugin_config: The tap or target config dictionary.
 
     Returns:
-        A new FlatteningOptions object or None if flattening is disabled.
+        A new FlatteningOptions object.
     """
-    if plugin_config.get("flattening_enabled", False):
-        if (max_depth := plugin_config.get("flattening_max_depth")) is not None:
-            return FlatteningOptions(max_level=int(max_depth))
-
-        msg = "Flattening is misconfigured"
-        raise ConfigValidationError(
-            msg,
-            errors=["flattening_max_depth is required when flattening is enabled"],
-        )
-
-    return None
+    return FlatteningOptions.from_dict(plugin_config)
 
 
-def flatten_key(key_name: str, parent_keys: list[str], separator: str = "__") -> str:
+def flatten_key(
+    key_name: str,
+    parent_keys: list[str],
+    separator: str = "__",
+    *,
+    max_key_length: int = DEFAULT_MAX_KEY_LENGTH,
+) -> str:
     """Concatenate `key_name` with its `parent_keys` using `separator`.
 
     Args:
         key_name: The node's key.
         parent_keys: A list of parent keys which are ancestors to this node.
         separator: The separator used during concatenation. Defaults to "__".
+        max_key_length: The maximum length of the key. Defaults to 255.
 
     Returns:
         The flattened key name as a string.
@@ -68,13 +97,12 @@ def flatten_key(key_name: str, parent_keys: list[str], separator: str = "__") ->
     full_key = [*parent_keys, key_name]
     inflected_key = full_key.copy()
     reducer_index = 0
-    while len(
-        separator.join(inflected_key),
-    ) >= 255 and reducer_index < len(  # noqa: PLR2004
-        inflected_key,
+    pattern = re.compile(r"[a-z]")
+    while (
+        len(separator.join(inflected_key)) >= max_key_length  # Keep the key short
+        and reducer_index < len(inflected_key)
     ):
-        reduced_key = re.sub(
-            r"[a-z]",
+        reduced_key = pattern.sub(
             "",
             inflection.camelize(inflected_key[reducer_index]),
         )
@@ -90,6 +118,8 @@ def flatten_schema(
     schema: dict,
     max_level: int,
     separator: str = "__",
+    *,
+    max_key_length: int = DEFAULT_MAX_KEY_LENGTH,
 ) -> dict:
     """Flatten the provided schema up to a depth of max_level.
 
@@ -97,6 +127,7 @@ def flatten_schema(
         schema: The schema definition to flatten.
         separator: The string to use when concatenating key names.
         max_level: The max recursion level (zero-based, exclusive).
+        max_key_length: The maximum length of the key. Defaults to 255.
 
     Returns:
         A flattened version of the provided schema definition.
@@ -283,6 +314,7 @@ def flatten_schema(
         schema_node=new_schema,
         max_level=max_level,
         separator=separator,
+        max_key_length=max_key_length,
     )
     return new_schema
 
@@ -293,6 +325,8 @@ def _flatten_schema(  # noqa: C901, PLR0912
     separator: str = "__",
     level: int = 0,
     max_level: int = 0,
+    *,
+    max_key_length: int = DEFAULT_MAX_KEY_LENGTH,
 ) -> dict:
     """Flatten the provided schema node, recursively up to depth of `max_level`.
 
@@ -302,6 +336,7 @@ def _flatten_schema(  # noqa: C901, PLR0912
         separator: The string to use when concatenating key names.
         level: The current recursion level (zero-based).
         max_level: The max recursion level (zero-based, exclusive).
+        max_key_length: The maximum length of the key. Defaults to 255.
 
     Returns:
         A flattened version of the provided node.
@@ -314,7 +349,12 @@ def _flatten_schema(  # noqa: C901, PLR0912
         return {}
 
     for field_name, field_schema in schema_node["properties"].items():
-        new_key = flatten_key(field_name, parent_keys, separator)
+        new_key = flatten_key(
+            field_name,
+            parent_keys,
+            separator,
+            max_key_length=max_key_length,
+        )
         if "type" in field_schema:
             if (
                 "object" in field_schema["type"]
@@ -328,6 +368,7 @@ def _flatten_schema(  # noqa: C901, PLR0912
                         separator=separator,
                         level=level + 1,
                         max_level=max_level,
+                        max_key_length=max_key_length,
                     ).items(),
                 )
             elif "array" in field_schema["type"] or (
@@ -375,6 +416,8 @@ def flatten_record(
     flattened_schema: dict,
     max_level: int,
     separator: str = "__",
+    *,
+    max_key_length: int = DEFAULT_MAX_KEY_LENGTH,
 ) -> dict:
     """Flatten a record up to max_level.
 
@@ -383,6 +426,7 @@ def flatten_record(
         flattened_schema: The already flattened schema.
         separator: The string used to separate concatenated key names. Defaults to "__".
         max_level: The maximum depth of keys to flatten recursively.
+        max_key_length: The maximum length of the key. Defaults to 255.
 
     Returns:
         A flattened version of the record.
@@ -392,6 +436,7 @@ def flatten_record(
         flattened_schema=flattened_schema,
         separator=separator,
         max_level=max_level,
+        max_key_length=max_key_length,
     )
 
 
@@ -403,6 +448,7 @@ def _flatten_record(
     separator: str = "__",
     level: int = 0,
     max_level: int = 0,
+    max_key_length: int = DEFAULT_MAX_KEY_LENGTH,
 ) -> dict:
     """This recursive function flattens the record node.
 
@@ -416,6 +462,7 @@ def _flatten_record(
         separator: The string to use when concatenating key names.
         level: The current recursion level (zero-based).
         max_level: The max recursion level (zero-based, exclusive).
+        max_key_length: The maximum length of the key. Defaults to 255.
 
     Returns:
         A flattened version of the provided node.
@@ -425,7 +472,7 @@ def _flatten_record(
 
     items: list[tuple[str, t.Any]] = []
     for k, v in record_node.items():
-        new_key = flatten_key(k, parent_key, separator)
+        new_key = flatten_key(k, parent_key, separator, max_key_length=max_key_length)
         # If the value is a dictionary, and the key is not in the schema, and the
         # level is less than the max level, then we should continue to flatten.
         if (
@@ -442,6 +489,7 @@ def _flatten_record(
                     separator=separator,
                     level=level + 1,
                     max_level=max_level,
+                    max_key_length=max_key_length,
                 ).items(),
             )
         else:

--- a/singer_sdk/helpers/capabilities.py
+++ b/singer_sdk/helpers/capabilities.py
@@ -128,7 +128,7 @@ STREAM_MAPS_CONFIG = PropertiesList(
             ),
             Property(
                 "locale",
-                OneOf(StringType, ArrayType(StringType)),
+                OneOf(StringType, ArrayType(StringType())),
                 title="Faker Locale",
                 description=(
                     "One or more LCID locale strings to produce localized output for: "
@@ -160,6 +160,12 @@ FLATTENING_CONFIG = PropertiesList(
         IntegerType(),
         title="Max Flattening Depth",
         description="The max depth to flatten schemas.",
+    ),
+    Property(
+        "flattening_max_key_length",
+        IntegerType(),
+        title="Max Key Length",
+        description="The maximum length of a flattened key.",
     ),
 ).to_dict()
 BATCH_CONFIG = PropertiesList(

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -107,7 +107,7 @@ class StreamMap(metaclass=abc.ABCMeta):
         """
         return (
             self.flattening_options is not None
-            and self.flattening_options.flattening_enabled
+            and self.flattening_options.enabled
             and self.flattening_options.max_level > 0
         )
 
@@ -130,6 +130,7 @@ class StreamMap(metaclass=abc.ABCMeta):
             flattened_schema=self.transformed_schema,
             max_level=self.flattening_options.max_level,
             separator=self.flattening_options.separator,
+            max_key_length=self.flattening_options.max_key_length,
         )
 
     def flatten_schema(self, raw_schema: dict) -> dict:
@@ -148,6 +149,7 @@ class StreamMap(metaclass=abc.ABCMeta):
             raw_schema,
             separator=self.flattening_options.separator,
             max_level=self.flattening_options.max_level,
+            max_key_length=self.flattening_options.max_key_length,
         )
 
     @abc.abstractmethod
@@ -679,7 +681,7 @@ class PluginMapper:
         self.stream_maps: dict[str, list[StreamMap]] = {}
         self.map_config = plugin_config.get("stream_map_config", {})
         self.faker_config = plugin_config.get("faker_config", {})
-        self.flattening_options = get_flattening_options(plugin_config)
+        self.flattening_options = get_flattening_options(plugin_config)  # type: ignore[arg-type]
         self.default_mapper_type: type[DefaultStreamMap] = SameRecordTransform
         self.logger = logger
 

--- a/tests/core/test_flattening.py
+++ b/tests/core/test_flattening.py
@@ -4,6 +4,7 @@ import pytest
 
 from singer_sdk.exceptions import ConfigValidationError
 from singer_sdk.helpers._flattening import (
+    flatten_key,
     flatten_record,
     flatten_schema,
     get_flattening_options,
@@ -81,14 +82,27 @@ def test_flatten_record(flattened_schema, max_level, expected):
 
 def test_get_flattening_options_missing_max_depth():
     with pytest.raises(
-        ConfigValidationError, match="Flattening is misconfigured"
+        ConfigValidationError,
+        match="Flattening is misconfigured",
     ) as exc:
         get_flattening_options({"flattening_enabled": True})
 
+    assert isinstance(exc.value, ConfigValidationError)
     assert (
         exc.value.errors[0]
         == "flattening_max_depth is required when flattening is enabled"
     )
+
+
+def test_get_flattening_options_max_key_length():
+    options = get_flattening_options(
+        {
+            "flattening_enabled": True,
+            "flattening_max_depth": 5,
+            "flattening_max_key_length": 30,
+        }
+    )
+    assert options.max_key_length == 30
 
 
 def test_flatten_schema_with_typeless_properties():
@@ -184,3 +198,50 @@ def test_flatten_record_with_typeless_property_values():
     # Typeless properties with simple values should be preserved
     assert "changes__NewValue" in flattened_record
     assert flattened_record["changes__NewValue"] == "simple string"
+
+
+def test_flatten_key_with_long_names(subtests: pytest.Subtests):
+    """Test that flatten_key abbreviates long key names to stay under 255 chars.
+
+    This test exercises the while loop in flatten_key that reduces key length
+    by abbreviating parent keys when the concatenated result exceeds 255 chars.
+    """
+    # Create a deeply nested structure with long key names that will exceed
+    # 255 chars when concatenated with the default "__" separator
+    long_key_name = "very_long_key_name_that_contains_many_characters"
+    parent_keys = [
+        "first_extremely_long_parent_key_name_with_many_words",
+        "second_extremely_long_parent_key_name_with_many_words",
+        "third_extremely_long_parent_key_name_with_many_words",
+        "fourth_extremely_long_parent_key_name_with_many_words",
+        "fifth_extremely_long_parent_key_name_with_many_words",
+    ]
+
+    with subtests.test("default parameters"):
+        # Without abbreviation, this would be well over 255 characters
+        # (each parent key is ~53 chars, plus the final key ~47 chars,
+        # plus 5 separators = ~317 chars)
+        result = flatten_key(long_key_name, parent_keys)
+
+        # The result should be under 255 characters
+        assert len(result) < 255
+
+        # The result should still contain all the keys in some form (abbreviated)
+        # The abbreviation logic removes lowercase letters from camelized versions
+        # or truncates to 3 chars if that results in <= 1 char
+        assert result.count("__") == len(parent_keys)  # All separators are present
+
+    with subtests.test("custom separator"):
+        # Test with a custom separator to ensure it works with different separators
+        result_custom_sep = flatten_key(long_key_name, parent_keys, separator=".")
+        assert len(result_custom_sep) < 255
+        assert result_custom_sep.count(".") == len(parent_keys)
+
+    with subtests.test("custom max_key_length"):
+        result_custom_length = flatten_key(
+            long_key_name,
+            parent_keys,
+            max_key_length=100,
+        )
+        assert len(result_custom_length) < 100
+        assert result_custom_length.count("__") == len(parent_keys)


### PR DESCRIPTION
## Summary by Sourcery

Support configurable maximum key length for schema flattening by adding a flattening_max_key_length option (default 255), updating flattening utilities to enforce this limit via abbreviation, refactoring FlatteningOptions to a dataclass with validation, and updating tests, docs, and capabilities accordingly.

New Features:
- Introduce flattening_max_key_length configuration option to limit flattened key name length

Enhancements:
- Refactor FlatteningOptions to a dataclass with post-init validation and from_dict factory method
- Extend flattening functions (flatten_key, flatten_schema, flatten_record) to accept and enforce max_key_length parameter
- Simplify get_flattening_options to leverage the new FlatteningOptions.from_dict

Documentation:
- Document new flattening_max_key_length option in stream_maps.md

Tests:
- Add tests for custom flattening_max_key_length and long key abbreviation behavior

Chores:
- Add flattening_max_key_length property to capabilities schema