### PR TITLE
fix(taps): Do not leave dangling `nullable` field in OpenAPI schema properties

### DIFF
--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -362,7 +362,7 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
             schema_type = result.get("type", [])
 
         types = [schema_type] if isinstance(schema_type, str) else schema_type
-        if types and result.pop("nullable", False) and "null" not in types:
+        if result.pop("nullable", False) and types and "null" not in types:
             result["type"] = [*types, "null"]
 
         # Remove 'enum' keyword

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -857,6 +857,7 @@ class TestOpenAPISchemaNormalization:
         source = OpenAPISchema(openapi_file)
         normalized = source.preprocess_schema(schema)
         assert "type" not in normalized["properties"]["id"]
+        assert "nullable" not in normalized["properties"]["id"]
         assert normalized["properties"]["id"]["anyOf"] == [
             {"type": "string"},
             {"type": "null"},


### PR DESCRIPTION
Signed-off-by: Edgar Ramírez Mondragón <edgarrm358@gmail.com>

## Summary by Sourcery

Ensure OpenAPI schema normalization does not leave a dangling nullable flag on properties lacking an explicit type.

Bug Fixes:
- Fix handling of nullable properties so schemas without an explicit type do not retain an unused nullable field.

Tests:
- Extend schema normalization tests to assert nullable is removed from properties without a type.