### PR TITLE
docs: Format Python code blocks in Markdown files with native Ruff support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,7 @@ repos:
       (?x)^(
         cookiecutter/.*
       )$
+    types_or: [python, markdown]
 
 - repo: https://github.com/astral-sh/uv-pre-commit
   rev: 0.10.0

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -105,6 +105,7 @@ To mark a test as platform-specific, use the `@pytest.mark.<platform>` decorator
 ```python
 import pytest
 
+
 @pytest.mark.windows
 def test_windows_only():
     pass

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -120,7 +120,7 @@ class MyStream(Stream):
             [
                 "s3://my-bucket/my-batch-file-1.parquet",
                 "s3://my-bucket/my-batch-file-2.parquet",
-            ]
+            ],
         )
 ```
 

--- a/docs/code_samples.md
+++ b/docs/code_samples.md
@@ -41,6 +41,7 @@ class TapCountries(Tap):
     """Sample tap for Countries GraphQL API. This tap has no
     config options and does not require authentication.
     """
+
     name = "tap-countries"
     config_jsonschema = th.PropertiesList([]).to_dict()
 
@@ -168,8 +169,8 @@ val1,val2,val3
 val1,val2,val3
 """
 
-class ParquetStream(Stream):
 
+class ParquetStream(Stream):
     @property
     def schema(self):
         """Dynamically detect the json schema for the stream.
@@ -189,7 +190,7 @@ custom `get_jsonschema_type()` function to return the data type.
 class ParquetStream(Stream):
     """Stream class for Parquet streams."""
 
-    #...
+    # ...
 
     @property
     def schema(self) -> dict:
@@ -226,26 +227,6 @@ class TapCountries(Tap):
         ]
 ```
 
-Or equivalently:
-
-```python
-
-# Declare list of types here at the top of the file
-STREAM_TYPES = [
-    CountriesStream,
-    ContinentsStream,
-]
-
-class TapCountries(Tap):
-    # ...
-    def discover_streams(self) -> List[Stream]:
-        """Return a list with one each of all defined stream types."""
-        return [
-            stream_type(tap=self)
-            for stream_type in STREAM_TYPES
-        ]
-```
-
 ### Run the standard built-in tap tests
 
 ```python
@@ -258,6 +239,7 @@ from tap_parquet.tap import TapParquet
 SAMPLE_CONFIG = {
     # ...
 }
+
 
 def test_sdk_standard_tap_tests():
     """Run the built-in tap tests from the SDK."""
@@ -272,8 +254,10 @@ def test_sdk_standard_tap_tests():
 from singer_sdk.authenticators import OAuthAuthenticator, SingletonMeta
 from singer_sdk.streams import RESTStream
 
+
 class SingletonAuthenticator(OAuthAuthenticator, metaclass=SingletonMeta):
     """A singleton authenticator."""
+
 
 class SingletonAuthStream(RESTStream):
     """A stream with singleton authenticator."""
@@ -292,6 +276,7 @@ from functools import cached_property
 from singer_sdk.authenticators import APIAuthenticatorBase
 from singer_sdk.streams import RESTStream
 
+
 class CachedAuthStream(RESTStream):
     """A stream with singleton authenticator."""
 
@@ -306,6 +291,7 @@ class CachedAuthStream(RESTStream):
 ```python
 from requests.auth import HTTPDigestAuth
 from singer_sdk.streams import RESTStream
+
 
 class DigestAuthStream(RESTStream):
     """A stream with digest authentication."""

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -109,6 +109,7 @@ By default, the Singer SDK for REST streams assumes the API responds with a JSON
 ```python
 class EntityStream(RESTStream):
     """Entity stream from a generic REST API."""
+
     records_jsonpath = "$.data.records[*]"
 ```
 

--- a/docs/guides/config-schema.md
+++ b/docs/guides/config-schema.md
@@ -15,9 +15,23 @@ class MyTap(Tap):
     name = "my-tap"
 
     config_jsonschema = th.PropertiesList(
-        th.Property("api_key", th.StringType(nullable=False), required=True, title="API Key"),
-        th.Property("base_url", th.StringType(nullable=True), default="https://api.example.com", title="Base URL"),
-        th.Property("start_date", th.DateTimeType(nullable=True), title="Start Date"),
+        th.Property(
+            "api_key",
+            th.StringType(nullable=False),
+            required=True,
+            title="API Key",
+        ),
+        th.Property(
+            "base_url",
+            th.StringType(nullable=True),
+            default="https://api.example.com",
+            title="Base URL",
+        ),
+        th.Property(
+            "start_date",
+            th.DateTimeType(nullable=True),
+            title="Start Date",
+        ),
     ).to_dict()
 ```
 

--- a/docs/guides/custom-clis.md
+++ b/docs/guides/custom-clis.md
@@ -11,12 +11,14 @@ To add a custom command, you will need to add a new method to your plugin class 
 ```python
 # tap_shortcut/tap.py
 
+
 class ShortcutTap(Tap):
     """Shortcut tap class."""
 
     @plugin_cli
     def update_schema(cls) -> click.Command:
         """Update the OpenAPI schema for this tap."""
+
         @click.command()
         def update():
             response = requests.get(

--- a/docs/guides/pagination-classes.md
+++ b/docs/guides/pagination-classes.md
@@ -33,6 +33,7 @@ class can be used to handle this pattern.
 # Original implementation
 from urllib.parse import parse_qsl
 
+
 class MyStream(RESTStream):
     def get_next_page_token(self, response, previous_token):
         data = response.json()
@@ -51,6 +52,7 @@ class MyStream(RESTStream):
 # New implementation
 
 from singer_sdk.pagination import BaseHATEOASPaginator
+
 
 class MyPaginator(BaseHATEOASPaginator):
     def get_next_url(self, response):

--- a/docs/guides/schema-sources.md
+++ b/docs/guides/schema-sources.md
@@ -25,9 +25,12 @@ from myproject import schemas
 # then the following code will load the schemas from the schemas subpackage:
 SCHEMAS_DIR = SchemaDirectory(schemas)
 
+
 class ProjectsStream(RESTStream):
     name = "projects"
-    schema: ClassVar[StreamSchema] = StreamSchema(SCHEMAS_DIR)  # Loads from projects.json
+
+    # Loads from projects.json
+    schema: ClassVar[StreamSchema] = StreamSchema(SCHEMAS_DIR)
 ```
 
 ## OpenAPI Integration
@@ -40,9 +43,12 @@ from singer_sdk import OpenAPISchema, StreamSchema
 # Load from OpenAPI spec
 openapi_source = OpenAPISchema("https://api.example.com/openapi.json")
 
+
 class UsersStream(RESTStream):
     name = "users"
-    schema: ClassVar[StreamSchema] = StreamSchema(openapi_source, key="User")  # Load "User" component
+
+    # Load "User" component
+    schema: ClassVar[StreamSchema] = StreamSchema(openapi_source, key="User")
 ```
 
 ## Migrating from File-Path Based Schemas
@@ -56,6 +62,7 @@ from pathlib import Path
 from singer_sdk import RESTStream
 
 SCHEMAS_DIR = Path(__file__).parent / "schemas"
+
 
 class ProjectsStream(RESTStream):
     """Projects stream with file-path based schema."""
@@ -72,6 +79,7 @@ from singer_sdk import RESTStream, SchemaDirectory, StreamSchema
 from myproject import schemas  # Your schemas module/package
 
 SCHEMAS_DIR = SchemaDirectory(schemas)
+
 
 class ProjectsStream(RESTStream):
     """Projects stream with schema source."""
@@ -118,6 +126,7 @@ class ProjectsStream(RESTStream):
    class MyStream(RESTStream):
        schema_filepath = SCHEMAS_DIR / "my_stream.json"
 
+
    # After
    class MyStream(RESTStream):
        schema: ClassVar[StreamSchema] = StreamSchema(SCHEMAS_DIR)
@@ -129,7 +138,9 @@ class ProjectsStream(RESTStream):
    # If your stream name doesn't match the schema file name
    class ProjectDetailsStream(RESTStream):
        name = "project_details"
-       schema: ClassVar[StreamSchema] = StreamSchema(SCHEMAS_DIR, key="ProjectDetail")  # Uses ProjectDetail.json
+
+       # Uses ProjectDetail.json
+       schema: ClassVar[StreamSchema] = StreamSchema(SCHEMAS_DIR, key="ProjectDetail")
    ```
 
 ### Benefits of Migration

--- a/docs/implementation/logging.md
+++ b/docs/implementation/logging.md
@@ -179,6 +179,5 @@ logging.config.dictConfig(
 )
 
 
-class MyTap(Tap):
-    ...
+class MyTap(Tap): ...
 ```

--- a/docs/incremental_replication.md
+++ b/docs/incremental_replication.md
@@ -10,12 +10,15 @@ You'll either have to manage your own [state file](https://hub.meltano.com/singe
 
 ```py
 class CommentsStream(RESTStream):
-
     replication_key = "date_gmt"
     is_sorted = True
 
     schema = th.PropertiesList(
-        th.Property("date_gmt", th.DateTimeType(nullable=True), description="Date"),
+        th.Property(
+            "date_gmt",
+            th.DateTimeType(nullable=True),
+            description="Date",
+        ),
     ).to_dict()
 
     def get_url_params(self, context, next_page_token):

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,10 +31,7 @@ SAMPLE_CONFIG = {
 
 
 # Run standard built-in tap tests from the SDK:
-TestTapExample = get_tap_test_class(
-    tap_class=TapExample,
-    config=SAMPLE_CONFIG
-)
+TestTapExample = get_tap_test_class(tap_class=TapExample, config=SAMPLE_CONFIG)
 ```
 
 ### Testing Targets
@@ -54,7 +51,7 @@ SAMPLE_CONFIG: Dict[str, Any] = {
 # Run standard built-in target tests from the SDK:
 StandardTargetTests = get_target_test_class(
     target_class=TargetExample,
-    config=SAMPLE_CONFIG
+    config=SAMPLE_CONFIG,
 )
 
 
@@ -92,9 +89,7 @@ SAMPLE_CONFIG = {
     "metrics_log_level": "debug",
 }
 
-TEST_SUITE_CONFIG = SuiteConfig(
-    ignore_no_records_for_streams=["tag_synonyms"]
-)
+TEST_SUITE_CONFIG = SuiteConfig(ignore_no_records_for_streams=["tag_synonyms"])
 
 TestTapStackExchange = get_tap_test_class(
     tap_class=TapStackExchange, config=SAMPLE_CONFIG, suite_config=TEST_SUITE_CONFIG
@@ -111,6 +106,7 @@ Check out [`singer_sdk/testing/tap_tests.py`](https://github.com/meltano/sdk/tre
 ```python
 class TapCLIPrintsTest(TapTestTemplate):
     "Test that the tap is able to print standard metadata."
+
     name = "cli_prints"
 
     def test(self):
@@ -122,9 +118,7 @@ class TapCLIPrintsTest(TapTestTemplate):
 Once you have created some tests, add them to a suite:
 
 ```python
-my_custom_tap_tests = TestSuite(
-    kind="tap", tests=[TapCLIPrintsTest]
-)
+my_custom_tap_tests = TestSuite(kind="tap", tests=[TapCLIPrintsTest])
 ```
 
 This suite can now be passed to {func}`get_tap_test_class <singer_sdk.testing.get_tap_test_class>` or {func}`get_target_test_class <singer_sdk.testing.get_target_test_class>` in a list of `custom_suites` along with any other suites, to generate your custom test class.

--- a/packages/meltano-tap-dummyjson/ruff.toml
+++ b/packages/meltano-tap-dummyjson/ruff.toml
@@ -1,13 +1,10 @@
+preview = true
 src = ["tap_dummyjson"]
 
 [lint]
 ignore = [
-    "ANN",
-    "ARG",
+    "CPY",
     "D",
-    "COM812",  # missing-trailing-comma
-    "ISC001",  # single-line-implicit-string-concatenation
-    "S113",    # request-without-timeout
     "PLR2004", # magic-value-comparison
     "RUF012",  # mutable-class-default
 ]

--- a/packages/meltano-tap-dummyjson/tap_dummyjson/auth.py
+++ b/packages/meltano-tap-dummyjson/tap_dummyjson/auth.py
@@ -16,13 +16,15 @@ EXPIRES_IN_MINS = 30
 
 
 class DummyJSONAuthenticator(metaclass=SingletonMeta):
+    """DummyJSON authenticator class."""
+
     def __init__(
         self,
         auth_url: str,
         refresh_token_url: str,
         username: str,
         password: str,
-    ):
+    ) -> None:
         self.auth_url = auth_url
         self.refresh_token_url = refresh_token_url
         self.username = username

--- a/packages/meltano-tap-dummyjson/tap_dummyjson/streams.py
+++ b/packages/meltano-tap-dummyjson/tap_dummyjson/streams.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from singer_sdk import typing as th
 
 from .client import DummyJSONStream
@@ -48,7 +50,7 @@ class Products(DummyJSONStream):
                     th.Property("date", th.DateTimeType),
                     th.Property("reviewerName", th.StringType),
                     th.Property("reviewerEmail", th.StringType),
-                )
+                ),
             ),
         ),
         th.Property("returnPolicy", th.StringType),

--- a/packages/meltano-tap-dummyjson/tap_dummyjson/tap.py
+++ b/packages/meltano-tap-dummyjson/tap_dummyjson/tap.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from singer_sdk import Tap
 from singer_sdk import typing as th  # JSON schema typing helpers
 
 from . import streams
+
+if TYPE_CHECKING:
+    from singer_sdk import Stream
 
 
 class TapDummyJSON(Tap):
@@ -41,7 +48,7 @@ class TapDummyJSON(Tap):
         ),
     ).to_dict()
 
-    def discover_streams(self):
+    def discover_streams(self) -> list[Stream]:
         """Return a list of discovered streams.
 
         Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -337,12 +337,15 @@ parquet = "singer_sdk.contrib.batch_encoder_parquet:ParquetBatcher"
 extend-exclude = [
     "cookiecutter/*",
 ]
+extend-include = [
+    "*.md",
+]
 line-length = 88
+preview = true
 required-version = ">=0.15"
 
 [tool.ruff.format]
 docstring-code-format = true
-preview = true
 
 [tool.ruff.lint]
 explicit-preview-rules = false
@@ -351,7 +354,6 @@ ignore = [
     "N818",    # Exception name should be named with an Error suffix
     "COM812",  # missing-trailing-comma
 ]
-preview = true
 select = [
     "F",    # Pyflakes
     "E",    # pycodestyle (error)


### PR DESCRIPTION
## Links

- [The Ruff Formatter - Markdown code formatting](https://docs.astral.sh/ruff/formatter/#markdown-code-formatting)

## Summary by Sourcery

Enable and apply Ruff-based formatting for embedded Python code in Markdown docs and tighten typing and linting configuration for the DummyJSON tap.

Enhancements:
- Add type hints, docstrings, and TYPE_CHECKING imports to the DummyJSON tap client, tap class, and authenticator for better type safety and clarity.

Build:
- Update Ruff configuration to run in preview mode and include Markdown files in formatting and linting targets, with adjusted ignore rules for the DummyJSON package.

CI:
- Adjust pre-commit configuration so Ruff checks run on both Python and Markdown files.

Documentation:
- Reformat Python code blocks across multiple Markdown guides and examples to align with Ruff’s formatter and improve consistency and readability.

## Summary by Sourcery

Enable Ruff preview-mode formatting for Python code blocks in Markdown and tighten typing and linting for the DummyJSON tap.

Enhancements:
- Add type hints, docstrings, and TYPE_CHECKING-only imports to the DummyJSON tap client, tap class, and authenticator for improved type safety.
- Refine DummyJSON tap pagination and request methods with explicit return and parameter types.

Build:
- Enable Ruff preview mode for the DummyJSON tap and relax selected lint rules specific to that package.
- Configure Ruff to include Markdown files in formatting and linting targets.

CI:
- Update pre-commit Ruff hook to run on both Python and Markdown files.

Documentation:
- Reformat and lightly restructure Python examples across multiple Markdown guides to match Ruff’s formatter and improve readability.