### PR TITLE
chore: Replace `mdformat_frontmatter` with `mdformat-front-matters`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,10 +81,10 @@ repos:
       )$
 
 - repo: https://github.com/executablebooks/mdformat
-  rev: 0.7.22
+  rev: 1.0.0
   hooks:
   - id: mdformat
     exclude: tests/snapshots/about_format/markdown\.snap\.md
-    args: [--extensions, frontmatter]
+    args: [--strict-front-matter]
     additional_dependencies:
-    - mdformat-frontmatter
+    - mdformat-front-matters


### PR DESCRIPTION
## Summary by Sourcery

Update Markdown formatting pre-commit hook configuration to use the latest mdformat and correct frontmatter plugin package.

Build:
- Bump mdformat pre-commit hook from 0.7.22 to 1.0.0.
- Replace the mdformat frontmatter plugin dependency with the mdformat-front-matters package in pre-commit config.