### PR TITLE
chore: Use `nox.session(default=...)` to mark default sessions and make `noxfile.py` executable

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -49,7 +49,7 @@ First clone, then...
 1. Most development tasks you might need should be covered by `nox` sessions. You can use `nox -l` to list all available tasks.
    For example:
 
-   - Run unit tests: `nox -r`.
+   - Run all default checks: `nox`.
 
      We use `coverage` for code coverage metrics.
 
@@ -61,7 +61,7 @@ First clone, then...
      [mypy](https://mypy.readthedocs.io/en/stable/).
      The project-wide max line length is `88`.
 
-   - Build documentation: `nox -rs docs`
+   - Build documentation: `nox -s docs`
 
      We use `sphinx` to build documentation.
 
@@ -79,20 +79,24 @@ To run tests:
 
 ```bash
 # Run just the core and cookiecutter tests (no external credentials required):
-nox -rs tests
+nox -s tests
 
 # Run all tests (external credentials required):
-nox -rs test-external
+nox -s test-external
 
 # Run type checks
-nox -rt typing
+nox -t typing
 ```
 
 To view the code coverage report in HTML format:
 
 ```bash
-nox -rs coverage -- html && open ./htmlcov/index.html
+nox -s coverage -- html && open ./htmlcov/index.html
 ```
+
+:::{tip}
+You can execute the Noxfile directly, for example: `./noxfile.py -s tests`.
+:::
 
 ### Platform-specific Testing
 
@@ -139,7 +143,7 @@ def test_snapshot(snapshot, snapshot_dir):
 To update or generate snapshots, run the nox `update_snapshots` session
 
 ```bash
-nox -rs snap
+nox -s snap
 ```
 
 or use the `--snapshot-update` flag
@@ -161,7 +165,7 @@ versions of the docs for us.
 To build the docs and live-reload them locally:
 
 ```bash
-nox -rs docs-serve
+nox -s docs-serve
 ```
 
 Sphinx will automatically generate class stubs, so be sure to `git add` them.

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# dependencies = ["nox"]
+# ///
+
 """Nox configuration."""
 
 from __future__ import annotations
@@ -11,6 +17,7 @@ import nox
 
 nox.needs_version = ">=2025.2.9"
 nox.options.default_venv_backend = "uv"
+nox.options.reuse_venv = "yes"
 
 RUFF_OVERRIDES = """\
 extend = "./pyproject.toml"
@@ -32,14 +39,6 @@ package = "singer_sdk"
 main_python = Path(".python-version").read_text(encoding="utf-8").rstrip()
 python_versions = nox.project.python_versions(PYPROJECT)
 locations = "singer_sdk", "tests", "noxfile.py", "docs/conf.py"
-nox.options.sessions = [
-    f"mypy-{main_python}",
-    f"ty-{main_python}",
-    f"tests-{main_python}",
-    "doctest",
-    "deps",
-    "docs",
-]
 
 
 def _install_env(session: nox.Session) -> dict[str, str]:
@@ -140,7 +139,7 @@ def tests(session: nox.Session) -> None:
     )
 
 
-@nox.session(name="test-external", python=main_python, tags=["test"])
+@nox.session(name="test-external", python=main_python, tags=["test"], default=False)
 def test_external(session: nox.Session) -> None:
     """Execute pytest tests and compute coverage."""
     session.run_install(
@@ -164,6 +163,7 @@ def test_external(session: nox.Session) -> None:
     name="test-contrib",
     python=[python_versions[0], main_python],
     tags=["test"],
+    default=False,
 )
 def test_contrib(session: nox.Session) -> None:
     """Execute pytest tests and compute coverage."""
@@ -191,6 +191,7 @@ def test_contrib(session: nox.Session) -> None:
     name="test-packages",
     python=[python_versions[0], main_python],
     tags=["test"],
+    default=False,
 )
 def test_packages(session: nox.Session) -> None:
     """Execute pytest tests and compute coverage."""
@@ -215,7 +216,12 @@ def test_packages(session: nox.Session) -> None:
     )
 
 
-@nox.session(name="test-lowest", python=python_versions[0], tags=["test"])
+@nox.session(
+    name="test-lowest",
+    python=python_versions[0],
+    tags=["test"],
+    default=False,
+)
 def test_lowest_requirements(session: nox.Session) -> None:
     """Test the package with the lowest dependency versions."""
     install_env = _install_env(session)
@@ -256,7 +262,7 @@ def test_lowest_requirements(session: nox.Session) -> None:
     )
 
 
-@nox.session(tags=["test"])
+@nox.session(tags=["test"], default=False)
 def benches(session: nox.Session) -> None:
     """Run benchmarks."""
     session.run_install(
@@ -277,7 +283,7 @@ def benches(session: nox.Session) -> None:
     )
 
 
-@nox.session()
+@nox.session(default=False)
 def coverage(session: nox.Session) -> None:
     """Generate coverage report."""
     args = session.posargs or ["report", "-m"]
@@ -318,7 +324,7 @@ def dependencies(session: nox.Session) -> None:
     session.run("deptry", "singer_sdk", *session.posargs)
 
 
-@nox.session(name="snap")
+@nox.session(name="snap", default=False)
 def update_snapshots(session: nox.Session) -> None:
     """Update pytest snapshots."""
     session.run_install(
@@ -376,7 +382,7 @@ def docs(session: nox.Session) -> None:
     session.run("sphinx-build", *args)
 
 
-@nox.session(name="docs-serve")
+@nox.session(name="docs-serve", default=False)
 def docs_serve(session: nox.Session) -> None:
     """Build the documentation."""
     args = session.posargs or [
@@ -405,7 +411,7 @@ def docs_serve(session: nox.Session) -> None:
 
 
 @nox.parametrize("replay_file_path", COOKIECUTTER_REPLAY_FILES)
-@nox.session()
+@nox.session(default=False)
 def templates(session: nox.Session, replay_file_path: Path) -> None:
     """Uses the tap template to build an empty cookiecutter.
 
@@ -467,29 +473,7 @@ def templates(session: nox.Session, replay_file_path: Path) -> None:
     session.run("uvx", "--with=tox-uv", "tox", "-e=typing")
 
 
-@nox.session(name="version-bump")
-def version_bump(session: nox.Session) -> None:
-    """Run commitizen."""
-    session.install(
-        "commitizen",
-        "commitizen-version-bump @ git+https://github.com/meltano/commitizen-version-bump.git@main",
-    )
-    default_args = [
-        "--changelog",
-        "--files-only",
-        "--check-consistency",
-        "--changelog-to-stdout",
-    ]
-    args = session.posargs or default_args
-
-    session.run(
-        "cz",
-        "bump",
-        *args,
-    )
-
-
-@nox.session(name="api")
+@nox.session(name="api", default=False)
 def api_changes(session: nox.Session) -> None:
     """Check for API changes."""
     args = [
@@ -505,3 +489,7 @@ def api_changes(session: nox.Session) -> None:
         args.append("-f=github")
 
     session.run("uvx", "griffe", *args, external=True)
+
+
+if __name__ == "__main__":
+    nox.main()


### PR DESCRIPTION
## Summary by Sourcery

Configure Nox session defaults and reuse behavior while aligning contributor docs with the updated Nox usage and making the Noxfile directly executable.

Enhancements:
- Enable Nox virtual environment reuse via configuration rather than per-invocation flags.
- Refine which Nox sessions are considered default by explicitly marking non-default sessions.
- Make the Nox configuration file directly executable as a script entry point.

Documentation:
- Update contributor documentation to reflect the new default Nox invocation pattern and session selection flags, including guidance on running the Noxfile directly.

Chores:
- Remove the obsolete Nox session used for version bumping from the project configuration.