### PR TITLE
refactor: Move `plugin_cli` implementation to private module `singer_sdk.cli._decorator`

### DIFF
--- a/samples/sample_tap_bigquery/tap_bigquery/__init__.py
+++ b/samples/sample_tap_bigquery/tap_bigquery/__init__.py
@@ -2,40 +2,6 @@
 
 from __future__ import annotations
 
-from singer_sdk import SQLConnector, SQLStream, SQLTap
-from singer_sdk import typing as th  # JSON schema typing helpers
-
-
-class BigQueryConnector(SQLConnector):
-    """Connects to the BigQuery SQL source."""
-
-    def get_sqlalchemy_url(self, config: dict) -> str:  # noqa: PLR6301
-        """Concatenate a SQLAlchemy URL for use in connecting to the source."""
-        return f"bigquery://{config['project_id']}"
-
-
-class BigQueryStream(SQLStream):
-    """Stream class for BigQuery streams."""
-
-    connector_class = BigQueryConnector
-
-
-class TapBigQuery(SQLTap):
-    """BigQuery tap class."""
-
-    name = "tap-bigquery"
-
-    config_jsonschema = th.PropertiesList(
-        th.Property(
-            "project_id",
-            th.StringType,
-            required=True,
-            title="Project ID",
-            description="GCP Project",
-        ),
-    ).to_dict()
-
-    default_stream_class: type[SQLStream] = BigQueryStream
-
+from .tap import BigQueryConnector, BigQueryStream, TapBigQuery
 
 __all__ = ["BigQueryConnector", "BigQueryStream", "TapBigQuery"]

--- a/samples/sample_tap_bigquery/tap_bigquery/tap.py
+++ b/samples/sample_tap_bigquery/tap_bigquery/tap.py
@@ -1,0 +1,41 @@
+"""A sample implementation for BigQuery."""
+
+from __future__ import annotations
+
+from singer_sdk import SQLConnector, SQLStream, SQLTap
+from singer_sdk import typing as th  # JSON schema typing helpers
+
+
+class BigQueryConnector(SQLConnector):
+    """Connects to the BigQuery SQL source."""
+
+    def get_sqlalchemy_url(self, config: dict) -> str:  # noqa: PLR6301
+        """Concatenate a SQLAlchemy URL for use in connecting to the source."""
+        return f"bigquery://{config['project_id']}"
+
+
+class BigQueryStream(SQLStream):
+    """Stream class for BigQuery streams."""
+
+    connector_class = BigQueryConnector
+
+
+class TapBigQuery(SQLTap):
+    """BigQuery tap class."""
+
+    name = "tap-bigquery"
+
+    config_jsonschema = th.PropertiesList(
+        th.Property(
+            "project_id",
+            th.StringType,
+            required=True,
+            title="Project ID",
+            description="GCP Project",
+        ),
+    ).to_dict()
+
+    default_stream_class: type[SQLStream] = BigQueryStream
+
+
+__all__ = ["BigQueryConnector", "BigQueryStream", "TapBigQuery"]

--- a/singer_sdk/cli/__init__.py
+++ b/singer_sdk/cli/__init__.py
@@ -2,34 +2,6 @@
 
 from __future__ import annotations
 
-import typing as t
+from ._decorator import plugin_cli
 
-if t.TYPE_CHECKING:
-    import click
-
-_T = t.TypeVar("_T")
-
-
-class plugin_cli:  # noqa: N801
-    """Decorator to create a plugin CLI."""
-
-    def __init__(self, method: t.Callable[..., click.Command]) -> None:
-        """Create a new plugin CLI.
-
-        Args:
-            method: The method to call to get the command.
-        """
-        self.method = method
-        self.name: str | None = None
-
-    def __get__(self, instance: _T, owner: type[_T]) -> click.Command:
-        """Get the command.
-
-        Args:
-            instance: The instance of the plugin.
-            owner: The plugin class.
-
-        Returns:
-            The CLI entrypoint.
-        """
-        return self.method(owner)
+__all__ = ["plugin_cli"]

--- a/singer_sdk/cli/_decorator.py
+++ b/singer_sdk/cli/_decorator.py
@@ -1,0 +1,35 @@
+"""Helpers for the tap, target and mapper CLIs."""
+
+from __future__ import annotations
+
+import typing as t
+
+if t.TYPE_CHECKING:
+    import click
+
+_T = t.TypeVar("_T")
+
+
+class plugin_cli:  # noqa: N801
+    """Decorator to create a plugin CLI."""
+
+    def __init__(self, method: t.Callable[..., click.Command]) -> None:
+        """Create a new plugin CLI.
+
+        Args:
+            method: The method to call to get the command.
+        """
+        self.method = method
+        self.name: str | None = None
+
+    def __get__(self, instance: _T, owner: type[_T]) -> click.Command:
+        """Get the command.
+
+        Args:
+            instance: The instance of the plugin.
+            owner: The plugin class.
+
+        Returns:
+            The CLI entrypoint.
+        """
+        return self.method(owner)


### PR DESCRIPTION
## Summary by Sourcery

Extract the plugin CLI decorator into a dedicated private module and reorganize the BigQuery sample tap implementation into a separate module for better structure and reuse.

Enhancements:
- Move the plugin_cli decorator implementation from the CLI package __init__ into a new private module singer_sdk.cli._decorator and re-export it for public use.
- Relocate the sample BigQuery tap classes into a dedicated tap module and simplify the package __init__ to re-export them.