### PR TITLE
chore: Enable Ruff `LOG` rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -372,6 +372,7 @@ select = [
     "FA",   # flake8-future-annotations
     "ISC",  # flake8-implicit-str-concat
     "ICN",  # flake8-import-conventions
+    "LOG",  # flake8-logging
     "G",    # flake8-logging-format
     "INP",  # flake8-no-pep420
     "PIE",  # flake8-pie

--- a/tests/core/test_mapper.py
+++ b/tests/core/test_mapper.py
@@ -534,19 +534,20 @@ def _run_transform(
 ):
     output: dict[str, list[dict]] = {}
     output_schemas = {}
+    logger = logging.getLogger()
     mapper = PluginMapper(
         plugin_config={
             "stream_maps": stream_maps,
             "stream_map_config": stream_map_config,
         },
-        logger=logging.getLogger(),
+        logger=logger,
     )
     mapper.register_raw_streams_from_catalog(sample_catalog_obj)
 
     for stream_name, stream in sample_stream.items():
         for stream_map in mapper.stream_maps[stream_name]:
             if isinstance(stream_map, RemoveRecordTransform):
-                logging.info("Skipping ignored stream '%s'", stream_name)
+                logger.info("Skipping ignored stream '%s'", stream_name)
                 continue
             output_schemas[stream_map.stream_alias] = stream_map.transformed_schema
             output[stream_map.stream_alias] = []


### PR DESCRIPTION
Signed-off-by: Edgar Ramírez Mondragón <edgarrm358@gmail.com>

## Summary by Sourcery

Enable Ruff LOG logging style checks and update tests to use a dedicated logger instance instead of the root logger.

Enhancements:
- Configure Ruff to enforce flake8-logging (LOG) rules in the linter configuration.

Tests:
- Adjust mapper tests to obtain a logger instance once and reuse it for logging calls instead of using the root logger directly.