### PR TITLE
chore: This is a library, reduce Dependabot cooldown to 1 day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
         dependency-type: production
     versioning-strategy: lockfile-only
     cooldown:
-      default-days: 7
+      default-days: 1
   - package-ecosystem: pip
     directory: "/.github/workflows/resources"
     schedule:


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Shorten Dependabot's default cooldown from 7 days to 1 day in the GitHub configuration.