### PR TITLE
chore: Bump Ruff to 0.15 and update code to the 2026 style guide

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
   - id: check-readthedocs
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.14
+  rev: v0.15.0
   hooks:
   - id: ruff-check
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,10 +338,11 @@ extend-exclude = [
     "cookiecutter/*",
 ]
 line-length = 88
-required-version = ">=0.13"
+required-version = ">=0.15"
 
 [tool.ruff.format]
 docstring-code-format = true
+preview = true
 
 [tool.ruff.lint]
 explicit-preview-rules = false

--- a/singer_sdk/about.py
+++ b/singer_sdk/about.py
@@ -174,9 +174,9 @@ class TextFormatter(AboutFormatter, format_name="text"):
 
         if about_info.supported_python_versions:
             output += "\nSupported Python Versions:\n"
-            output += "\n".join(
-                [f"  - {v}" for v in about_info.supported_python_versions]
-            )
+            output += "\n".join([
+                f"  - {v}" for v in about_info.supported_python_versions
+            ])
 
         output += "\nCapabilities:\n"
         output += "\n".join([f"  - {c}" for c in about_info.capabilities])

--- a/singer_sdk/logging.py
+++ b/singer_sdk/logging.py
@@ -120,21 +120,17 @@ class StructuredFormatter(logging.Formatter):
 
         # Handle exception chaining (__cause__ and __context__)
         if hasattr(exc_value, "__cause__") and exc_value.__cause__:
-            exception_data["cause"] = self._format_exception(
-                (
-                    type(exc_value.__cause__),
-                    exc_value.__cause__,
-                    exc_value.__cause__.__traceback__,
-                )
-            )
+            exception_data["cause"] = self._format_exception((
+                type(exc_value.__cause__),
+                exc_value.__cause__,
+                exc_value.__cause__.__traceback__,
+            ))
         elif hasattr(exc_value, "__context__") and exc_value.__context__:
-            exception_data["context"] = self._format_exception(
-                (
-                    type(exc_value.__context__),
-                    exc_value.__context__,
-                    exc_value.__context__.__traceback__,
-                )
-            )
+            exception_data["context"] = self._format_exception((
+                type(exc_value.__context__),
+                exc_value.__context__,
+                exc_value.__context__.__traceback__,
+            ))
 
         return exception_data
 

--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -462,9 +462,10 @@ class OpenAPISchema(SchemaSource[_TKey]):
             UnsupportedOpenAPISpec: If the OpenAPI specification file type is not
                 supported.
         """
-        if isinstance(self.source, str) and self.source.startswith(
-            ("http://", "https://")
-        ):
+        if isinstance(self.source, str) and self.source.startswith((
+            "http://",
+            "https://",
+        )):
             response = requests.get(self.source, timeout=30)
             response.raise_for_status()
             content = response.content

--- a/singer_sdk/singerlib/schema.py
+++ b/singer_sdk/singerlib/schema.py
@@ -244,9 +244,9 @@ def resolve_schema_references(
     registry: Registry = Registry()
     schema_resource = DRAFT202012.create_resource(schema)
     registry = registry.with_resource("", schema_resource)
-    registry = registry.with_resources(
-        [(k, DRAFT202012.create_resource(v)) for k, v in refs.items()]
-    )
+    registry = registry.with_resources([
+        (k, DRAFT202012.create_resource(v)) for k, v in refs.items()
+    ])
 
     resolver = registry.resolver()
     return _resolve_schema_references(schema, resolver)

--- a/singer_sdk/sql/sink.py
+++ b/singer_sdk/sql/sink.py
@@ -167,7 +167,8 @@ class SQLSink(BatchSink, t.Generic[_C]):
         # strip leading/trailing whitespace,
         # transform to lowercase and replace - . and spaces to _
         name = (
-            name.lower()
+            name
+            .lower()
             .lstrip()
             .rstrip()
             .replace(".", "_")

--- a/singer_sdk/testing/factory.py
+++ b/singer_sdk/testing/factory.py
@@ -245,20 +245,18 @@ class TapTestClassFactory:
             test_params = []
             for stream in streams:
                 final_schema = stream.stream_maps[-1].transformed_schema["properties"]
-                test_params.extend(
-                    [
-                        TestParam(
-                            id=f"{stream.name}.{prop_name}",
-                            values=StreamAttributeTestParams(stream, prop_name),
-                        )
-                        for prop_name, prop_schema in final_schema.items()
-                        if test_class.evaluate(
-                            stream=stream,
-                            property_name=prop_name,
-                            property_schema=prop_schema,
-                        )
-                    ]
-                )
+                test_params.extend([
+                    TestParam(
+                        id=f"{stream.name}.{prop_name}",
+                        values=StreamAttributeTestParams(stream, prop_name),
+                    )
+                    for prop_name, prop_schema in final_schema.items()
+                    if test_class.evaluate(
+                        stream=stream,
+                        property_name=prop_name,
+                        property_schema=prop_schema,
+                    )
+                ])
 
             if test_params:
                 setattr(

--- a/tests/core/rest/test_pagination.py
+++ b/tests/core/rest/test_pagination.py
@@ -447,21 +447,17 @@ def test_continue_if_empty(tap: Tap):
             query = parse_qs(parsed.query)
 
             if query.get("page", ["1"]) == ["1"]:
-                r._content = json.dumps(
-                    {
-                        "data": [{"id": 1}, {"id": 2}],
-                        "hasMore": True,
-                    }
-                ).encode()
+                r._content = json.dumps({
+                    "data": [{"id": 1}, {"id": 2}],
+                    "hasMore": True,
+                }).encode()
             elif query.get("page", ["2"]) == ["2"]:
                 r._content = json.dumps({"data": [], "hasMore": True}).encode()
             elif query.get("page", ["3"]) == ["3"]:
-                r._content = json.dumps(
-                    {
-                        "data": [{"id": 3}, {"id": 4}],
-                        "hasMore": True,
-                    }
-                ).encode()
+                r._content = json.dumps({
+                    "data": [{"id": 3}, {"id": 4}],
+                    "hasMore": True,
+                }).encode()
             else:
                 r._content = json.dumps({"data": [], "hasMore": False}).encode()
 

--- a/tests/core/test_catalog_selection.py
+++ b/tests/core/test_catalog_selection.py
@@ -259,48 +259,46 @@ def test_record_property_pop(
 
 def test_deselect_all_streams():
     """Test that deselect_all_streams sets all streams to not selected."""
-    catalog = singer.Catalog.from_dict(
-        {
-            "streams": [
-                {
-                    "tap_stream_id": "test_stream_a",
-                    "stream": "test_stream_a",
-                    "schema": {
-                        "type": "object",
-                        "properties": {
-                            "col_a": {
-                                "type": "string",
-                            },
+    catalog = singer.Catalog.from_dict({
+        "streams": [
+            {
+                "tap_stream_id": "test_stream_a",
+                "stream": "test_stream_a",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "col_a": {
+                            "type": "string",
                         },
                     },
-                    "metadata": [
-                        {
-                            "breadcrumb": (),
-                            "metadata": {"selected": True},
-                        },
-                    ],
                 },
-                {
-                    "tap_stream_id": "test_stream_b",
-                    "stream": "test_stream_b",
-                    "schema": {
-                        "type": "object",
-                        "properties": {
-                            "col_a": {
-                                "type": "string",
-                            },
+                "metadata": [
+                    {
+                        "breadcrumb": (),
+                        "metadata": {"selected": True},
+                    },
+                ],
+            },
+            {
+                "tap_stream_id": "test_stream_b",
+                "stream": "test_stream_b",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "col_a": {
+                            "type": "string",
                         },
                     },
-                    "metadata": [
-                        {
-                            "breadcrumb": (),
-                            "metadata": {"selected": True},
-                        },
-                    ],
                 },
-            ],
-        }
-    )
+                "metadata": [
+                    {
+                        "breadcrumb": (),
+                        "metadata": {"selected": True},
+                    },
+                ],
+            },
+        ],
+    })
 
     # Stream is selected
     assert catalog["test_stream_a"].metadata.root.selected is True

--- a/tests/core/test_flattening.py
+++ b/tests/core/test_flattening.py
@@ -95,25 +95,21 @@ def test_get_flattening_options_missing_max_depth():
 
 
 def test_get_flattening_options_max_key_length():
-    options = get_flattening_options(
-        {
-            "flattening_enabled": True,
-            "flattening_max_depth": 5,
-            "flattening_max_key_length": 30,
-        }
-    )
+    options = get_flattening_options({
+        "flattening_enabled": True,
+        "flattening_max_depth": 5,
+        "flattening_max_key_length": 30,
+    })
     assert options.max_key_length == 30
 
 
 def test_get_flattening_options_custom_separator():
-    options = get_flattening_options(
-        {
-            "flattening_enabled": True,
-            "flattening_max_depth": 5,
-            "flattening_max_key_length": 30,
-            "flattening_separator": ".",
-        }
-    )
+    options = get_flattening_options({
+        "flattening_enabled": True,
+        "flattening_max_depth": 5,
+        "flattening_max_key_length": 30,
+        "flattening_separator": ".",
+    })
     assert options.separator == "."
 
 

--- a/tests/sql/test_connector.py
+++ b/tests/sql/test_connector.py
@@ -781,12 +781,10 @@ class TestJSONSchemaToSQL:  # noqa: PLR0904
         json_schema_to_sql: JSONSchemaToSQL,
     ):
         json_schema_to_sql.register_format_handler("my-format", sqlalchemy.LargeBinary)
-        result = json_schema_to_sql.to_sql_type(
-            {
-                "type": "string",
-                "format": "my-format",
-            }
-        )
+        result = json_schema_to_sql.to_sql_type({
+            "type": "string",
+            "format": "my-format",
+        })
         assert isinstance(result, sqlalchemy.LargeBinary)
 
     def test_string(self, json_schema_to_sql: JSONSchemaToSQL):


### PR DESCRIPTION
Links

- Announcement: https://astral.sh/blog/ruff-v0.15.0
- Style Guide: https://astral.sh/blog/ruff-v0.15.0#the-ruff-2026-style-guide

## Summary by Sourcery

Update codebase and tooling configuration to align with Ruff 0.15 and its 2026 formatting/style guidelines.

Enhancements:
- Reformat collections, function calls, and method chains across core modules and tests to conform to the Ruff 2026 style guide, without changing behavior.

Build:
- Bump Ruff required version in pyproject configuration and enable formatter preview mode.
- Update pre-commit Ruff hook to use v0.15.0.