### PR TITLE
chore: Fix pre-commit hooks for tap-dummyjson

### DIFF
--- a/.prekignore
+++ b/.prekignore
@@ -1,0 +1,3 @@
+cookiecutter/mapper-template/*/
+cookiecutter/tap-template/*/
+cookiecutter/target-template/*/

--- a/packages/tap-dummyjson/.pre-commit-config.yaml
+++ b/packages/tap-dummyjson/.pre-commit-config.yaml
@@ -22,17 +22,11 @@ repos:
   hooks:
   - id: check-dependabot
   - id: check-github-workflows
+  - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.14.5
   hooks:
-  - id: ruff
+  - id: ruff-check
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
   - id: ruff-format
-
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.18.2
-  hooks:
-  - id: mypy
-    additional_dependencies:
-    - types-requests


### PR DESCRIPTION
## Summary by Sourcery

Update pre-commit configuration for tap-dummyjson to add Meltano checks, rename the Ruff hook, remove MyPy, and introduce a .prekignore file

Build:
- Add check-meltano hook to the pre-commit config
- Rename the Ruff hook id from ruff to ruff-check
- Remove the pre-commit mypy hook and its dependencies
- Add a .prekignore file for pre-commit ignore patterns