### PR TITLE
fix(templates): Remove `branches` condition from pull request workflow trigger

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
@@ -13,7 +13,6 @@ on:
     - pyproject.toml
     - uv.lock
   pull_request:
-    branches: [main]
     paths:
     - .github/workflows/test.yml
     - {{ cookiecutter.library_name }}/**

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
@@ -13,7 +13,6 @@ on:
     - pyproject.toml
     - uv.lock
   pull_request:
-    branches: [main]
     paths:
     - .github/workflows/test.yml
     - {{ cookiecutter.library_name }}/**

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
@@ -13,7 +13,6 @@ on:
     - pyproject.toml
     - uv.lock
   pull_request:
-    branches: [main]
     paths:
     - .github/workflows/test.yml
     - {{ cookiecutter.library_name }}/**


### PR DESCRIPTION
## Summary by Sourcery

Allow GitHub Actions test workflows to run pull request triggers regardless of branch across all Cookiecutter templates

CI:
- Remove branch filter from pull_request triggers in mapper-template test workflow
- Remove branch filter from pull_request triggers in tap-template test workflow
- Remove branch filter from pull_request triggers in target-template test workflow