### PR TITLE
fix(templates): Update templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Setup uv
-      uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
+      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
     - name: Run Tox
       run: |
         uvx --with=tox-uv tox -e {{ '${{ matrix.python-version }}' }}
@@ -63,7 +63,7 @@ jobs:
       with:
         python-version: 3.x
     - name: Setup uv
-      uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
+      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
       with:
         version: ">=0.8"
     - name: Run Tox

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
   - id: ruff-format
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.9.30
+  rev: 0.10.0
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Setup uv
-      uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
+      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
     - name: Run Tox
       run: |
         uvx --with=tox-uv tox -e {{ '${{ matrix.python-version }}' }}
@@ -63,7 +63,7 @@ jobs:
       with:
         python-version: 3.x
     - name: Setup uv
-      uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
+      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
       with:
         version: ">=0.8"
     - name: Run Tox

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
   - id: ruff-format
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.9.30
+  rev: 0.10.0
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Setup uv
-      uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
+      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
     - name: Run Tox
       run: |
         uvx --with=tox-uv tox -e {{ '${{ matrix.python-version }}' }}
@@ -63,7 +63,7 @@ jobs:
       with:
         python-version: 3.x
     - name: Setup uv
-      uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
+      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
       with:
         version: ">=0.8"
     - name: Run Tox

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
   - id: ruff-format
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.9.30
+  rev: 0.10.0
   hooks:
   - id: uv-lock
   - id: uv-sync


### PR DESCRIPTION
## Summary by Sourcery

Update cookiecutter templates to use newer uv tooling versions in CI and pre-commit hooks.

CI:
- Bump astral-sh/setup-uv GitHub Action to v7.3.0 in mapper, tap, and target template test workflows.

Tests:
- Align template test workflows with the updated uv setup action for running tox across Python versions.

Chores:
- Update uv-pre-commit hook revision to 0.10.0 in mapper, tap, and target templates' pre-commit configurations.