### PR TITLE
fix(taps): Make the `context` parameter of `Stream.get_replication_key_signpost()` optional and default to `None`

### DIFF
--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -508,7 +508,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
 
     def get_replication_key_signpost(
         self,
-        context: types.Context | None,  # noqa: ARG002
+        context: types.Context | None = None,  # noqa: ARG002
     ) -> datetime.datetime | t.Any | None:  # noqa: ANN401
         """Get the replication signpost.
 
@@ -1399,8 +1399,7 @@ class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
         self.context = MappingProxyType(context) if context else None
 
         # Use a replication signpost, if available
-        signpost = self.get_replication_key_signpost(context)
-        if signpost:
+        if signpost := self.get_replication_key_signpost(context):
             self._write_replication_key_signpost(context, signpost)
 
         # Send a SCHEMA message to the downstream target:


### PR DESCRIPTION
## Summary by Sourcery

Make the replication signpost retrieval more flexible and simplify its usage during stream sync.

Bug Fixes:
- Allow calling `Stream.get_replication_key_signpost()` without explicitly passing a context by making the context parameter optional.

Enhancements:
- Stream sync flow now uses the walrus operator to inline retrieval and conditional handling of the replication key signpost.

## Summary by Sourcery

Make replication key signpost handling more flexible and simplify its usage in stream synchronization.

Bug Fixes:
- Allow `Stream.get_replication_key_signpost()` to be called without an explicit context by making the context parameter optional.

Enhancements:
- Inline retrieval and conditional handling of the replication key signpost in the stream sync flow using a single conditional expression.