### PR TITLE
refactor: Enable Ruff `FURB` rules

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -453,8 +453,7 @@ def templates(session: nox.Session, replay_file_path: Path) -> None:
     )
     session.chdir(cc_test_output)
 
-    with Path("ruff.toml").open("w", encoding="utf-8") as ruff_toml:
-        ruff_toml.write(RUFF_OVERRIDES)
+    Path("ruff.toml").write_text(RUFF_OVERRIDES, encoding="utf-8")
 
     # Use the local singer-sdk
     session.run("uv", "add", f"singer-sdk @ {sdk_dir}")

--- a/packages/meltano-tap-countries/tap_countries/streams.py
+++ b/packages/meltano-tap-countries/tap_countries/streams.py
@@ -28,7 +28,7 @@ else:
 SCHEMAS_DIR = SchemaDirectory(schemas)
 
 
-class CountriesAPIStream(GraphQLStream, metaclass=abc.ABCMeta):
+class CountriesAPIStream(GraphQLStream, abc.ABC):
     """Sample tap test for countries.
 
     NOTE: This API does not require authentication.

--- a/packages/meltano-target-parquet/target_parquet/sink.py
+++ b/packages/meltano-target-parquet/target_parquet/sink.py
@@ -42,7 +42,7 @@ def _json_schema_to_arrow_fields(
         field = pa.field(name, _json_type_to_arrow_field(property_schema))
         fields.append(field)
 
-    return fields if fields else [pa.field("dummy", pa.string())]
+    return fields or [pa.field("dummy", pa.string())]
 
 
 def _json_type_to_arrow_field(  # noqa: PLR0911

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -395,6 +395,7 @@ select = [
     "TRY",  # tryceratops
     "FLY",  # flynt
     "PERF", # perflint
+    "FURB", # refurb
     "RUF",  # ruff
 ]
 unfixable = [

--- a/singer_sdk/contrib/filesystem/stream.py
+++ b/singer_sdk/contrib/filesystem/stream.py
@@ -30,7 +30,7 @@ SDC_META_FILEPATH = "_sdc_path"
 SDC_META_MODIFIED_AT = "_sdc_modified_at"
 
 
-class FileStream(Stream, metaclass=abc.ABCMeta):
+class FileStream(Stream, abc.ABC):
     """Abstract base class for file streams."""
 
     SDC_PROPERTIES: t.ClassVar[dict[str, dict]] = {

--- a/singer_sdk/exceptions.py
+++ b/singer_sdk/exceptions.py
@@ -65,7 +65,7 @@ class MaxRecordsLimitException(RequestedAbortException):
     """Exception indicating the sync aborted due to too many records."""
 
 
-class AbortedSyncExceptionBase(Exception, metaclass=abc.ABCMeta):
+class AbortedSyncExceptionBase(Exception, abc.ABC):
     """Base exception to raise when a stream sync is aborted.
 
     Developers should not raise this directly, and instead should use:

--- a/singer_sdk/helpers/_flattening.py
+++ b/singer_sdk/helpers/_flattening.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import collections.abc
 import itertools
+import operator
 import re
 import typing as t
 from copy import deepcopy
@@ -408,11 +409,9 @@ def _flatten_schema(  # noqa: C901, PLR0912
             items.append((new_key, {"type": ["null", "string"]}))
 
     # Sort and check for duplicates
-    def _key_func(item: tuple[str, dict]) -> str:
-        return item[0]  # first item in tuple is the key name.
-
-    sorted_items = sorted(items, key=_key_func)
-    for field_name, g in itertools.groupby(sorted_items, key=_key_func):
+    key_func = operator.itemgetter(0)
+    sorted_items = sorted(items, key=key_func)
+    for field_name, g in itertools.groupby(sorted_items, key=key_func):
         if len(list(g)) > 1:
             msg = f"Duplicate column name produced in schema: {field_name}"
             raise ValueError(msg)

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -71,7 +71,7 @@ def sha256(string: str) -> str:
 StreamMapsDict: t.TypeAlias = dict[str, str | dict | None]
 
 
-class StreamMap(metaclass=abc.ABCMeta):
+class StreamMap(abc.ABC):
     """Abstract base class for all map classes."""
 
     def __init__(

--- a/singer_sdk/mapper_base.py
+++ b/singer_sdk/mapper_base.py
@@ -21,7 +21,7 @@ if t.TYPE_CHECKING:
     )
 
 
-class InlineMapper(BaseSingerReader, BaseSingerWriter, metaclass=abc.ABCMeta):
+class InlineMapper(BaseSingerReader, BaseSingerWriter, abc.ABC):
     """Abstract base class for inline mappers."""
 
     #: A list of plugin capabilities.

--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -169,7 +169,7 @@ def log(logger: logging.Logger, point: Point) -> None:
     logger.info("METRIC: %s", point)
 
 
-class Meter(metaclass=abc.ABCMeta):
+class Meter(abc.ABC):
     """Base class for all meters."""
 
     def __init__(self, metric: Metric, tags: dict | None = None) -> None:

--- a/singer_sdk/pagination.py
+++ b/singer_sdk/pagination.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 import typing as t
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from urllib.parse import ParseResult, urlparse
 
 from singer_sdk.helpers.jsonpath import extract_jsonpath
@@ -36,7 +36,7 @@ def first(iterable: t.Iterable[T]) -> T:
     return next(iter(iterable))
 
 
-class BaseAPIPaginator(t.Generic[TPageToken], metaclass=ABCMeta):
+class BaseAPIPaginator(ABC, t.Generic[TPageToken]):
     """An API paginator object."""
 
     def __init__(self, start_value: TPageToken) -> None:
@@ -197,7 +197,7 @@ class SinglePagePaginator(BaseAPIPaginator[None]):
         return
 
 
-class BaseHATEOASPaginator(BaseAPIPaginator[ParseResult | None], metaclass=ABCMeta):
+class BaseHATEOASPaginator(BaseAPIPaginator[ParseResult | None], ABC):
     """Paginator class for APIs supporting HATEOAS links in their response bodies.
 
     HATEOAS stands for "Hypermedia as the Engine of Application State". See
@@ -355,7 +355,7 @@ class SimpleHeaderPaginator(BaseAPIPaginator[str | None]):
         return response.headers.get(self._key, None)
 
 
-class BasePageNumberPaginator(BaseAPIPaginator[int], metaclass=ABCMeta):
+class BasePageNumberPaginator(BaseAPIPaginator[int], ABC):
     """Paginator class for APIs that use page number."""
 
     @override
@@ -371,7 +371,7 @@ class BasePageNumberPaginator(BaseAPIPaginator[int], metaclass=ABCMeta):
         return self._value + 1
 
 
-class BaseOffsetPaginator(BaseAPIPaginator[int], metaclass=ABCMeta):
+class BaseOffsetPaginator(BaseAPIPaginator[int], ABC):
     """Paginator class for APIs that use page offset."""
 
     def __init__(

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -189,7 +189,7 @@ def _plugin_log_level(*, plugin_name: str) -> str:
     return level.upper() if level is not None else DEFAULT_LOG_LEVEL
 
 
-class PluginBase(metaclass=abc.ABCMeta):  # noqa: PLR0904
+class PluginBase(abc.ABC):  # noqa: PLR0904
     """Abstract base class for taps."""
 
     #: The executable name of the tap or target plugin. e.g. tap-foo
@@ -771,7 +771,7 @@ class BaseSingerIO(PluginBase):
         return instance or default_cls()
 
 
-class BaseSingerReader(BaseSingerIO, metaclass=abc.ABCMeta):
+class BaseSingerReader(BaseSingerIO, abc.ABC):
     """Base class for Singer readers."""
 
     message_reader_class: type[GenericSingerReader] = SingerReader

--- a/singer_sdk/singerlib/catalog.py
+++ b/singer_sdk/singerlib/catalog.py
@@ -22,7 +22,7 @@ Breadcrumb = tuple[str, ...]
 logger = logging.getLogger(__name__)
 
 
-class SelectionMask(dict[Breadcrumb, bool]):
+class SelectionMask(dict[Breadcrumb, bool]):  # noqa: FURB189
     """Boolean mask for property selection in schemas and records."""
 
     def __missing__(self, breadcrumb: Breadcrumb) -> bool:
@@ -102,7 +102,7 @@ class StreamMetadata(Metadata):
 AnyMetadata: t.TypeAlias = Metadata | StreamMetadata
 
 
-class MetadataMapping(dict[Breadcrumb, AnyMetadata]):
+class MetadataMapping(dict[Breadcrumb, AnyMetadata]):  # noqa: FURB189
     """Stream metadata mapping."""
 
     @classmethod
@@ -375,7 +375,7 @@ class CatalogEntry:
         return result
 
 
-class Catalog(dict[str, CatalogEntry]):
+class Catalog(dict[str, CatalogEntry]):  # noqa: FURB189
     """Singer catalog mapping of stream entries."""
 
     @classmethod

--- a/singer_sdk/singerlib/encoding/base.py
+++ b/singer_sdk/singerlib/encoding/base.py
@@ -35,7 +35,7 @@ class SingerMessageType(str, enum.Enum):
     BATCH = "BATCH"
 
 
-class GenericSingerReader(t.Generic[T], metaclass=abc.ABCMeta):
+class GenericSingerReader(abc.ABC, t.Generic[T]):
     """Interface for all plugins reading Singer messages as strings or bytes."""
 
     def __init__(self) -> None:
@@ -114,7 +114,7 @@ class GenericSingerReader(t.Generic[T], metaclass=abc.ABCMeta):
         raise ValueError(msg)
 
 
-class GenericSingerWriter(t.Generic[T, M], metaclass=abc.ABCMeta):
+class GenericSingerWriter(abc.ABC, t.Generic[T, M]):
     """Interface for all plugins writing Singer messages as strings or bytes."""
 
     def format_message(self, message: M) -> T:

--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -125,7 +125,7 @@ class JSONSchemaValidator(BaseJSONSchemaValidator):
             raise InvalidRecord(e.message, record) from e
 
 
-class Sink(metaclass=abc.ABCMeta):  # noqa: PLR0904
+class Sink(abc.ABC):  # noqa: PLR0904
     """Abstract base class for target sinks."""
 
     # max timestamp/datetime supported, used to reset invalid dates

--- a/singer_sdk/sql/stream.py
+++ b/singer_sdk/sql/stream.py
@@ -24,7 +24,7 @@ if t.TYPE_CHECKING:
 __all__ = ["SQLStream"]
 
 
-class SQLStream(Stream, metaclass=abc.ABCMeta):
+class SQLStream(Stream, abc.ABC):
     """Base class for SQLAlchemy-based streams."""
 
     connector_class = SQLConnector

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -66,7 +66,7 @@ REPLICATION_INCREMENTAL = "INCREMENTAL"
 REPLICATION_LOG_BASED = "LOG_BASED"
 
 
-class Stream(metaclass=abc.ABCMeta):  # noqa: PLR0904
+class Stream(abc.ABC):  # noqa: PLR0904
     """Abstract base class for tap streams.
 
     :ivar context: Stream partition or context dictionary. This is a read-only

--- a/singer_sdk/streams/graphql.py
+++ b/singer_sdk/streams/graphql.py
@@ -13,7 +13,7 @@ if t.TYPE_CHECKING:
 _TToken = t.TypeVar("_TToken")
 
 
-class GraphQLStream(RESTStream, t.Generic[_TToken], metaclass=abc.ABCMeta):
+class GraphQLStream(RESTStream, abc.ABC, t.Generic[_TToken]):
     """Abstract base class for API-type streams.
 
     GraphQL streams inherit from the class `GraphQLStream`, which in turn inherits from

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -47,7 +47,7 @@ _TToken = t.TypeVar("_TToken")
 _TNum = t.TypeVar("_TNum", int, float)
 
 
-class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: PLR0904
+class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
     """Abstract base class for HTTP streams."""
 
     _page_size: int = DEFAULT_PAGE_SIZE
@@ -785,7 +785,7 @@ class _HTTPStream(Stream, t.Generic[_TToken], metaclass=abc.ABCMeta):  # noqa: P
             exception = yield value(exception)
 
 
-class RESTStream(_HTTPStream, t.Generic[_TToken], metaclass=abc.ABCMeta):
+class RESTStream(_HTTPStream, abc.ABC, t.Generic[_TToken]):
     """Abstract base class for REST API streams."""
 
     #: Optional JSONPath expression to extract a pagination token from the API response.

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+import collections.abc
 import contextlib
 import typing as t
 import warnings
@@ -50,7 +51,7 @@ class CliTestOptionValue(Enum):
     Disabled = "disabled"
 
 
-class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
+class Tap(BaseSingerWriter, abc.ABC):  # noqa: PLR0904
     """Abstract base class for taps.
 
     The Tap class governs configuration, validation, and stream discovery for tap
@@ -121,8 +122,8 @@ class Tap(BaseSingerWriter, metaclass=abc.ABCMeta):  # noqa: PLR0904
         # Process input catalog
         if isinstance(catalog, Catalog):
             self._input_catalog = catalog
-        elif isinstance(catalog, dict):
-            self._input_catalog = Catalog.from_dict(catalog)  # type: ignore[arg-type]
+        elif isinstance(catalog, collections.abc.MutableMapping):
+            self._input_catalog = Catalog.from_dict(catalog)  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
         elif catalog is not None:
             self._input_catalog = Catalog.from_dict(read_json_file(catalog))
             warnings.warn(

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -43,7 +43,7 @@ if t.TYPE_CHECKING:
 _MAX_PARALLELISM = 8
 
 
-class Target(BaseSingerReader, metaclass=abc.ABCMeta):
+class Target(BaseSingerReader, abc.ABC):
     """Abstract base class for targets.
 
     The `Target` class manages config information and is responsible for processing the

--- a/singer_sdk/testing/runners.py
+++ b/singer_sdk/testing/runners.py
@@ -23,7 +23,7 @@ if t.TYPE_CHECKING:
 T = t.TypeVar("T", bound=PluginBase)
 
 
-class SingerTestRunner(t.Generic[T], metaclass=abc.ABCMeta):
+class SingerTestRunner(abc.ABC, t.Generic[T]):
     """Base Singer Test Runner."""
 
     def __init__(

--- a/tests/core/test_typing.py
+++ b/tests/core/test_typing.py
@@ -381,11 +381,11 @@ def test_conform_object_no_additional_properties(
         ),
         pytest.param(1, {"type": ["boolean"]}, True, id="one_to_boolean_single_type"),
         # Number conversions
-        pytest.param(3.14, {"type": "number"}, 3.14, id="float_to_number"),
+        pytest.param(1.618, {"type": "number"}, 1.618, id="float_to_number"),
         pytest.param(
-            decimal.Decimal("3.14"),
+            decimal.Decimal("1.618"),
             {"type": "integer"},
-            decimal.Decimal("3.14"),
+            decimal.Decimal("1.618"),
             id="decimal_to_integer",
         ),
         pytest.param(float("nan"), {"type": "number"}, None, id="float_nan_to_number"),


### PR DESCRIPTION
## Summary by Sourcery

Enable Ruff FURB rules and update codebase to satisfy new linting checks.

Enhancements:
- Refine use of abstract base classes by inheriting directly from abc.ABC instead of specifying ABCMeta as metaclass.
- Adopt more concise and expressive standard library helpers (e.g., operator.itemgetter, truthiness of lists) and modern file I/O helpers for configuration writing.
- Change catalog and selection mapping classes to use UserDict-based wrappers where appropriate for clearer semantics.

Build:
- Update Ruff configuration to enable FURB (refurb) rule set.

Tests:
- Adjust typing conformance tests to align with updated numeric example values.

## Summary by Sourcery

Enable Ruff FURB linting rules and update the codebase for compatibility with the new checks.

Enhancements:
- Refine abstract base class definitions to inherit directly from abc.ABC instead of using ABCMeta metaclasses.
- Adopt more concise standard-library utilities (e.g., operator.itemgetter, truthiness of sequences, pathlib write_text) for cleaner helper and I/O code.
- Broaden catalog input handling in tap initialization to accept any mutable mapping rather than only plain dict instances.
- Explicitly suppress specific FURB recommendations on catalog-related mapping types to retain their current dict-based implementations.

Build:
- Update Ruff configuration to enable the FURB (refurb) rule set.

Tests:
- Adjust typing conformance tests to use updated numeric example values while preserving intended behaviors.