### PR TITLE
chore(deps): Configure Dependabot to update transitive dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-      time: "12:00"
     labels: [Dependencies]
     groups:
       development-dependencies:
@@ -15,11 +14,12 @@ updates:
     versioning-strategy: lockfile-only
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "all"
   - package-ecosystem: pip
     directory: "/.github/workflows/resources"
     schedule:
       interval: weekly
-      time: "12:00"
     labels: [Dependencies]
     groups:
       ci:


### PR DESCRIPTION
## Links

- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#dependency-type-allow

## Summary by Sourcery

Configure Dependabot to broaden dependency update coverage and simplify scheduling configuration.

Build:
- Enable Dependabot to update all dependency types for the main package ecosystem.
- Remove explicit scheduled run times from Dependabot update configurations in favor of interval-only scheduling.