### PR TITLE
fix: Treat `sqlalchemy.types.Float` and `sqlalchemy.types.Numeric` as distinct types when mapping them to JSON schema in preparation for SQLAlchemy 2.1

### DIFF
--- a/singer_sdk/sql/connector.py
+++ b/singer_sdk/sql/connector.py
@@ -210,10 +210,18 @@ class SQLToJSONSchema:
         return th.IntegerType.type_dict  # type: ignore[no-any-return]
 
     @to_jsonschema.register
-    def float_to_jsonschema(
-        self,
-        column_type: t.Union[sqlalchemy.types.Float, sqlalchemy.types.Numeric],  # noqa: ARG002, UP007
-    ) -> dict:
+    def float_to_jsonschema(self, column_type: sqlalchemy.types.Float) -> dict:  # noqa: ARG002
+        """Return a JSON Schema representation of a generic number type.
+
+        Args:
+            column_type (:column_type:`Float`): The column type.
+        """
+        if self.use_singer_decimal:
+            return th.SingerDecimalType.type_dict  # type: ignore[no-any-return]
+        return th.DecimalType.type_dict  # type: ignore[no-any-return]
+
+    @to_jsonschema.register
+    def numeric_to_jsonschema(self, column_type: sqlalchemy.types.Numeric) -> dict:  # noqa: ARG002
         """Return a JSON Schema representation of a generic number type.
 
         Args:

--- a/singer_sdk/sql/connector.py
+++ b/singer_sdk/sql/connector.py
@@ -212,7 +212,7 @@ class SQLToJSONSchema:
     @to_jsonschema.register
     def float_to_jsonschema(
         self,
-        column_type: sqlalchemy.types.Float | sqlalchemy.types.Numeric,  # noqa: ARG002
+        column_type: t.Union[sqlalchemy.types.Float, sqlalchemy.types.Numeric],  # noqa: ARG002, UP007
     ) -> dict:
         """Return a JSON Schema representation of a generic number type.
 

--- a/singer_sdk/sql/connector.py
+++ b/singer_sdk/sql/connector.py
@@ -225,7 +225,7 @@ class SQLToJSONSchema:
         """Return a JSON Schema representation of a generic number type.
 
         Args:
-            column_type (:column_type:`Float`): The column type.
+            column_type (:column_type:`Numeric`): The column type.
         """
         if self.use_singer_decimal:
             return th.SingerDecimalType.type_dict  # type: ignore[no-any-return]

--- a/singer_sdk/sql/connector.py
+++ b/singer_sdk/sql/connector.py
@@ -210,11 +210,14 @@ class SQLToJSONSchema:
         return th.IntegerType.type_dict  # type: ignore[no-any-return]
 
     @to_jsonschema.register
-    def float_to_jsonschema(self, column_type: sqlalchemy.types.Numeric) -> dict:  # noqa: ARG002
+    def float_to_jsonschema(
+        self,
+        column_type: sqlalchemy.types.Float | sqlalchemy.types.Numeric,  # noqa: ARG002
+    ) -> dict:
         """Return a JSON Schema representation of a generic number type.
 
         Args:
-            column_type (:column_type:`Numeric`): The column type.
+            column_type (:column_type:`Float`): The column type.
         """
         if self.use_singer_decimal:
             return th.SingerDecimalType.type_dict  # type: ignore[no-any-return]

--- a/tests/sql/test_connector.py
+++ b/tests/sql/test_connector.py
@@ -757,6 +757,10 @@ def test_numeric_to_singer_decimal():
         "type": ["string"],
         "format": "singer.decimal",
     }
+    assert converter.to_jsonschema(sqlalchemy.FLOAT()) == {
+        "type": ["string"],
+        "format": "singer.decimal",
+    }
 
 
 class TestJSONSchemaToSQL:  # noqa: PLR0904


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correctly map sqlalchemy.types.Float separately from sqlalchemy.types.Numeric when generating JSON schema.