### PR TITLE
fix(taps): For log-based streams, write starting bookmark to the state to ensure the sync runs "incrementally"

### DIFF
--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -483,7 +483,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         Args:
             context: Stream partition or context dictionary.
         """
-        if self.replication_method != REPLICATION_INCREMENTAL:
+        if self.replication_method == REPLICATION_FULL_TABLE:
             self.log(
                 (
                     "Stream is not configured for incremental replication. Not "
@@ -1151,7 +1151,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         """
         self._write_state_message()  # Write out state message if pending.
 
-        if self.replication_method == "FULL_TABLE":
+        if self.replication_method == REPLICATION_FULL_TABLE:
             msg = "Sync operation aborted for stream in 'FULL_TABLE' replication mode."
             raise AbortedSyncFailedException(msg) from abort_reason
 


### PR DESCRIPTION
## Summary by Sourcery

Fix replication logic to write starting bookmarks for incremental streams and standardize full-table replication checks using the constant

Bug Fixes:
- Change condition in _write_starting_replication_value to skip only for full-table replication, ensuring incremental streams record the starting bookmark
- Replace hard-coded "FULL_TABLE" string comparison with REPLICATION_FULL_TABLE constant in _abort_sync