### PR TITLE
feat(targets): Add a config fixture for target tests

### DIFF
--- a/singer_sdk/testing/factory.py
+++ b/singer_sdk/testing/factory.py
@@ -352,11 +352,31 @@ class TargetTestClassFactory:
                 yield  # noqa: PT022
 
             @pytest.fixture
-            def runner(self) -> TargetTestRunner:  # noqa: PLR6301
+            def plugin_config(self) -> dict | None:  # noqa: PLR6301
+                """Plugin configuration fixture.
+
+                Override this fixture in your test class to provide a custom
+                config generated from other fixtures.
+
+                Returns:
+                    The plugin configuration dict, or None to use default.
+                """
+                return config
+
+            @pytest.fixture
+            def runner(self, plugin_config: dict | None) -> TargetTestRunner:  # noqa: PLR6301
+                """Create the test runner.
+
+                Args:
+                    plugin_config: The plugin configuration from the plugin_config fixture.
+
+                Returns:
+                    A test runner instance.
+                """
                 # Instantiate new runner class and populate records for use in tests
                 return TargetTestRunner(
                     target_class=target_class,
-                    config=config,
+                    config=plugin_config,
                     suite_config=suite_config,
                     **kwargs,
                 )

--- a/tests/packages/test_tap_csv.py
+++ b/tests/packages/test_tap_csv.py
@@ -42,7 +42,7 @@ class TestCSVOneStreamPerFile(_TestCSVOneStreamPerFile):
     pass
 
 
-# Three days into the future.
+# Three days into the future for state testing
 FUTURE = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=3)
 
 STATE = {

--- a/tests/packages/test_target_parquet.py
+++ b/tests/packages/test_target_parquet.py
@@ -11,15 +11,9 @@ from target_parquet.target import TargetParquet
 
 from singer_sdk.testing import get_target_test_class
 
-SAMPLE_FILEPATH = Path(f".output/test_{uuid.uuid4()}/")
-SAMPLE_FILENAME = SAMPLE_FILEPATH / "testfile.parquet"
-SAMPLE_CONFIG = {
-    "filepath": str(SAMPLE_FILENAME),
-}
-
 StandardTests = get_target_test_class(
     target_class=TargetParquet,
-    config=SAMPLE_CONFIG,
+    config=None,  # Config will be provided via plugin_config fixture
 )
 
 
@@ -28,10 +22,23 @@ class TestSampleTargetParquet(StandardTests):
 
     @pytest.fixture(scope="class")
     def test_output_dir(self):
-        return SAMPLE_FILEPATH
+        """Create a unique output directory for this test class."""
+        output_dir = Path(f".output/test_{uuid.uuid4()}/")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        yield output_dir
+        shutil.rmtree(output_dir)
+
+    @pytest.fixture
+    def plugin_config(self, test_output_dir: Path) -> dict:
+        """Generate target config using the test output directory fixture.
+
+        This demonstrates composing plugin_config from another fixture
+        (test_output_dir) for dynamic file path creation.
+        """
+        filepath = test_output_dir / "testfile.parquet"
+        return {"filepath": str(filepath)}
 
     @pytest.fixture(scope="class")
     def resource(self, test_output_dir):
-        test_output_dir.mkdir(parents=True, exist_ok=True)
-        yield test_output_dir
-        shutil.rmtree(test_output_dir)
+        """Provide the output directory as a resource."""
+        return test_output_dir

--- a/tests/packages/test_target_sqlite.py
+++ b/tests/packages/test_target_sqlite.py
@@ -39,12 +39,22 @@ if t.TYPE_CHECKING:
 
 _TestTargetSQLite = get_target_test_class(
     target_class=SQLiteTarget,
-    config={"path_to_db": ":memory:"},
+    config=None,  # Config will be provided via plugin_config fixture
 )
 
 
 class TestTargetSQLite(_TestTargetSQLite):
     """Test Target SQLite."""
+
+    @pytest.fixture
+    def plugin_config(self, tmp_path: Path) -> dict:
+        """Generate target config using a temporary database file.
+
+        This demonstrates using the plugin_config fixture to generate
+        config dynamically from other pytest fixtures (tmp_path).
+        """
+        db_path = tmp_path / "target_test_sqlite.db"
+        return {"path_to_db": str(db_path)}
 
     @pytest.mark.xfail(
         reason="Our sample target SQLite does not support duplicate records.",


### PR DESCRIPTION
## Summary by Sourcery

Introduce a fixture-based configuration mechanism for target tests and update existing target test suites to use it.

New Features:
- Add a plugin_config pytest fixture to target test classes for providing configurable target plugin settings.
- Allow the target test runner fixture to consume configuration from the plugin_config fixture instead of a static config dict.

Enhancements:
- Refactor parquet, CSV, and SQLite target tests to build their configs dynamically via plugin_config and other pytest fixtures.
- Add tests validating that factory-generated target test classes expose and correctly wire the plugin_config fixture into the runner.

Tests:
- Extend factory tests to cover the presence, override behavior, and usage of the plugin_config fixture in generated target test classes.