### PR TITLE
chore: Use `https://github.com/hukkin/mdformat` instead of `https://github.com/executablebooks/mdformat`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
         packages/.*\.json|
       )$
 
-- repo: https://github.com/executablebooks/mdformat
+- repo: https://github.com/hukkin/mdformat
   rev: 1.0.0
   hooks:
   - id: mdformat


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update pre-commit configuration to reference the hukkin/mdformat repository for Markdown formatting.