### PR TITLE
chore: Use ty for type checking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       NOXFORCEPYTHON: ${{ matrix.python-version }}
       NOXSESSION: ${{ matrix.session }}
     permissions:
-      contents: read
+      contents: read  # read repository contents
     outputs:
       os: ${{ matrix.os }}
       nox-session: ${{ matrix.session }}
@@ -69,8 +69,6 @@ jobs:
         - "3.14"
         include:
         - { session: doctest,       python-version: "3.14", os: "ubuntu-latest" }
-        - { session: mypy,          python-version: "3.14", os: "ubuntu-latest" }
-        - { session: mypy,          python-version: "3.10",  os: "ubuntu-latest" }
         - { session: deps,          python-version: "3.14", os: "ubuntu-latest" }
         - { session: test-lowest,   python-version: "3.10",  os: "ubuntu-latest" }
         - { session: test-contrib,  python-version: "3.10",  os: "ubuntu-latest" }
@@ -108,6 +106,42 @@ jobs:
         include-hidden-files: true
         name: coverage-data-nox_${{ matrix.session }}-${{ matrix.os }}-py${{ matrix.python-version }}
         path: ".coverage.*"
+
+  typing:
+    name: Typing
+    runs-on: ubuntu-latest
+    needs: tests
+    env:
+      NOXFORCEPYTHON: ${{ matrix.python-version }}
+    permissions:
+      contents: read  # read repository contents
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+        - "3.10"
+        - "3.14"
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install Nox
+        run: |
+          uv tool install nox
+          nox --version
+
+      - name: Run Nox
+        run: |
+          nox --verbose --tags typing
 
   tests-external:
     name: External Tests

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -78,11 +78,14 @@ First clone, then...
 To run tests:
 
 ```bash
-# Run just the core and cookiecutter tests (no external creds required):
+# Run just the core and cookiecutter tests (no external credentials required):
 nox -rs tests
 
-# Run all tests (external creds required):
+# Run all tests (external credentials required):
 nox -rs test-external
+
+# Run type checks
+nox -rt typing
 ```
 
 To view the code coverage report in HTML format:

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,7 +59,7 @@ def _install_env(session: nox.Session) -> dict[str, str]:
     return env
 
 
-@nox.session(python=[python_versions[0], main_python])
+@nox.session(python=[python_versions[0], main_python], tags=["typing"])
 def mypy(session: nox.Session) -> None:
     """Check types with mypy."""
     default_locations = [
@@ -75,9 +75,30 @@ def mypy(session: nox.Session) -> None:
         "--all-extras",
         env=_install_env(session),
     )
-    session.run("mypy", *args)
+    python = session.python if isinstance(session.python, str) else main_python
+    session.run("mypy", "--python-version", python, *args)
     if not session.posargs:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")
+
+
+@nox.session(python=[python_versions[0], main_python], tags=["typing"])
+def ty(session: nox.Session) -> None:
+    """Check types with ty."""
+    default_locations = [
+        "packages",
+        "samples",
+        "singer_sdk",
+    ]
+    args = session.posargs or default_locations
+    session.run_install(
+        *UV_SYNC_COMMAND,
+        "--group=packages",
+        "--group=typing",
+        "--all-extras",
+        env=_install_env(session),
+    )
+    python = session.python if isinstance(session.python, str) else main_python
+    session.run("ty", "check", "--python-version", python, *args)
 
 
 def _run_pytest(session: nox.Session, *pytest_args: str, coverage: bool = True) -> None:

--- a/packages/meltano-tap-fake-people/tap_fake_people/tap.py
+++ b/packages/meltano-tap-fake-people/tap_fake_people/tap.py
@@ -57,7 +57,7 @@ class TapFakePeople(Tap):
     package_name: str = "meltano-tap-fake-people"
 
     @override  # type: ignore[misc]
-    def write_message(self, message: Message) -> None:
+    def write_message(self, message: Message) -> None:  # ty: ignore[override-of-final-method]
         if message.type == SingerMessageType.STATE:
             return
         super().write_message(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ typing = [
     {"include-group" = "testing"},
     "mypy>=1.17",
     "pyarrow-stubs>=19.1",
+    "ty>=0.0.4",
     "types-jsonschema>=4.17.0.6",
     "types-pytz>=2022.7.1.2",
     "types-requests>=2.28.11",

--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -449,11 +449,11 @@ class BasicAuthenticator(APIAuthenticatorBase):
         category=SingerSDKDeprecationWarning,
     )
     def create_for_stream(
-        cls: type[BasicAuthenticator],
+        cls: type[BasicAuthenticator],  # ty: ignore[deprecated]
         stream: _HTTPStream,
         username: str,
         password: str,
-    ) -> BasicAuthenticator:
+    ) -> BasicAuthenticator:  # ty: ignore[deprecated]
         """Create an Authenticator object specific to the Stream class.
 
         Args:
@@ -758,7 +758,7 @@ class OAuthJWTAuthenticator(OAuthAuthenticator):
                 password=passphrase,
                 backend=default_backend(),
             )
-        private_key_string: str | t.Any = private_key.decode("UTF-8")
+        private_key_string: str | t.Any = private_key.decode("UTF-8")  # ty: ignore[possibly-missing-attribute]
         return {
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
             "assertion": jwt.encode(

--- a/singer_sdk/contrib/msgspec.py
+++ b/singer_sdk/contrib/msgspec.py
@@ -60,7 +60,7 @@ def serialize_jsonl(obj: object, **kwargs: t.Any) -> bytes:  # noqa: ARG001
     """
     encoder.encode_into(obj, _jsonl_msg_buffer)
     _jsonl_msg_buffer.extend(b"\n")
-    return _jsonl_msg_buffer
+    return _jsonl_msg_buffer  # ty: ignore[invalid-return-type]
 
 
 class MsgSpecReader(GenericSingerReader[str]):

--- a/singer_sdk/helpers/_batch.py
+++ b/singer_sdk/helpers/_batch.py
@@ -214,7 +214,7 @@ class BatchConfig:
             self.encoding = BaseBatchFileEncoding.from_dict(self.encoding)  # type: ignore[unreachable]
 
         if isinstance(self.storage, dict):
-            self.storage = StorageTarget.from_dict(self.storage)
+            self.storage = StorageTarget.from_dict(self.storage)  # ty: ignore[invalid-argument-type]
 
         if self.batch_size is None:
             self.batch_size = DEFAULT_BATCH_SIZE  # type: ignore[unreachable]

--- a/singer_sdk/helpers/_flattening.py
+++ b/singer_sdk/helpers/_flattening.py
@@ -24,7 +24,7 @@ def _first(iterable: t.Iterable[_T]) -> _T | None:
     return next(iter(iterable), None)
 
 
-class PluginFlatteningConfig(t.TypedDict):
+class PluginFlatteningConfig(t.TypedDict, total=False):
     """Plugin flattening configuration."""
 
     flattening_enabled: bool

--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -250,7 +250,7 @@ def _greater_than_signpost(
 ) -> bool:
     """Compare and return True if new_value is greater than signpost."""
     # fails if signpost and bookmark are incompatible types
-    return new_value > signpost
+    return new_value > signpost  # ty: ignore[unsupported-operator]
 
 
 def is_state_non_resumable(stream_or_partition_state: dict) -> bool:

--- a/singer_sdk/helpers/capabilities.py
+++ b/singer_sdk/helpers/capabilities.py
@@ -382,7 +382,7 @@ class DeprecatedEnumMeta(EnumMeta):
         Returns:
             Enum member.
         """
-        obj: Enum = super().__getitem__(name)
+        obj: Enum = super().__getitem__(name)  # ty: ignore[invalid-assignment]
         if isinstance(obj, DeprecatedEnum) and obj.deprecation_message:
             obj.emit_warning()
         return obj

--- a/singer_sdk/logging.py
+++ b/singer_sdk/logging.py
@@ -92,7 +92,7 @@ class StructuredFormatter(logging.Formatter):
 
         # Extract basic exception info
         exception_data: _ExceptionData = {
-            "type": exc_type.__name__,
+            "type": exc_type.__name__,  # ty: ignore[possibly-missing-attribute]
             "module": exc_type.__module__,
             "message": str(exc_value),
         }

--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -633,7 +633,7 @@ class Sink(metaclass=abc.ABCMeta):  # noqa: PLR0904
                     date_val = handle_invalid_timestamp_in_record(
                         record,
                         [key],
-                        date_val,
+                        date_val,  # ty: ignore[invalid-argument-type]
                         datelike_type,
                         ex,
                         treatment,

--- a/singer_sdk/sql/connector.py
+++ b/singer_sdk/sql/connector.py
@@ -716,7 +716,7 @@ class SQLConnector:  # noqa: PLR0904
             SingerSDKDeprecationWarning,
             stacklevel=2,
         )
-        return self.create_sqlalchemy_connection()
+        return self.create_sqlalchemy_connection()  # ty: ignore[deprecated]
 
     @property
     def sqlalchemy_url(self) -> str:
@@ -792,7 +792,7 @@ class SQLConnector:  # noqa: PLR0904
                 SingerSDKDeprecationWarning,
                 stacklevel=2,
             )
-            return th.to_jsonschema_type(sql_type)
+            return th.to_jsonschema_type(sql_type)  # ty: ignore[deprecated]
 
         if isinstance(sql_type, type):  # pragma: no cover
             warnings.warn(
@@ -802,7 +802,7 @@ class SQLConnector:  # noqa: PLR0904
                 stacklevel=2,
             )
             if issubclass(sql_type, sqlalchemy.types.TypeEngine):
-                return th.to_jsonschema_type(sql_type)
+                return th.to_jsonschema_type(sql_type)  # ty: ignore[deprecated]
 
             msg = f"Unexpected type received: '{sql_type.__name__}'"
             raise ValueError(msg)
@@ -1738,8 +1738,8 @@ class SQLConnector:  # noqa: PLR0904
              The removed collation as a string.
         """
         if hasattr(column_type, "collation") and column_type.collation:
-            column_type_collation: str = column_type.collation
-            column_type.collation = None
+            column_type_collation: str = column_type.collation  # ty: ignore[invalid-assignment]
+            column_type.collation = None  # ty: ignore[invalid-assignment]
             return column_type_collation
         return None
 
@@ -1755,7 +1755,7 @@ class SQLConnector:  # noqa: PLR0904
             collation: The colation
         """
         if hasattr(column_type, "collation") and collation:
-            column_type.collation = collation
+            column_type.collation = collation  # ty: ignore[invalid-assignment]
 
     def _adapt_column_type(
         self,

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -170,11 +170,11 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         self.child_streams: list[Stream] = []
         if schema:
             if isinstance(schema, (PathLike, str)):
-                if not Path(schema).is_file():
+                if not Path(schema).is_file():  # ty: ignore[invalid-argument-type]
                     msg = f"Could not find schema file '{self.schema_filepath}'."
                     raise FileNotFoundError(msg)
 
-                self._schema_filepath = Path(schema)
+                self._schema_filepath = Path(schema)  # ty: ignore[invalid-argument-type]
                 warnings.warn(
                     "Passing a schema filepath is deprecated. Please pass a schema "
                     "dictionary or a Singer Schema object instead.",
@@ -247,7 +247,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
                     stream_alias=self.name,
                     raw_schema=self.schema,
                     key_properties=self.primary_keys,
-                    flattening_options=get_flattening_options(self.config),
+                    flattening_options=get_flattening_options(self.config),  # ty: ignore[invalid-argument-type]
                 ),
             ]
         return self._stream_maps

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -854,7 +854,7 @@ class RESTStream(_HTTPStream, t.Generic[_TToken], metaclass=abc.ABCMeta):
                 DeprecationWarning,
                 stacklevel=2,
             )
-            return LegacyStreamPaginator(self)
+            return LegacyStreamPaginator(self)  # ty: ignore[invalid-argument-type]
 
         if self.next_page_token_jsonpath:
             return JSONPathPaginator(self.next_page_token_jsonpath)

--- a/uv.lock
+++ b/uv.lock
@@ -904,7 +904,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2832,6 +2832,7 @@ dev = [
     { name = "sphinx-reredirects", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "time-machine" },
     { name = "toolz" },
+    { name = "ty" },
     { name = "types-jsonschema" },
     { name = "types-pytz" },
     { name = "types-pyyaml" },
@@ -2897,6 +2898,7 @@ typing = [
     { name = "rfc3339-validator" },
     { name = "time-machine" },
     { name = "toolz" },
+    { name = "ty" },
     { name = "types-jsonschema" },
     { name = "types-pytz" },
     { name = "types-pyyaml" },
@@ -2980,6 +2982,7 @@ dev = [
     { name = "sphinx-reredirects", specifier = ">=0.1.5" },
     { name = "time-machine", specifier = ">=2.10.0" },
     { name = "toolz", specifier = ">=1.0.0" },
+    { name = "ty", specifier = ">=0.0.4" },
     { name = "types-jsonschema", specifier = ">=4.17.0.6" },
     { name = "types-pytz", specifier = ">=2022.7.1.2" },
     { name = "types-pyyaml", specifier = ">=6.0.12" },
@@ -3043,6 +3046,7 @@ typing = [
     { name = "rfc3339-validator", specifier = ">=0.1.4" },
     { name = "time-machine", specifier = ">=2.10.0" },
     { name = "toolz", specifier = ">=1.0.0" },
+    { name = "ty", specifier = ">=0.0.4" },
     { name = "types-jsonschema", specifier = ">=4.17.0.6" },
     { name = "types-pytz", specifier = ">=2022.7.1.2" },
     { name = "types-pyyaml", specifier = ">=6.0.12" },
@@ -3466,6 +3470,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/d9/97d5808e851f790e58f8a54efb5c7b9f404640baf9e295f424846040b316/ty-0.0.4.tar.gz", hash = "sha256:2ea47a0089d74730658ec4e988c8ef476a1e9bd92df3e56709c4003c2895ff3b", size = 4780289, upload-time = "2025-12-19T00:13:53.12Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/94/b32a962243cc8a16e8dc74cf1fe75e8bb013d0e13e71bb540e2c86214b61/ty-0.0.4-py3-none-linux_armv6l.whl", hash = "sha256:5225da65a8d1defeb21ee9d74298b1b97c6cbab36e235a310c1430d9079e4b6a", size = 9762399, upload-time = "2025-12-19T00:14:11.261Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/d2/7c76e0c22ddfc2fcd4a3458a65f87ce074070eb1c68c07ee475cc2b6ea68/ty-0.0.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f87770d7988f470b795a2043185082fa959dbe1979a11b4bfe20f1214d37bd6e", size = 9590410, upload-time = "2025-12-19T00:13:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/84/de4b1fc85669faca3622071d5a3f3ec7bfb239971f368c28fae461d3398a/ty-0.0.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ecf68b8ea48674a289d733b4786aecc259242a2d9a920b3ec8583db18c67496a", size = 9131113, upload-time = "2025-12-19T00:14:08.593Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ff/b5bf385b6983be56a470856bbcbac1b7e816bcd765a7e9d39ab2399e387d/ty-0.0.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efc396d76a57e527393cae4ee8faf23b93be3df9e93202f39925721a7a2bb7b8", size = 9599152, upload-time = "2025-12-19T00:13:40.484Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d6/9880ba106f2f20d13e6a5dca5d5ca44bfb3782936ee67ff635f89a2959c0/ty-0.0.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c893b968d2f9964a4d4db9992c9ba66b01f411b1f48dffcde08622e19cd6ab97", size = 9585368, upload-time = "2025-12-19T00:14:00.994Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/53/503cfc18bc4c7c4e02f89dd43debc41a6e343b41eb43df658dfb493a386d/ty-0.0.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:526c925b80d68a53c165044d2370fcfc0def1f119f7b7e483ee61d24da6fb891", size = 9998412, upload-time = "2025-12-19T00:14:18.653Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/bd/dd2d3e29834da5add2eda0ab5b433171ce9ce9a248c364d2e237f82073d7/ty-0.0.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:857f605a7fa366b6c6e6f38abc311d0606be513c2bee8977b5c8fd4bde1a82d5", size = 10853890, upload-time = "2025-12-19T00:13:50.891Z" },
+    { url = "https://files.pythonhosted.org/packages/07/fe/28ba3be1672e6b8df46e43de66a02dc076ffba7853d391a5466421886225/ty-0.0.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b4cc981aa3ebdac2c233421b1e58c80b0df6a8e6e6fa8b9e69fbdfd2f82768af", size = 10587263, upload-time = "2025-12-19T00:14:21.577Z" },
+    { url = "https://files.pythonhosted.org/packages/26/9c/bb598772043f686afe5bc26cb386020709c1a0bcc164bc22ad9da2b4f55d/ty-0.0.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b03b2708b0bf67c76424a860f848aebaa4772c05529170c3761bfcaea93ec199", size = 10401204, upload-time = "2025-12-19T00:13:43.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/18/71765e9d63669bf09461c3fea84a7a63232ccb0e83b84676f07b987fc217/ty-0.0.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:469890e885544beb129c21e2f8f15321f0573d094aec13da68593c5f86389ff9", size = 10129713, upload-time = "2025-12-19T00:14:13.725Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/2d/c03eba570aa85e9c361de5ed36d60b9ab139e93ee91057f455ab4af48e54/ty-0.0.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:abfd928d09567e12068aeca875e920def3badf1978896f474aa4b85b552703c4", size = 9586203, upload-time = "2025-12-19T00:14:03.423Z" },
+    { url = "https://files.pythonhosted.org/packages/61/f1/8c3c82a8df69bd4417c77be4f895d043db26dd47bfcc90b33dc109cd0096/ty-0.0.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:44b8e94f9d64df12eae4cf8031c5ca9a4c610b57092b26ad3d68d91bcc7af122", size = 9608230, upload-time = "2025-12-19T00:13:58.252Z" },
+    { url = "https://files.pythonhosted.org/packages/51/0c/d8ba3a85c089c246ef6bd49d0f0b40bc0f9209bb819e8c02ccbea5cb4d57/ty-0.0.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9d6a439813e21a06769daf858105818c385d88018929d4a56970d4ddd5cd3df2", size = 9725125, upload-time = "2025-12-19T00:14:05.996Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/38/e30f64ad1e40905c766576ec70cffc69163591a5842ce14652672f6ab394/ty-0.0.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c3cfcf26cfe6c828e91d7a529cc2dda37bc3b51ba06909c9be07002a6584af52", size = 10237174, upload-time = "2025-12-19T00:14:23.858Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d7/8d650aa0be8936dd3ed74e2b0655230e2904caa6077c30c16a089b523cff/ty-0.0.4-py3-none-win32.whl", hash = "sha256:58bbf70dd27af6b00dedbdebeec92d5993aa238664f96fa5c0064930f7a0d30b", size = 9188434, upload-time = "2025-12-19T00:13:45.875Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d7/9fc0c81cf0b0d281ac9c18bfbdb4d6bae2173503ba79e40b210ab41c2c8b/ty-0.0.4-py3-none-win_amd64.whl", hash = "sha256:7c2db0f96218f08c140bd9d3fcbb1b3c8c5c4f0c9b0a5624487f0a2bf4b76163", size = 10019313, upload-time = "2025-12-19T00:14:15.968Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b8/3e3246738eed1cd695c5964a401f3b9c757d20ac21fdae06281af9f40ef6/ty-0.0.4-py3-none-win_arm64.whl", hash = "sha256:69f14fc98e4a847afa9f8c5d5234d008820dbc09c7dcdb3ac1ba16628f5132df", size = 9561857, upload-time = "2025-12-19T00:13:48.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Introduce a dedicated typing Nox/CI workflow using the ty type checker alongside mypy adjustments and minor typing suppressions across the codebase.

Enhancements:
- Tag mypy and new ty Nox sessions for typing, ensuring Python-version-aware type checking.
- Relax or adjust type hints and operations with targeted ty ignore annotations to satisfy the new type checker.
- Make the plugin flattening config TypedDict partially optional by marking it total=False.

Build:
- Add ty as a typing dependency in pyproject.toml.

CI:
- Add a separate GitHub Actions job to run Nox sessions tagged as typing across multiple Python versions.

Documentation:
- Update contributor documentation to describe how to run the new typing Nox sessions locally.