### PR TITLE
fix(templates): Add concurrency config to CI workflows in templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: {{ '${{ github.workflow }}-${{ github.head_ref || github.run_id }}' }}
   cancel-in-progress: true
 
 env:

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: {{ '${{ github.workflow }}-${{ github.head_ref || github.run_id }}' }}
   cancel-in-progress: true
 
 env:

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: {{ '${{ github.workflow }}-${{ github.head_ref || github.run_id }}' }}
   cancel-in-progress: true
 
 env:

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: {{ '${{ github.workflow }}-${{ github.head_ref || github.run_id }}' }}
   cancel-in-progress: true
 
 env:

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: {{ '${{ github.workflow }}-${{ github.head_ref || github.run_id }}' }}
   cancel-in-progress: true
 
 env:

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: {{ '${{ github.workflow }}-${{ github.head_ref || github.run_id }}' }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary by Sourcery

Add concurrency control and color-forcing environment to GitHub Actions workflows in all cookiecutter templates for mappers, taps, and targets.

CI:
- Configure workflow-level concurrency groups with in-progress run cancellation for build and test workflows in mapper, tap, and target templates.
- Set FORCE_COLOR=1 in build workflows for mapper, tap, and target templates to ensure colored output in CI.

## Summary by Sourcery

Add concurrency control and colorized output settings to CI workflows across mapper, tap, and target cookiecutter templates.

CI:
- Configure workflow-level concurrency groups with in-progress run cancellation for build and test workflows in mapper, tap, and target templates.
- Enable FORCE_COLOR=1 in build workflows for mapper, tap, and target templates to force colored output in CI logs.