### PR TITLE
refactor: Insert then delete

### DIFF
--- a/tests/packages/snapshots/test_target_sqlite/test_sqlite_activate_version/singer.log
+++ b/tests/packages/snapshots/test_target_sqlite/test_sqlite_activate_version/singer.log
@@ -2,4 +2,4 @@ INFO sqlconnector Creating empty table zzz_tmp_test_sqlite_activate_version
 WARNING target-sqlite The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for '%s' even though `add_record_metadata` is disabled.
 INFO target-sqlite.zzz_tmp_test_sqlite_activate_version Inserting with SQL: INSERT INTO zzz_tmp_test_sqlite_activate_version (col_a) VALUES (:col_a)
 WARNING target-sqlite The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for '%s' even though `add_record_metadata` is disabled.
-INFO target-sqlite.zzz_tmp_test_sqlite_activate_version Inserting with SQL: INSERT INTO zzz_tmp_test_sqlite_activate_version (col_a) VALUES (:col_a)
+INFO target-sqlite.zzz_tmp_test_sqlite_activate_version Upserting with SQL: INSERT OR REPLACE INTO zzz_tmp_test_sqlite_activate_version (col_a) VALUES (:col_a)


### PR DESCRIPTION
- On top of #3450

## Summary by Sourcery

Refactor SQL hard-delete handling to upsert then delete based on the soft delete column for LOG_BASED replication.

New Features:
- Introduce a generic bulk_upsert_records method on SQLSink for database-specific bulk upsert implementations using the table schema.

Bug Fixes:
- Ensure hard delete processing works even when records already exist by upserting before deleting rows marked as deleted.

Enhancements:
- Simplify SQLSink hard delete flow by removing record-splitting logic and delegating deletion to a connector-level method using the soft delete column.
- Replace key-based deletion with a connector method that deletes all rows where the soft delete column is set, improving consistency and reducing required inputs.