### PR TITLE
fix(deps): Migrate from `backoff` to `python-backoff`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 
 dependencies = [
-    'backoff>=2.2.0; python_version<"4"',
     'backports-datetime-fromisoformat>=2.0.1; python_version<"3.11"',
     "click>=8.2,<9",
     "fsspec>=2024.9.0",
@@ -41,6 +40,7 @@ dependencies = [
     "jsonpath-ng>=1.5.3",
     "jsonschema>=4.16.0",
     "packaging>=23.1",
+    'python-backoff>=2.2.2',
     "python-dotenv>=0.20",
     "PyYAML>=6.0",
     "referencing>=0.30.0",
@@ -188,7 +188,6 @@ addopts = [
 ]
 filterwarnings = [
     'error',
-    '''once:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning''',  # https://github.com/litl/backoff/pull/220
     'once:No records were available to test:UserWarning',
     # https://github.com/meltano/sdk/issues/1354
     'ignore:The function singer_sdk.testing.get_standard_tap_tests is deprecated:DeprecationWarning',

--- a/uv.lock
+++ b/uv.lock
@@ -241,15 +241,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backoff"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
-]
-
-[[package]]
 name = "backports-datetime-fromisoformat"
 version = "2.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -808,7 +799,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1952,6 +1943,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-backoff"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/5c/a31d90dfeb6689599439a62d3b9cc13a7a5ebafa75241f8f15f9eadf6a12/python_backoff-2.2.2.tar.gz", hash = "sha256:c8052800503e30fbfe3e6daa1ba03087f1fe42c9de03354da0f713b1e4f5028d", size = 18243, upload-time = "2025-11-17T19:24:52.442Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/80/251d50f76088bfdff7d36c47ffbaa91d0e826efd35207898b1ba7ff6db91/python_backoff-2.2.2-py3-none-any.whl", hash = "sha256:6fd39a8dfb4773dafe45f4a569ebcf17b4e9092a969efb51185b010d48bbfbf3", size = 15486, upload-time = "2025-11-17T19:24:50.97Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2359,7 +2359,6 @@ wheels = [
 name = "singer-sdk"
 source = { editable = "." }
 dependencies = [
-    { name = "backoff", marker = "python_full_version < '4'" },
     { name = "backports-datetime-fromisoformat", marker = "python_full_version < '3.11'" },
     { name = "click" },
     { name = "fsspec" },
@@ -2369,6 +2368,7 @@ dependencies = [
     { name = "jsonpath-ng" },
     { name = "jsonschema" },
     { name = "packaging" },
+    { name = "python-backoff" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "referencing" },
@@ -2509,7 +2509,6 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "backoff", marker = "python_full_version < '4'", specifier = ">=2.2.0" },
     { name = "backports-datetime-fromisoformat", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "click", specifier = ">=8.2,<9" },
     { name = "cryptography", marker = "extra == 'jwt'", specifier = ">=3.4.6" },
@@ -2526,6 +2525,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15" },
     { name = "pyjwt", marker = "extra == 'jwt'", specifier = ">=2.4.0" },
     { name = "pytest", marker = "extra == 'testing'", specifier = ">=9" },
+    { name = "python-backoff", specifier = ">=2.2.2" },
     { name = "python-dotenv", specifier = ">=0.20" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "referencing", specifier = ">=0.30.0" },


### PR DESCRIPTION
## Summary by Sourcery

Migrate from backoff to python-backoff and update related test configuration

Enhancements:
- Replace deprecated 'backoff' dependency with 'python-backoff>=2.2.2'
- Remove obsolete deprecation warning filter for asyncio.iscoroutinefunction
- Regenerate lock file to reflect updated dependencies