### PR TITLE
chore: Use dynamic versioning in workspace packages

### DIFF
--- a/packages/mapper-custom/pyproject.toml
+++ b/packages/mapper-custom/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mapper-custom"
-version = "0.1.0"
+dynamic = [ "version" ]
 description = "Singer mapper for custom transformations, built with the Meltano Singer SDK"
 authors = [{ name = "Meltano Team", email = "hello@meltano.com" }]
 keywords = [
@@ -28,9 +28,13 @@ mapper-custom = 'mapper_custom.mapper:StreamTransform.cli'
 [tool.mypy]
 warn_unused_configs = true
 
+[tool.hatch.version]
+fallback-version = "0.0.0"
+source = "vcs"
+
 [tool.uv.sources]
 singer-sdk = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/packages/tap-countries/pyproject.toml
+++ b/packages/tap-countries/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tap-countries"
-version = "0.1.0"
+dynamic = [ "version" ]
 description = "Singer tap for countries.trevorblades.com, built with the Meltano Singer SDK"
 authors = [{ name = "Meltano Team", email = "hello@meltano.com" }]
 keywords = [
@@ -32,9 +32,13 @@ tap-countries = 'tap_countries.tap:TapCountries.cli'
 [tool.mypy]
 warn_unused_configs = true
 
+[tool.hatch.version]
+fallback-version = "0.0.0"
+source = "vcs"
+
 [tool.uv.sources]
 singer-sdk = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/packages/tap-csv/pyproject.toml
+++ b/packages/tap-csv/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tap-csv"
-version = "0.1.0"
+dynamic = [ "version" ]
 description = "Singer tap for CSV files, built with the Meltano Singer SDK"
 authors = [{ name = "Meltano Team", email = "hello@meltano.com" }]
 keywords = [
@@ -29,9 +29,13 @@ tap-csv = 'tap_csv.tap:TapCSV.cli'
 [tool.mypy]
 warn_unused_configs = true
 
+[tool.hatch.version]
+fallback-version = "0.0.0"
+source = "vcs"
+
 [tool.uv.sources]
 singer-sdk = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/packages/tap-dummyjson/pyproject.toml
+++ b/packages/tap-dummyjson/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tap-dummyjson"
-version = "0.1.0"
+dynamic = [ "version" ]
 description = "Singer tap for DummyJSON, built with the Meltano Singer SDK"
 readme = "README.md"
 authors = [{ name = "Meltano Team", email = "hello@meltano.com" }]
@@ -40,6 +40,10 @@ dev = [
     "singer-sdk[testing]",
 ]
 
+[tool.hatch.version]
+fallback-version = "0.0.0"
+source = "vcs"
+
 [tool.mypy]
 python_version = "3.12"
 warn_unused_configs = true
@@ -48,5 +52,5 @@ warn_unused_configs = true
 singer-sdk = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/packages/tap-fake-people/pyproject.toml
+++ b/packages/tap-fake-people/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tap-fake-people"
-version = "0.1.0"
+dynamic = [ "version" ]
 description = "Singer tap for fake people, built with the Meltano Singer SDK"
 authors = [{ name = "Meltano Team", email = "hello@meltano.com" }]
 keywords = [
@@ -31,9 +31,13 @@ tap-fake-people = 'tap_fake_people.tap:TapFakePeople.cli'
 [tool.mypy]
 warn_unused_configs = true
 
+[tool.hatch.version]
+fallback-version = "0.0.0"
+source = "vcs"
+
 [tool.uv.sources]
 singer-sdk = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/packages/tap-fundamentals/pyproject.toml
+++ b/packages/tap-fundamentals/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tap-fundamentals"
-version = "0.1.0"
+dynamic = [ "version" ]
 description = "Singer tap for AAPL data, built with the Meltano Singer SDK"
 authors = [{ name = "Meltano Team", email = "hello@meltano.com" }]
 keywords = [
@@ -30,9 +30,13 @@ tap-fundamentals = 'tap_fundamentals:Fundamentals.cli'
 [tool.mypy]
 warn_unused_configs = true
 
+[tool.hatch.version]
+fallback-version = "0.0.0"
+source = "vcs"
+
 [tool.uv.sources]
 singer-sdk = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/packages/tap-gitlab/pyproject.toml
+++ b/packages/tap-gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tap-gitlab"
-version = "0.1.0"
+dynamic = [ "version" ]
 description = "Singer tap for GitLab, built with the Meltano Singer SDK"
 authors = [{ name = "Meltano Team", email = "hello@meltano.com" }]
 keywords = [
@@ -29,9 +29,13 @@ tap-gitlab = 'tap_gitlab.tap:TapGitlab.cli'
 [tool.mypy]
 warn_unused_configs = true
 
+[tool.hatch.version]
+fallback-version = "0.0.0"
+source = "vcs"
+
 [tool.uv.sources]
 singer-sdk = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/packages/tap-hostile/pyproject.toml
+++ b/packages/tap-hostile/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tap-hostile"
-version = "0.1.0"
+dynamic = [ "version" ]
 description = "Singer tap with hostile output"
 authors = [{ name = "Meltano Team", email = "hello@meltano.com" }]
 keywords = [
@@ -25,6 +25,10 @@ dependencies = [
 [project.scripts]
 tap-hostile = 'tap_hostile.tap:TapHostile.cli'
 
+[tool.hatch.version]
+fallback-version = "0.0.0"
+source = "vcs"
+
 [tool.mypy]
 warn_unused_configs = true
 
@@ -32,5 +36,5 @@ warn_unused_configs = true
 singer-sdk = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/packages/tap-sqlite/pyproject.toml
+++ b/packages/tap-sqlite/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tap-sqlite"
-version = "0.1.0"
+dynamic = [ "version" ]
 description = "Singer tap for SQLite, built with the Meltano Singer SDK"
 authors = [{ name = "Meltano Team", email = "hello@meltano.com" }]
 keywords = [
@@ -27,6 +27,10 @@ dependencies = [
 [project.scripts]
 tap-sqlite = 'tap_sqlite:SQLiteTap.cli'
 
+[tool.hatch.version]
+fallback-version = "0.0.0"
+source = "vcs"
+
 [tool.mypy]
 warn_unused_configs = true
 
@@ -34,5 +38,5 @@ warn_unused_configs = true
 singer-sdk = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/packages/target-csv/pyproject.toml
+++ b/packages/target-csv/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "target-csv"
-version = "0.1.0"
+dynamic = [ "version" ]
 description = "Singer target for CSV files, built with the Meltano Singer SDK"
 authors = [{ name = "Meltano Team", email = "hello@meltano.com" }]
 keywords = [
@@ -26,6 +26,10 @@ dependencies = [
 [project.scripts]
 target-csv = 'target_csv.target:TargetCSV.cli'
 
+[tool.hatch.version]
+fallback-version = "0.0.0"
+source = "vcs"
+
 [tool.mypy]
 warn_unused_configs = true
 
@@ -33,5 +37,5 @@ warn_unused_configs = true
 singer-sdk = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/packages/target-parquet/pyproject.toml
+++ b/packages/target-parquet/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "target-parquet"
-version = "0.1.0"
+dynamic = [ "version" ]
 description = "Singer target for Parquet files, built with the Meltano Singer SDK"
 authors = [{ name = "Meltano Team", email = "hello@meltano.com" }]
 keywords = [
@@ -26,6 +26,10 @@ dependencies = [
 [project.scripts]
 target-parquet = 'target_parquet.target:TargetParquet.cli'
 
+[tool.hatch.version]
+fallback-version = "0.0.0"
+source = "vcs"
+
 [tool.mypy]
 warn_unused_configs = true
 
@@ -33,5 +37,5 @@ warn_unused_configs = true
 singer-sdk = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/packages/target-sqlite/pyproject.toml
+++ b/packages/target-sqlite/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "target-sqlite"
-version = "0.1.0"
+dynamic = [ "version" ]
 description = "Singer target for SQLite files, built with the Meltano Singer SDK"
 authors = [{ name = "Meltano Team", email = "hello@meltano.com" }]
 keywords = [
@@ -26,6 +26,10 @@ dependencies = [
 [project.scripts]
 target-sqlite = 'target_sqlite:SQLiteTarget.cli'
 
+[tool.hatch.version]
+fallback-version = "0.0.0"
+source = "vcs"
+
 [tool.mypy]
 warn_unused_configs = true
 
@@ -33,5 +37,5 @@ warn_unused_configs = true
 singer-sdk = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/uv.lock
+++ b/uv.lock
@@ -799,7 +799,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1163,7 +1163,6 @@ wheels = [
 
 [[package]]
 name = "mapper-custom"
-version = "0.1.0"
 source = { editable = "packages/mapper-custom" }
 dependencies = [
     { name = "singer-sdk" },
@@ -2908,7 +2907,6 @@ wheels = [
 
 [[package]]
 name = "tap-countries"
-version = "0.1.0"
 source = { editable = "packages/tap-countries" }
 dependencies = [
     { name = "msgspec" },
@@ -2927,7 +2925,6 @@ requires-dist = [
 
 [[package]]
 name = "tap-csv"
-version = "0.1.0"
 source = { editable = "packages/tap-csv" }
 dependencies = [
     { name = "singer-sdk" },
@@ -2938,7 +2935,6 @@ requires-dist = [{ name = "singer-sdk", editable = "." }]
 
 [[package]]
 name = "tap-dummyjson"
-version = "0.1.0"
 source = { editable = "packages/tap-dummyjson" }
 dependencies = [
     { name = "requests" },
@@ -2976,7 +2972,6 @@ dev = [
 
 [[package]]
 name = "tap-fake-people"
-version = "0.1.0"
 source = { editable = "packages/tap-fake-people" }
 dependencies = [
     { name = "faker" },
@@ -2993,7 +2988,6 @@ requires-dist = [
 
 [[package]]
 name = "tap-fundamentals"
-version = "0.1.0"
 source = { editable = "packages/tap-fundamentals" }
 dependencies = [
     { name = "singer-sdk" },
@@ -3008,7 +3002,6 @@ requires-dist = [
 
 [[package]]
 name = "tap-gitlab"
-version = "0.1.0"
 source = { editable = "packages/tap-gitlab" }
 dependencies = [
     { name = "singer-sdk" },
@@ -3023,7 +3016,6 @@ requires-dist = [
 
 [[package]]
 name = "tap-hostile"
-version = "0.1.0"
 source = { editable = "packages/tap-hostile" }
 dependencies = [
     { name = "singer-sdk" },
@@ -3038,7 +3030,6 @@ requires-dist = [
 
 [[package]]
 name = "tap-sqlite"
-version = "0.1.0"
 source = { editable = "packages/tap-sqlite" }
 dependencies = [
     { name = "msgspec" },
@@ -3055,7 +3046,6 @@ requires-dist = [
 
 [[package]]
 name = "target-csv"
-version = "0.1.0"
 source = { editable = "packages/target-csv" }
 dependencies = [
     { name = "singer-sdk" },
@@ -3066,7 +3056,6 @@ requires-dist = [{ name = "singer-sdk", editable = "." }]
 
 [[package]]
 name = "target-parquet"
-version = "0.1.0"
 source = { editable = "packages/target-parquet" }
 dependencies = [
     { name = "pyarrow" },
@@ -3081,7 +3070,6 @@ requires-dist = [
 
 [[package]]
 name = "target-sqlite"
-version = "0.1.0"
 source = { editable = "packages/target-sqlite" }
 dependencies = [
     { name = "msgspec" },


### PR DESCRIPTION
## Summary by Sourcery

Enable dynamic versioning for all workspace packages by switching to VCS-sourced versions, removing static version fields, and adding hatch-vcs to the build configuration

Enhancements:
- Remove hard-coded version entries and configure dynamic version sourcing from VCS with a fallback version for each package

Build:
- Add hatch-vcs alongside hatchling to build-system requirements in all pyproject.toml files

Chores:
- Update uv.lock to reflect the new build-system dependency