### PR TITLE
fix: Simplify Python version handling in templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   pytest:
-    name: Integration Tests
+    name: Integration Tests / Python {{ '${{ matrix.python-version }}' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -49,7 +49,7 @@ jobs:
         version: ">=0.8"
     - name: Run Tox
       run: |
-        uvx --with=tox-uv tox -e $(echo py{{ '${{ matrix.python-version }}' }} | tr -d .)
+        uvx --with=tox-uv tox -e {{ '${{ matrix.python-version }}' }}
 
   typing:
     name: Type Checking

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   pytest:
-    name: Integration Tests
+    name: Integration Tests / Python {{ '${{ matrix.python-version }}' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -49,7 +49,7 @@ jobs:
         version: ">=0.8"
     - name: Run Tox
       run: |
-        uvx --with=tox-uv tox -e $(echo py{{ '${{ matrix.python-version }}' }} | tr -d .)
+        uvx --with=tox-uv tox -e {{ '${{ matrix.python-version }}' }}
 
   typing:
     name: Type Checking

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   pytest:
-    name: Integration Tests
+    name: Integration Tests / Python {{ '${{ matrix.python-version }}' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -49,7 +49,7 @@ jobs:
         version: ">=0.8"
     - name: Run Tox
       run: |
-        uvx --with=tox-uv tox -e $(echo py{{ '${{ matrix.python-version }}' }} | tr -d .)
+        uvx --with=tox-uv tox -e {{ '${{ matrix.python-version }}' }}
 
   typing:
     name: Type Checking


### PR DESCRIPTION
## Summary by Sourcery

Simplify Python version handling in GitHub Actions test workflows for mapper, tap, and target templates.

CI:
- Update pytest job names to include the active Python matrix version in GitHub Actions workflows for mapper, tap, and target templates.
- Simplify tox environment selection by using the matrix Python version directly in CI workflows instead of constructing environment names from it.