### PR TITLE
ci: Start testing with Python 3.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Test
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
     paths:
       - "packages/**"
       - "samples/**"
@@ -67,6 +66,7 @@ jobs:
         - "3.12"
         - "3.13"
         - "3.14"
+        - "3.15"
         include:
         - { session: doctest,       python-version: "3.14", os: "ubuntu-latest" }
         - { session: deps,          python-version: "3.14", os: "ubuntu-latest" }

--- a/noxfile.py
+++ b/noxfile.py
@@ -118,13 +118,17 @@ def _run_pytest(session: nox.Session, *pytest_args: str, coverage: bool = True) 
 @nox.session(python=python_versions, tags=["test"])
 def tests(session: nox.Session) -> None:
     """Execute pytest tests and compute coverage."""
+    env = _install_env(session)
+    if session.python not in python_versions:
+        env["PYO3_USE_ABI3_FORWARD_COMPATIBILITY"] = "1"
+
     session.run_install(
         *UV_SYNC_COMMAND,
         "--group=testing",
         "--extra=faker",
         "--extra=jwt",
         "--extra=s3",
-        env=_install_env(session),
+        env=env,
     )
 
     _run_pytest(


### PR DESCRIPTION
## Summary by Sourcery

Add Python 3.15 to the supported and tested versions and ensure test sessions configure ABI3 forward compatibility when running on non-standard Python interpreters.

New Features:
- Start running CI tests against Python 3.15.

Enhancements:
- Update nox test session to reuse the installed environment and enable ABI3 forward compatibility when using Python versions outside the defined test matrix.

CI:
- Extend the GitHub Actions test matrix to include Python 3.15 and simplify pull_request triggers.