### PR TITLE
refactor: Set default `User-Agent` even if user overrides `http_headers`

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -158,7 +158,6 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
             Dictionary of HTTP headers to use as a base for every request.
         """
         return {
-            "User-Agent": self.user_agent,
             **self._http_headers,
         }
 
@@ -402,6 +401,7 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
             A :class:`requests.PreparedRequest` object.
         """
         request = requests.Request(*args, **kwargs)
+        request.headers.setdefault("User-Agent", self.user_agent)
         self.requests_session.auth = self.authenticator
         return self.requests_session.prepare_request(request)
 


### PR DESCRIPTION
- Extracted from https://github.com/meltano/sdk/pull/3483

## Summary by Sourcery

Bug Fixes:
- Preserve the SDK's default User-Agent header when users override http_headers so requests consistently include a User-Agent value.