### PR TITLE
chore: Consolidate Ruff `PL` rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -390,10 +390,7 @@ select = [
     "PTH",  # flake8-use-pathlib
     "ERA",  # eradicate
     "PGH",  # pygrep-hooks
-    "PLC",  # pylint (convention)
-    "PLE",  # pylint (error)
-    "PLR",  # pylint (refactor)
-    "PLW",  # pylint (warning)
+    "PL",   # pylint
     "TRY",  # tryceratops
     "FLY",  # flynt
     "PERF", # perflint


### PR DESCRIPTION
## Summary by Sourcery

Consolidate pylint-related Ruff rules and add typing improvements to the DummyJSON authenticator.

Enhancements:
- Add explicit type annotations and typing-only imports to the DummyJSON authenticator for clearer request and response handling.
- Configure Ruff to use the unified `PL` pylint rule set instead of individual `PLC`, `PLE`, `PLR`, and `PLW` rule groups.