### PR TITLE
fix(taps): Do not add `"type": ["null"]` to OpenAPI spec properties without a type

### DIFF
--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -362,7 +362,7 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
             schema_type = result.get("type", [])
 
         types = [schema_type] if isinstance(schema_type, str) else schema_type
-        if result.pop("nullable", False) and "null" not in types:
+        if types and result.pop("nullable", False) and "null" not in types:
             result["type"] = [*types, "null"]
 
         # Remove 'enum' keyword

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -838,3 +838,26 @@ class TestOpenAPISchemaNormalization:
 
             # Check that the array itself can be nullable
             assert normalized["properties"]["tags"]["type"] == ["array", "null"]
+
+    def test_normalize_properties_with_no_type(self, tmp_path: Path):
+        """Test that properties with no type are handled."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "null"},
+                    ],
+                },
+            },
+        }
+        openapi_file = tmp_path / "openapi.json"
+        openapi_file.write_text(json.dumps(schema))
+        source = OpenAPISchema(openapi_file)
+        normalized = source.preprocess_schema(schema)
+        assert "type" not in normalized["properties"]["id"]
+        assert normalized["properties"]["id"]["anyOf"] == [
+            {"type": "string"},
+            {"type": "null"},
+        ]


### PR DESCRIPTION
## Summary by Sourcery

Adjust OpenAPI schema normalization to correctly handle nullable properties without explicit types.

Bug Fixes:
- Prevent nullable OpenAPI properties that lack an explicit type from being incorrectly assigned a type array containing only null.

Tests:
- Add a regression test to ensure properties defined via anyOf with a null option do not receive an extraneous type field during normalization.