### PR TITLE
docs: Align function names in SQL target example

### DIFF
--- a/docs/guides/sql-target.md
+++ b/docs/guides/sql-target.md
@@ -67,7 +67,7 @@ from sqlalchemy.types import SMALLINT
 from my_sqlalchemy_dialect import VectorType
 
 
-def vector_to_sql(jsonschema: dict) -> VectorType:
+def custom_vector_to_sql(jsonschema: dict) -> VectorType:
     return VectorType(**jsonschema.get("x-sql-datatype-properties", {}))
 
 


### PR DESCRIPTION
- https://github.com/meltano/sdk/pull/3373#pullrequestreview-3673405455

## Summary by Sourcery

Documentation:
- Update the SQL target guide to use the function name `custom_vector_to_sql` in the vector type example for consistency.