### PR TITLE
ci: Use prek to validate templates

### DIFF
--- a/.github/workflows/resources/requirements.txt
+++ b/.github/workflows/resources/requirements.txt
@@ -1,4 +1,4 @@
 griffe~=1.15
 nox==2025.11.12
-pre-commit==4.5.1
+prek==0.3.1
 twine==6.2.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -479,7 +479,7 @@ def templates(session: nox.Session, replay_file_path: Path) -> None:
 
     session.run("git", "init", "-b", "main", external=True)
     session.run("git", "add", "-A", external=True)
-    session.run("uvx", "pre-commit", "run", "--all-files")
+    session.run("uvx", "prek", "run", "--all-files")
     session.run("uvx", "--with=tox-uv", "tox", "-e=typing")
 
 


### PR DESCRIPTION
## Summary by Sourcery

Switch template validation tooling in CI and nox from pre-commit to prek.

Build:
- Update workflow resources requirements to depend on prek instead of pre-commit.

CI:
- Align template validation command in the nox templates session to run prek rather than pre-commit.