### PR TITLE
fix(templates): Add details to the `variant` prompt in templates

### DIFF
--- a/cookiecutter/mapper-template/cookiecutter.json
+++ b/cookiecutter/mapper-template/cookiecutter.json
@@ -15,6 +15,7 @@
     "admin_email": "Provide your [bold yellow]email[/]",
     "mapper_id": "The ID of the mapper, in kebab-case (e.g., 'mapper-mymapper')",
     "library_name": "The name of the library, in snake_case (e.g., 'mapper_mymapper'). This is how the library will be imported in Python.",
+    "variant": "If you are planning to distribute your project on PyPI and the mapper_id is already in use, you can set a variant name. e.g. 'meltanolabs' or 'pipelinewise'.",
     "faker_extra": "Add [bold orange1][link=https://faker.readthedocs.io/en/master/]Faker[/link][/] as an extra dependency to support generating fake data in stream maps?",
     "include_ci_files": "Whether to include CI files for a common CI services",
     "license": "The license for the project",

--- a/cookiecutter/tap-template/cookiecutter.json
+++ b/cookiecutter/tap-template/cookiecutter.json
@@ -24,6 +24,7 @@
     "admin_email": "Provide your [bold yellow]email[/]",
     "tap_id": "The ID of the tap, in kebab-case (e.g., 'tap-mysource')",
     "library_name": "The name of the library, in snake_case (e.g., 'tap_mysource'). This is how the library will be imported in Python.",
+    "variant": "If you are planning to distribute your project on PyPI and the tap_id is already in use, you can set a variant name. e.g. 'meltanolabs' or 'pipelinewise'.",
     "stream_type": "The type of stream the source provides",
     "auth_method": "The [bold red]authentication[/] method used by the source, for REST and GraphQL sources",
     "faker_extra": "Add [bold orange1][link=https://faker.readthedocs.io/en/master/]Faker[/link][/] as an extra dependency to support generating fake data in stream maps?",

--- a/cookiecutter/target-template/cookiecutter.json
+++ b/cookiecutter/target-template/cookiecutter.json
@@ -16,6 +16,7 @@
     "admin_email": "Provide your [bold yellow]email[/]",
     "target_id": "The ID of the target, in kebab-case (e.g., 'target-mydestination')",
     "library_name": "The name of the library, in snake_case (e.g., 'target_mydestination'). This is how the library will be imported in Python.",
+    "variant": "If you are planning to distribute your project on PyPI and the target_id is already in use, you can set a variant name. e.g. 'meltanolabs' or 'pipelinewise'.",
     "serialization_method": "The serialization method to use for loading data",
     "faker_extra": "Add [bold orange1][link=https://faker.readthedocs.io/en/master/]Faker[/link][/] as an extra dependency to support generating fake data in stream maps?",
     "include_ci_files": "Whether to include CI files for a common CI services",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Improve the `variant` prompt text in mapper, tap, and target cookiecutter templates to provide clearer guidance to users.