### PR TITLE
feat(targets): Use the presence of `_sdc_deleted_at` to flag records for deletion in hard-delete mode

### DIFF
--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -523,11 +523,15 @@ class Sink(metaclass=abc.ABCMeta):  # noqa: PLR0904
         ):
             properties_dict.pop(col, None)
 
-    def _remove_sdc_metadata_from_record(self, record: dict) -> None:  # noqa: PLR6301
+    def _remove_sdc_metadata_from_record(self, record: dict) -> None:
         """Remove metadata _sdc columns from incoming record message.
 
         Record metadata specs documented at:
         https://sdk.meltano.com/en/latest/implementation/record_metadata.html
+
+        Note:
+            When ``hard_delete=True``, the ``_sdc_deleted_at`` field is preserved
+            to support LOG_BASED replication hard deletes.
 
         Args:
             record: Individual record in the stream.
@@ -535,7 +539,9 @@ class Sink(metaclass=abc.ABCMeta):  # noqa: PLR0904
         record.pop("_sdc_extracted_at", None)
         record.pop("_sdc_received_at", None)
         record.pop("_sdc_batched_at", None)
-        record.pop("_sdc_deleted_at", None)
+        # Preserve _sdc_deleted_at when hard_delete is enabled for LOG_BASED deletes
+        if not self.config.get("hard_delete", False):
+            record.pop("_sdc_deleted_at", None)
         record.pop("_sdc_sequence", None)
         record.pop("_sdc_table_version", None)
         record.pop("_sdc_sync_started_at", None)

--- a/singer_sdk/sql/connector.py
+++ b/singer_sdk/sql/connector.py
@@ -1871,3 +1871,43 @@ class SQLConnector:  # noqa: PLR0904
                     f"WHERE {version_column_name} < {current_version}",
                 ),
             )
+
+    def delete_by_key(
+        self,
+        *,
+        full_table_name: str | FullyQualifiedName,
+        key_columns: t.Sequence[str],
+        key_values: t.Sequence[dict[str, t.Any]],
+    ) -> int:
+        """Hard-delete rows from the table by primary key.
+
+        This is used to delete records marked as deleted in LOG_BASED replication
+        when ``hard_delete`` is enabled.
+
+        Args:
+            full_table_name: The fully qualified table name.
+            key_columns: The names of the primary key columns.
+            key_values: A sequence of dicts containing key column values for
+                records to delete.
+
+        Returns:
+            The number of rows deleted.
+
+        .. versionadded:: 0.54.0
+        """
+        # Build WHERE clause and bind values in a single pass:
+        # (key1 = :k0_0 AND key2 = :k0_1) OR (key1 = :k1_0 AND key2 = :k1_1) ...
+        conditions = []
+        bind_values = {}
+        for i, record in enumerate(key_values):
+            key_conditions = []
+            for j, col in enumerate(key_columns):
+                param = f"k{i}_{j}"
+                key_conditions.append(f"{col} = :{param}")
+                bind_values[param] = record.get(col)
+            conditions.append(f"({' AND '.join(key_conditions)})")
+
+        query = f"DELETE FROM {full_table_name} WHERE {' OR '.join(conditions)}"  # noqa: S608
+        with self._connect() as conn, conn.begin():
+            result = conn.execute(sa.text(query), bind_values)
+            return result.rowcount

--- a/singer_sdk/sql/sink.py
+++ b/singer_sdk/sql/sink.py
@@ -271,10 +271,88 @@ class SQLSink(BatchSink, t.Generic[_C]):
         """
         # If duplicates are merged, these can be tracked via
         # :meth:`~singer_sdk.Sink.tally_duplicate_merged()`.
-        self.bulk_insert_records(
+        records = context["records"]
+
+        # Handle hard delete for LOG_BASED replication: records with _sdc_deleted_at
+        # set should be physically deleted from the target table.
+        if self.config.get("hard_delete", False) and self.key_properties:
+            to_delete, to_insert = self._split_records_for_hard_delete(records)
+
+            if to_delete:
+                count = self.hard_delete_records(to_delete)
+                self.logger.info(
+                    "Deleted %d records because they were deleted upstream",
+                    count,
+                )
+
+            if to_insert:
+                self.bulk_insert_records(
+                    full_table_name=self.full_table_name,
+                    schema=self.schema,
+                    records=to_insert,
+                )
+        else:
+            self.bulk_insert_records(
+                full_table_name=self.full_table_name,
+                schema=self.schema,
+                records=records,
+            )
+
+    def _split_records_for_hard_delete(
+        self,
+        records: t.Iterable[dict],
+    ) -> tuple[list[dict], list[dict]]:
+        """Split records into those to delete and those to insert.
+
+        Records with a non-null ``_sdc_deleted_at`` value are marked for deletion
+        in LOG_BASED replication.
+
+        Args:
+            records: The records to split.
+
+        Returns:
+            A tuple of (records_to_delete, records_to_insert). Records to delete
+            are returned as conformed records (column names match target schema).
+        """
+        conformed_delete_col = self.conform_name(
+            self.soft_delete_column_name,
+            "column",
+        )
+        records_to_delete = []
+        records_to_insert = []
+
+        for record in records:
+            conformed_record = self.conform_record(record)
+            if conformed_record.get(conformed_delete_col) is not None:
+                records_to_delete.append(conformed_record)
+            else:
+                records_to_insert.append(record)
+
+        return records_to_delete, records_to_insert
+
+    def hard_delete_records(
+        self,
+        records: t.Sequence[dict],
+    ) -> int:
+        """Hard delete records from the target table.
+
+        This method deletes records that have been marked for deletion in LOG_BASED
+        replication (i.e., records with ``_sdc_deleted_at`` set).
+
+        Subclasses can override this method to customize deletion behavior.
+
+        Args:
+            records: Conformed records to delete. Must contain the key properties.
+
+        Returns:
+            The number of records deleted.
+
+        .. versionadded:: 0.54.0
+        """
+        return self.connector.delete_by_key(
             full_table_name=self.full_table_name,
-            schema=self.schema,
-            records=context["records"],
+            key_columns=self.key_properties,
+            key_values=records,
         )
 
     def generate_insert_statement(


### PR DESCRIPTION
## Related

- Closes https://github.com/meltano/sdk/issues/3444

## Summary by Sourcery

Implement hard-delete handling for log-based replication using the `_sdc_deleted_at` flag and expose a key-based delete API for SQL connectors.

New Features:
- Add support in SQL sinks for hard deleting records marked with `_sdc_deleted_at` during LOG_BASED replication when `hard_delete` is enabled.
- Introduce a connector-level `delete_by_key` method to delete rows by primary key across SQL targets.

Enhancements:
- Preserve `_sdc_deleted_at` metadata on records when `hard_delete` is enabled so it can be used to drive hard deletes.

Tests:
- Add SQLite target tests covering hard delete and soft delete behavior for log-based replication, including composite primary key scenarios.