### PR TITLE
docs: Configure docs to build with Python 3.14 explicitly

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.14"
   jobs:
     create_environment:
       - asdf plugin add uv


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Set Read the Docs build environment to use Python 3.14 instead of 3.13 for documentation builds.