### PR TITLE
chore: Use upstream schema for `check-dependabot` pre-commit hook until a new version is published

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,10 @@
 ci:
   autofix_prs: true
-  autoupdate_schedule: weekly
+  autoupdate_schedule: monthly
   autoupdate_commit_msg: 'chore: pre-commit autoupdate'
   skip:
   - uv-lock
+  - check-dependabot
 
 default_language_version:
   python: python3.13
@@ -44,7 +45,13 @@ repos:
   rev: 0.35.0
   hooks:
   - id: check-codecov
-  - id: check-dependabot
+  # TODO: Restore built-in check when https://github.com/SchemaStore/schemastore/pull/5167 ships into check-jsonschema
+  # - id: check-dependabot
+  - id: check-jsonschema
+    alias: check-dependabot
+    name: validate Dependabot configuration
+    files: ^.github/dependabot\.yml$
+    args: ["--schemafile", "https://json.schemastore.org/dependabot-2.0.json"]
   - id: check-github-issue-config
   - id: check-github-issue-forms
   - id: check-github-workflows


### PR DESCRIPTION
## Summary by Sourcery

Switch Dependabot configuration validation in pre-commit to use the upstream JSON schema via check-jsonschema until native support is available, and adjust pre-commit CI autoupdate cadence.

Build:
- Update pre-commit CI autoupdate schedule from weekly to monthly.

CI:
- Temporarily replace the built-in check-dependabot pre-commit hook with a check-jsonschema-based validation of .github/dependabot.yml using the official Dependabot schema.