### PR TITLE
ci: Run fewer jobs on Windows and macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         session: [tests]
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest"]
         python-version:
         - "3.10"
         - "3.11"
@@ -68,6 +68,11 @@ jobs:
         - "3.14"
         - "3.15"
         include:
+        - { session: tests,         python-version: "3.14", os: "macos-latest" }
+        - { session: tests,         python-version: "3.10", os: "macos-latest" }
+        - { session: tests,         python-version: "3.14", os: "windows-latest" }
+        - { session: tests,         python-version: "3.10", os: "windows-latest" }
+        - { session: deps,          python-version: "3.14", os: "ubuntu-latest" }
         - { session: doctest,       python-version: "3.14", os: "ubuntu-latest" }
         - { session: deps,          python-version: "3.14", os: "ubuntu-latest" }
         - { session: test-lowest,   python-version: "3.10",  os: "ubuntu-latest" }


### PR DESCRIPTION
## Summary by Sourcery

Adjust the test workflow matrix to reduce the number of jobs run on Windows and macOS while keeping full coverage on Ubuntu.

CI:
- Limit the default OS matrix to Ubuntu for the tests session and explicitly include a reduced subset of Windows and macOS test jobs.
- Ensure selected sessions (tests, doctest, deps, test-lowest) still run on key Python versions via explicit matrix includes.