### PR TITLE
fix(templates): Update templates

### DIFF
--- a/.github/workflows/cookiecutter-e2e.yml
+++ b/.github/workflows/cookiecutter-e2e.yml
@@ -28,7 +28,7 @@ concurrency:
 env:
   FORCE_COLOR: "1"
   UV_CONSTRAINT: ${{ github.workspace }}/.github/workflows/resources/requirements.txt
-  UV_VERSION: ">=0.9,<0.10"
+  UV_VERSION: ">=0.9"
 
 permissions: {}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
       )$
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.9.28
+  rev: 0.9.29
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       name: {{ '${{ steps.baipp.outputs.package_name }}' }}
       version: {{ '${{ steps.baipp.outputs.package_version }}' }}
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
       id: baipp
 

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
@@ -42,15 +42,13 @@ jobs:
         - "3.13"
         - "3.14"
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python {{ '${{ matrix.python-version }}' }}
-      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Setup uv
-      uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
-      with:
-        version: ">=0.8"
+      uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
     - name: Run Tox
       run: |
         uvx --with=tox-uv tox -e {{ '${{ matrix.python-version }}' }}
@@ -59,13 +57,13 @@ jobs:
     name: Type Checking
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python
-      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: 3.x
     - name: Setup uv
-      uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+      uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
       with:
         version: ">=0.8"
     - name: Run Tox

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
@@ -19,22 +19,20 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.36.0
+  rev: 0.36.1
   hooks:
   - id: check-dependabot
   - id: check-github-workflows
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.13
+  rev: v0.15.0
   hooks:
   - id: ruff-check
-    args: [--diff]
   - id: ruff-format
-    args: [--diff]
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.9.26
+  rev: 0.9.30
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -61,7 +61,7 @@ test = [
 ]
 typing = [
     "mypy>=1.16.0",
-    "ty>=0.0.1-alpha.16",
+    "ty>=0.0.15",
 ]
 
 {%- if cookiecutter.variant != "None (Skip)" %}
@@ -100,9 +100,12 @@ warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
 
+[tool.ty.rules]
+unused-type-ignore-comment = "ignore"
+
 [tool.ruff]
 line-length = 100
-required-version = ">=0.14"
+required-version = ">=0.15"
 
 [tool.ruff.lint]
 future-annotations = true

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/{{cookiecutter.library_name}}/mapper.py
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/{{cookiecutter.library_name}}/mapper.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-import typing as t
+from typing import TYPE_CHECKING
 
 import singer_sdk.typing as th
 from singer_sdk import singerlib as singer
@@ -15,7 +15,8 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import override
 
-if t.TYPE_CHECKING:
+if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import PurePath
 
 
@@ -60,7 +61,7 @@ class {{ cookiecutter.name }}Mapper(InlineMapper):
         self.mapper = PluginMapper(plugin_config=dict(self.config), logger=self.logger)
 
     @override
-    def map_schema_message(self, message_dict: dict) -> t.Iterable[singer.Message]:
+    def map_schema_message(self, message_dict: dict) -> Iterable[singer.Message]:
         """Map a schema message to zero or more new messages.
 
         Args:
@@ -72,7 +73,7 @@ class {{ cookiecutter.name }}Mapper(InlineMapper):
     def map_record_message(
         self,
         message_dict: dict,
-    ) -> t.Iterable[singer.RecordMessage]:
+    ) -> Iterable[singer.RecordMessage]:
         """Map a record message to zero or more new messages.
 
         Args:
@@ -81,7 +82,7 @@ class {{ cookiecutter.name }}Mapper(InlineMapper):
         yield singer.RecordMessage.from_dict(message_dict)
 
     @override
-    def map_state_message(self, message_dict: dict) -> t.Iterable[singer.Message]:
+    def map_state_message(self, message_dict: dict) -> Iterable[singer.Message]:
         """Map a state message to zero or more new messages.
 
         Args:
@@ -93,7 +94,7 @@ class {{ cookiecutter.name }}Mapper(InlineMapper):
     def map_activate_version_message(
         self,
         message_dict: dict,
-    ) -> t.Iterable[singer.Message]:
+    ) -> Iterable[singer.Message]:
         """Map a version message to zero or more new messages.
 
         Args:

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       name: {{ '${{ steps.baipp.outputs.package_name }}' }}
       version: {{ '${{ steps.baipp.outputs.package_version }}' }}
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
       id: baipp
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
@@ -42,15 +42,13 @@ jobs:
         - "3.13"
         - "3.14"
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python {{ '${{ matrix.python-version }}' }}
-      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Setup uv
-      uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
-      with:
-        version: ">=0.8"
+      uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
     - name: Run Tox
       run: |
         uvx --with=tox-uv tox -e {{ '${{ matrix.python-version }}' }}
@@ -59,13 +57,13 @@ jobs:
     name: Type Checking
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python
-      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: 3.x
     - name: Setup uv
-      uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+      uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
       with:
         version: ">=0.8"
     - name: Run Tox

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
@@ -19,22 +19,20 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.36.0
+  rev: 0.36.1
   hooks:
   - id: check-dependabot
   - id: check-github-workflows
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.13
+  rev: v0.15.0
   hooks:
   - id: ruff-check
-    args: [--diff]
   - id: ruff-format
-    args: [--diff]
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.9.26
+  rev: 0.9.30
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -70,7 +70,7 @@ test = [
 ]
 typing = [
     "mypy>=1.16.0",
-    "ty>=0.0.1-alpha.16",
+    "ty>=0.0.15",
     {%- if cookiecutter.stream_type == "SQL" %}
     "sqlalchemy-stubs",
     {%- else %}
@@ -114,9 +114,12 @@ warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
 
+[tool.ty.rules]
+unused-type-ignore-comment = "ignore"
+
 [tool.ruff]
 line-length = 100
-required-version = ">=0.14"
+required-version = ">=0.15"
 
 [tool.ruff.lint]
 future-annotations = true

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/graphql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/graphql-client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import decimal
 import sys
-import typing as t
+from typing import TYPE_CHECKING
 
 import requests  # noqa: TC002
 from singer_sdk.streams import {{ cookiecutter.stream_type }}Stream
@@ -19,7 +19,9 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import override
 
-if t.TYPE_CHECKING:
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from singer_sdk.helpers.types import Context
 
 
@@ -62,7 +64,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         return {}
 
     @override
-    def parse_response(self, response: requests.Response) -> t.Iterable[dict]:
+    def parse_response(self, response: requests.Response) -> Iterable[dict]:
         """Parse the response and return an iterator of result records.
 
         Args:

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/other-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/other-client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-import typing as t
+from typing import TYPE_CHECKING
 
 from singer_sdk.streams import Stream
 
@@ -12,7 +12,9 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import override
 
-if t.TYPE_CHECKING:
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from singer_sdk.helpers.types import Context
 
 
@@ -23,7 +25,7 @@ class {{ cookiecutter.source_name }}Stream(Stream):
     def get_records(
         self,
         context: Context | None,
-    ) -> t.Iterable[dict]:
+    ) -> Iterable[dict]:
         """Return a generator of record-type dictionary objects.
 
         The optional `context` argument is used to identify a specific slice of the

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       name: {{ '${{ steps.baipp.outputs.package_name }}' }}
       version: {{ '${{ steps.baipp.outputs.package_version }}' }}
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
       id: baipp
 

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
@@ -42,15 +42,13 @@ jobs:
         - "3.13"
         - "3.14"
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python {{ '${{ matrix.python-version }}' }}
-      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Setup uv
-      uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
-      with:
-        version: ">=0.8"
+      uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
     - name: Run Tox
       run: |
         uvx --with=tox-uv tox -e {{ '${{ matrix.python-version }}' }}
@@ -59,13 +57,13 @@ jobs:
     name: Type Checking
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python
-      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: 3.x
     - name: Setup uv
-      uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+      uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
       with:
         version: ">=0.8"
     - name: Run Tox

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
@@ -19,22 +19,20 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.36.0
+  rev: 0.36.1
   hooks:
   - id: check-dependabot
   - id: check-github-workflows
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.13
+  rev: v0.15.0
   hooks:
   - id: ruff-check
-    args: [--diff]
   - id: ruff-format
-    args: [--diff]
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.9.26
+  rev: 0.9.30
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -65,7 +65,7 @@ test = [
 ]
 typing = [
     "mypy>=1.16.0",
-    "ty>=0.0.1-alpha.16",
+    "ty>=0.0.15",
     {%- if cookiecutter.serialization_method == "SQL" %}
     "sqlalchemy-stubs",
     {%- else %}
@@ -109,9 +109,12 @@ warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
 
+[tool.ty.rules]
+unused-type-ignore-comment = "ignore"
+
 [tool.ruff]
 line-length = 100
-required-version = ">=0.14"
+required-version = ">=0.15"
 
 [tool.ruff.lint]
 future-annotations = true

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/tests/{{ 'test' }}_core.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/tests/{{ 'test' }}_core.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import typing as t
+from typing import Any
 
 import pytest
 from singer_sdk.testing import get_target_test_class
@@ -10,7 +10,7 @@ from singer_sdk.testing import get_target_test_class
 from {{ cookiecutter.library_name }}.target import Target{{ cookiecutter.destination_name }}
 
 # TODO: Initialize minimal target config
-SAMPLE_CONFIG: dict[str, t.Any] = {}
+SAMPLE_CONFIG: dict[str, Any] = {}
 
 
 # Run standard built-in target tests from the SDK:

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_sql.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_sql.py
@@ -6,7 +6,6 @@ import sys
 from typing import TYPE_CHECKING, Any
 
 from singer_sdk.connectors import SQLConnector
-from singer_sdk.connectors.sql import FullyQualifiedName
 from singer_sdk.sinks import SQLSink
 
 if sys.version_info >= (3, 12):
@@ -16,6 +15,8 @@ else:
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+    from singer_sdk.connectors.sql import FullyQualifiedName
 
 
 class {{ cookiecutter.destination_name }}Connector(SQLConnector):

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,7 +23,12 @@ RUFF_OVERRIDES = """\
 extend = "./pyproject.toml"
 
 [lint]
-extend-ignore = ["TD002", "TD003", "FIX002"]
+extend-ignore = [
+  # Ignore TODO comments
+  "TD002",
+  "TD003",
+  "FIX002",
+]
 """
 
 COOKIECUTTER_REPLAY_FILES = list(Path("./e2e-tests/cookiecutters").glob("*.json"))

--- a/packages/meltano-tap-dummyjson/.pre-commit-config.yaml
+++ b/packages/meltano-tap-dummyjson/.pre-commit-config.yaml
@@ -13,14 +13,14 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.36.0
+  rev: 0.36.1
   hooks:
   - id: check-dependabot
   - id: check-github-workflows
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.13
+  rev: v0.15.0
   hooks:
   - id: ruff-check
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]


### PR DESCRIPTION
## Summary by Sourcery

Update cookiecutter templates and tooling configuration to align with newer typing, linting, and packaging practices across taps, targets, and mappers.

Enhancements:
- Tighten type hints and TYPE_CHECKING imports in generated tap, target, and mapper clients to use standard Any/Iterable and avoid runtime-only dependencies.
- Adjust generated SQL, GraphQL, and other client templates to satisfy updated linting rules while preserving example code paths.
- Configure ty rules in generated projects to standardize handling of unused type ignore comments and bump ruff’s required version.

CI:
- Bump GitHub Actions versions (checkout, setup-python, setup-uv) in test and build workflows for all cookiecutter templates.
- Relax uv version constraint and update uv-pre-commit hooks for the main repo and generated projects.

Tests:
- Keep cookiecutter E2E workflow in sync with updated uv constraints to ensure template-based testing runs with newer tooling.

Chores:
- Update pre-commit hook versions (check-jsonschema, ruff, uv) across templates and internal packages to current releases.