### PR TITLE
ci: Bump uv

### DIFF
--- a/.github/workflows/api-changes.yml
+++ b/.github/workflows/api-changes.yml
@@ -13,8 +13,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_COLOR: 1
+  FORCE_COLOR: "1"
   UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
+  UV_VERSION: ">=0.9,<0.10"
 
 permissions:  # added using https://github.com/step-security/secure-repo
   contents: read
@@ -37,7 +38,7 @@ jobs:
 
     - uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
       with:
-        version: ">=0.8,<0.9"
+        version: ${{ env.UV_VERSION }}
 
     - name: Install tools
       run: |

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -30,6 +30,7 @@ concurrency:
 
 env:
   FORCE_COLOR: "1"
+  UV_VERSION: ">=0.9,<0.10"
 
 permissions: {}
 
@@ -51,7 +52,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
       with:
-        version: ">=0.9,<0.10"
+        version: ${{ env.UV_VERSION }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/cookiecutter-e2e.yml
+++ b/.github/workflows/cookiecutter-e2e.yml
@@ -28,6 +28,7 @@ concurrency:
 env:
   FORCE_COLOR: "1"
   UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
+  UV_VERSION: ">=0.9,<0.10"
 
 permissions: {}
 
@@ -44,7 +45,7 @@ jobs:
         persist-credentials: false
     - uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
       with:
-        version: ">=0.8,<0.9"
+        version: ${{ env.UV_VERSION }}
     - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
 
     - name: Install Nox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ concurrency:
 env:
   FORCE_COLOR: "1"
   UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
-  UV_VERSION: ">=0.8,<0.9"
+  UV_VERSION: ">=0.9,<0.10"
 
 permissions: {}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: "1"
+  UV_VERSION: ">=0.9,<0.10"
+
 permissions: {}
 
 jobs:
@@ -27,7 +31,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
         with:
-          version: ">=0.8,<0.9"
+          version: ${{ env.UV_VERSION }}
 
       - name: Run zizmor 🌈
         run: >


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions workflows to use a centralized UV_VERSION environment variable and bump the uv version constraint to >=0.9,<0.10, while standardizing FORCE_COLOR settings.

CI:
- Introduce UV_VERSION env var in all workflows and update setup-uv steps to reference it
- Bump uv constraint from >=0.8,<0.9 to >=0.9,<0.10 across workflows
- Ensure FORCE_COLOR is consistently set to "1"