### PR TITLE
test: Increased tap-dummyjson test record limit to exercise pagination

### DIFF
--- a/.http_cache/199c4fcec1a09424.json
+++ b/.http_cache/199c4fcec1a09424.json
@@ -1,0 +1,1536 @@
+{
+  "created_at": "2026-02-18T06:37:11.662906+00:00",
+  "elapsed": 2.337201,
+  "encoding": "utf-8",
+  "headers": {
+    "CF-RAY": "9cfb83b34f6a44e7-ATL",
+    "Connection": "keep-alive",
+    "Content-Encoding": "zstd",
+    "Content-Type": "application/json; charset=utf-8",
+    "Date": "Wed, 18 Feb 2026 06:37:11 GMT",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=EXGcoNoCt6u8uDhGWUZywGKu%2BKSPXNNg%2Fbxn%2F26dYxqhV6brupcGZVSfU%2FWCpxXK4HEHZiH0d1%2FNy9zDw1PSg5onQgEIOAHo2YQNY%2Fc%3D\"}]}",
+    "Server": "cloudflare",
+    "Transfer-Encoding": "chunked",
+    "access-control-allow-origin": "*",
+    "cf-cache-status": "DYNAMIC",
+    "etag": "W/\"922f-YJx72MeR4yiInWWRtMqgdJhBHsw\"",
+    "strict-transport-security": "max-age=15552000; includeSubDomains",
+    "vary": "Accept-Encoding",
+    "x-content-type-options": "nosniff",
+    "x-dns-prefetch-control": "off",
+    "x-download-options": "noopen",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ratelimit-limit": "100",
+    "x-ratelimit-remaining": "99",
+    "x-ratelimit-reset": "1771396634",
+    "x-xss-protection": "1; mode=block"
+  },
+  "reason": "OK",
+  "request": {
+    "body": null,
+    "headers": {
+      "Accept": "*/*",
+      "Accept-Encoding": "gzip, deflate, zstd",
+      "Authorization": "REDACTED",
+      "Connection": "keep-alive",
+      "User-Agent": "tap-dummyjson/0.0.0"
+    },
+    "method": "GET",
+    "url": "https://dummyjson.com/products?limit=25&skip=50"
+  },
+  "status_code": 200,
+  "url": "https://dummyjson.com/products?limit=25&skip=50",
+  "_decoded_content": {
+    "products": [
+      {
+        "id": 51,
+        "title": "Boxed Blender",
+        "description": "The Boxed Blender is a powerful and compact blender perfect for smoothies, shakes, and more. Its convenient design and multiple functions make it a versatile kitchen appliance.",
+        "category": "kitchen-accessories",
+        "price": 39.99,
+        "discountPercentage": 7.26,
+        "rating": 4.56,
+        "stock": 9,
+        "tags": [
+          "kitchen appliances",
+          "blenders"
+        ],
+        "sku": "KIT-BRD-BOX-051",
+        "weight": 1,
+        "dimensions": {
+          "width": 9.05,
+          "height": 19.45,
+          "depth": 17.59
+        },
+        "warrantyInformation": "5 year warranty",
+        "shippingInformation": "Ships in 1-2 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Very pleased!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Ella Adams",
+            "reviewerEmail": "ella.adams@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Would buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Ruby Andrews",
+            "reviewerEmail": "ruby.andrews@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Very happy with my purchase!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Aurora Lawson",
+            "reviewerEmail": "aurora.lawson@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 4,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "4823087836817",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/boxed-blender/1.webp",
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/boxed-blender/2.webp",
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/boxed-blender/3.webp",
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/boxed-blender/4.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/boxed-blender/thumbnail.webp"
+      },
+      {
+        "id": 52,
+        "title": "Carbon Steel Wok",
+        "description": "The Carbon Steel Wok is a versatile cooking pan suitable for stir-frying, saut\u00e9ing, and deep frying. Its sturdy construction ensures even heat distribution for delicious meals.",
+        "category": "kitchen-accessories",
+        "price": 29.99,
+        "discountPercentage": 6.53,
+        "rating": 4.05,
+        "stock": 40,
+        "tags": [
+          "cookware",
+          "woks"
+        ],
+        "sku": "KIT-BRD-CAR-052",
+        "weight": 2,
+        "dimensions": {
+          "width": 27.69,
+          "height": 7.54,
+          "depth": 10.11
+        },
+        "warrantyInformation": "2 year warranty",
+        "shippingInformation": "Ships in 1-2 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 4,
+            "comment": "Excellent quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Nolan Bryant",
+            "reviewerEmail": "nolan.bryant@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Highly impressed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Luna Perez",
+            "reviewerEmail": "luna.perez@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Very satisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Noah Lewis",
+            "reviewerEmail": "noah.lewis@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 9,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "1810862118199",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/carbon-steel-wok/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/carbon-steel-wok/thumbnail.webp"
+      },
+      {
+        "id": 53,
+        "title": "Chopping Board",
+        "description": "The Chopping Board is an essential kitchen accessory for food preparation. Made from durable material, it provides a safe and hygienic surface for cutting and chopping.",
+        "category": "kitchen-accessories",
+        "price": 12.99,
+        "discountPercentage": 8.03,
+        "rating": 3.7,
+        "stock": 14,
+        "tags": [
+          "kitchen tools",
+          "cutting boards"
+        ],
+        "sku": "KIT-BRD-CHO-053",
+        "weight": 2,
+        "dimensions": {
+          "width": 15.6,
+          "height": 6.93,
+          "depth": 8.51
+        },
+        "warrantyInformation": "3 months warranty",
+        "shippingInformation": "Ships in 2 weeks",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Great value for money!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Xavier Wright",
+            "reviewerEmail": "xavier.wright@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Great value for money!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Henry Turner",
+            "reviewerEmail": "henry.turner@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Fast shipping!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Evelyn Walker",
+            "reviewerEmail": "evelyn.walker@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 5,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "0085585730728",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/chopping-board/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/chopping-board/thumbnail.webp"
+      },
+      {
+        "id": 54,
+        "title": "Citrus Squeezer Yellow",
+        "description": "The Citrus Squeezer in Yellow is a handy tool for extracting juice from citrus fruits. Its vibrant color adds a cheerful touch to your kitchen gadgets.",
+        "category": "kitchen-accessories",
+        "price": 8.99,
+        "discountPercentage": 12.1,
+        "rating": 4.63,
+        "stock": 22,
+        "tags": [
+          "kitchen tools",
+          "juicers"
+        ],
+        "sku": "KIT-BRD-CIT-054",
+        "weight": 2,
+        "dimensions": {
+          "width": 17.16,
+          "height": 26.8,
+          "depth": 16.29
+        },
+        "warrantyInformation": "2 year warranty",
+        "shippingInformation": "Ships in 3-5 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 4,
+            "comment": "Highly recommended!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Lucas Ramirez",
+            "reviewerEmail": "lucas.ramirez@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Great product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Eleanor Collins",
+            "reviewerEmail": "eleanor.collins@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Highly impressed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Mila Hernandez",
+            "reviewerEmail": "mila.hernandez@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "60 days return policy",
+        "minimumOrderQuantity": 38,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "2231952604189",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/citrus-squeezer-yellow/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/citrus-squeezer-yellow/thumbnail.webp"
+      },
+      {
+        "id": 55,
+        "title": "Egg Slicer",
+        "description": "The Egg Slicer is a convenient tool for slicing boiled eggs evenly. It's perfect for salads, sandwiches, and other dishes where sliced eggs are desired.",
+        "category": "kitchen-accessories",
+        "price": 6.99,
+        "discountPercentage": 14.76,
+        "rating": 3.09,
+        "stock": 40,
+        "tags": [
+          "kitchen tools",
+          "slicers"
+        ],
+        "sku": "KIT-BRD-SLI-055",
+        "weight": 2,
+        "dimensions": {
+          "width": 10.81,
+          "height": 19.15,
+          "depth": 13.18
+        },
+        "warrantyInformation": "1 week warranty",
+        "shippingInformation": "Ships in 1 month",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 3,
+            "comment": "Very dissatisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Harper Garcia",
+            "reviewerEmail": "harper.garcia@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Very happy with my purchase!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Lily Torres",
+            "reviewerEmail": "lily.torres@x.dummyjson.com"
+          },
+          {
+            "rating": 1,
+            "comment": "Not worth the price!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Tyler Davis",
+            "reviewerEmail": "tyler.davis@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 32,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "6456249953517",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/egg-slicer/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/egg-slicer/thumbnail.webp"
+      },
+      {
+        "id": 56,
+        "title": "Electric Stove",
+        "description": "The Electric Stove provides a portable and efficient cooking solution. Ideal for small kitchens or as an additional cooking surface for various culinary needs.",
+        "category": "kitchen-accessories",
+        "price": 49.99,
+        "discountPercentage": 14.04,
+        "rating": 4.11,
+        "stock": 21,
+        "tags": [
+          "kitchen appliances",
+          "cooktops"
+        ],
+        "sku": "KIT-BRD-ELE-056",
+        "weight": 5,
+        "dimensions": {
+          "width": 24.17,
+          "height": 22.55,
+          "depth": 27.49
+        },
+        "warrantyInformation": "2 year warranty",
+        "shippingInformation": "Ships in 1 week",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 1,
+            "comment": "Would not recommend!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Ava Harris",
+            "reviewerEmail": "ava.harris@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Very dissatisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Liam Smith",
+            "reviewerEmail": "liam.smith@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Very pleased!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Christian Perez",
+            "reviewerEmail": "christian.perez@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 8,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "7534096777716",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/electric-stove/1.webp",
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/electric-stove/2.webp",
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/electric-stove/3.webp",
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/electric-stove/4.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/electric-stove/thumbnail.webp"
+      },
+      {
+        "id": 57,
+        "title": "Fine Mesh Strainer",
+        "description": "The Fine Mesh Strainer is a versatile tool for straining liquids and sifting dry ingredients. Its fine mesh ensures efficient filtering for smooth cooking and baking.",
+        "category": "kitchen-accessories",
+        "price": 9.99,
+        "discountPercentage": 3.5,
+        "rating": 3.04,
+        "stock": 85,
+        "tags": [
+          "kitchen tools",
+          "strainers"
+        ],
+        "sku": "KIT-BRD-FIN-057",
+        "weight": 9,
+        "dimensions": {
+          "width": 18.02,
+          "height": 13.23,
+          "depth": 15.92
+        },
+        "warrantyInformation": "1 month warranty",
+        "shippingInformation": "Ships overnight",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Very pleased!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Isabella Anderson",
+            "reviewerEmail": "isabella.anderson@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Highly impressed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Aaliyah Hanson",
+            "reviewerEmail": "aaliyah.hanson@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Would not recommend!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Layla Sullivan",
+            "reviewerEmail": "layla.sullivan@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 43,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "8181672477425",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/fine-mesh-strainer/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/fine-mesh-strainer/thumbnail.webp"
+      },
+      {
+        "id": 58,
+        "title": "Fork",
+        "description": "The Fork is a classic utensil for various dining and serving purposes. Its durable and ergonomic design makes it a reliable choice for everyday use.",
+        "category": "kitchen-accessories",
+        "price": 3.99,
+        "discountPercentage": 8.07,
+        "rating": 3.11,
+        "stock": 7,
+        "tags": [
+          "kitchen tools",
+          "utensils"
+        ],
+        "sku": "KIT-BRD-FOR-058",
+        "weight": 9,
+        "dimensions": {
+          "width": 12.3,
+          "height": 25.91,
+          "depth": 22.57
+        },
+        "warrantyInformation": "No warranty",
+        "shippingInformation": "Ships in 1 month",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Highly impressed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Elena Baker",
+            "reviewerEmail": "elena.baker@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Very satisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Avery Scott",
+            "reviewerEmail": "avery.scott@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Would not buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Mateo Perez",
+            "reviewerEmail": "mateo.perez@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 36,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "2851192866410",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/fork/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/fork/thumbnail.webp"
+      },
+      {
+        "id": 59,
+        "title": "Glass",
+        "description": "The Glass is a versatile and elegant drinking vessel suitable for a variety of beverages. Its clear design allows you to enjoy the colors and textures of your drinks.",
+        "category": "kitchen-accessories",
+        "price": 4.99,
+        "discountPercentage": 7.92,
+        "rating": 4.02,
+        "stock": 46,
+        "tags": [
+          "drinkware",
+          "glasses"
+        ],
+        "sku": "KIT-BRD-GLA-059",
+        "weight": 10,
+        "dimensions": {
+          "width": 20.23,
+          "height": 24.56,
+          "depth": 26.97
+        },
+        "warrantyInformation": "3 year warranty",
+        "shippingInformation": "Ships overnight",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Very happy with my purchase!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Jackson Evans",
+            "reviewerEmail": "jackson.evans@x.dummyjson.com"
+          },
+          {
+            "rating": 3,
+            "comment": "Waste of money!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Nicholas Bailey",
+            "reviewerEmail": "nicholas.bailey@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Very satisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Nathan Reed",
+            "reviewerEmail": "nathan.reed@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 17,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "4900880403720",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/glass/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/glass/thumbnail.webp"
+      },
+      {
+        "id": 60,
+        "title": "Grater Black",
+        "description": "The Grater in Black is a handy kitchen tool for grating cheese, vegetables, and more. Its sleek design and sharp blades make food preparation efficient and easy.",
+        "category": "kitchen-accessories",
+        "price": 10.99,
+        "discountPercentage": 3.56,
+        "rating": 3.21,
+        "stock": 84,
+        "tags": [
+          "kitchen tools",
+          "graters"
+        ],
+        "sku": "KIT-BRD-GRA-060",
+        "weight": 3,
+        "dimensions": {
+          "width": 6.32,
+          "height": 23.11,
+          "depth": 24.64
+        },
+        "warrantyInformation": "1 month warranty",
+        "shippingInformation": "Ships in 1 week",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 1,
+            "comment": "Would not buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Ella Adams",
+            "reviewerEmail": "ella.adams@x.dummyjson.com"
+          },
+          {
+            "rating": 1,
+            "comment": "Not as described!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Eli Ward",
+            "reviewerEmail": "eli.ward@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Highly impressed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "James Garcia",
+            "reviewerEmail": "james.garcia@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "60 days return policy",
+        "minimumOrderQuantity": 5,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "2542647841284",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/grater-black/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/grater-black/thumbnail.webp"
+      },
+      {
+        "id": 61,
+        "title": "Hand Blender",
+        "description": "The Hand Blender is a versatile kitchen appliance for blending, pureeing, and mixing. Its compact design and powerful motor make it a convenient tool for various recipes.",
+        "category": "kitchen-accessories",
+        "price": 34.99,
+        "discountPercentage": 17.02,
+        "rating": 3.86,
+        "stock": 84,
+        "tags": [
+          "kitchen appliances",
+          "blenders"
+        ],
+        "sku": "KIT-BRD-HAN-061",
+        "weight": 5,
+        "dimensions": {
+          "width": 27.31,
+          "height": 21,
+          "depth": 24.27
+        },
+        "warrantyInformation": "1 year warranty",
+        "shippingInformation": "Ships in 1 week",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Excellent quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Hazel Evans",
+            "reviewerEmail": "hazel.evans@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Highly impressed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Hannah Howard",
+            "reviewerEmail": "hannah.howard@x.dummyjson.com"
+          },
+          {
+            "rating": 1,
+            "comment": "Would not buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Jonathan Pierce",
+            "reviewerEmail": "jonathan.pierce@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 11,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "1980575898457",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/hand-blender/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/hand-blender/thumbnail.webp"
+      },
+      {
+        "id": 62,
+        "title": "Ice Cube Tray",
+        "description": "The Ice Cube Tray is a practical accessory for making ice cubes in various shapes. Perfect for keeping your drinks cool and adding a fun element to your beverages.",
+        "category": "kitchen-accessories",
+        "price": 5.99,
+        "discountPercentage": 0.63,
+        "rating": 4.71,
+        "stock": 13,
+        "tags": [
+          "kitchen tools",
+          "ice cube trays"
+        ],
+        "sku": "KIT-BRD-CUB-062",
+        "weight": 3,
+        "dimensions": {
+          "width": 26.67,
+          "height": 18.14,
+          "depth": 5.31
+        },
+        "warrantyInformation": "1 month warranty",
+        "shippingInformation": "Ships overnight",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Awesome product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Isaac Lawrence",
+            "reviewerEmail": "isaac.lawrence@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Would buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Leo Rivera",
+            "reviewerEmail": "leo.rivera@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Very pleased!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Henry Turner",
+            "reviewerEmail": "henry.turner@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 16,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "9123541111825",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/ice-cube-tray/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/ice-cube-tray/thumbnail.webp"
+      },
+      {
+        "id": 63,
+        "title": "Kitchen Sieve",
+        "description": "The Kitchen Sieve is a versatile tool for sifting and straining dry and wet ingredients. Its fine mesh design ensures smooth results in your cooking and baking.",
+        "category": "kitchen-accessories",
+        "price": 7.99,
+        "discountPercentage": 18.91,
+        "rating": 3.09,
+        "stock": 68,
+        "tags": [
+          "kitchen tools",
+          "strainers"
+        ],
+        "sku": "KIT-BRD-KIT-063",
+        "weight": 5,
+        "dimensions": {
+          "width": 20.68,
+          "height": 6.5,
+          "depth": 7.86
+        },
+        "warrantyInformation": "1 month warranty",
+        "shippingInformation": "Ships overnight",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Highly recommended!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Stella Morris",
+            "reviewerEmail": "stella.morris@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Very happy with my purchase!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Henry Adams",
+            "reviewerEmail": "henry.adams@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Awesome product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Lillian Simmons",
+            "reviewerEmail": "lillian.simmons@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 5,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "7119606190291",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/kitchen-sieve/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/kitchen-sieve/thumbnail.webp"
+      },
+      {
+        "id": 64,
+        "title": "Knife",
+        "description": "The Knife is an essential kitchen tool for chopping, slicing, and dicing. Its sharp blade and ergonomic handle make it a reliable choice for food preparation.",
+        "category": "kitchen-accessories",
+        "price": 14.99,
+        "discountPercentage": 18.86,
+        "rating": 3.26,
+        "stock": 7,
+        "tags": [
+          "kitchen tools",
+          "cutlery"
+        ],
+        "sku": "KIT-BRD-KNI-064",
+        "weight": 3,
+        "dimensions": {
+          "width": 25.19,
+          "height": 18.52,
+          "depth": 20.5
+        },
+        "warrantyInformation": "1 month warranty",
+        "shippingInformation": "Ships in 1 week",
+        "availabilityStatus": "Low Stock",
+        "reviews": [
+          {
+            "rating": 2,
+            "comment": "Very disappointed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Aaliyah Martinez",
+            "reviewerEmail": "aaliyah.martinez@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Fast shipping!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Addison Wright",
+            "reviewerEmail": "addison.wright@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Very pleased!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Mateo Nguyen",
+            "reviewerEmail": "mateo.nguyen@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 50,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "2258278927819",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/knife/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/knife/thumbnail.webp"
+      },
+      {
+        "id": 65,
+        "title": "Lunch Box",
+        "description": "The Lunch Box is a convenient and portable container for packing and carrying your meals. With compartments for different foods, it's perfect for on-the-go dining.",
+        "category": "kitchen-accessories",
+        "price": 12.99,
+        "discountPercentage": 10.34,
+        "rating": 4.93,
+        "stock": 94,
+        "tags": [
+          "kitchen tools",
+          "storage"
+        ],
+        "sku": "KIT-BRD-LUN-065",
+        "weight": 9,
+        "dimensions": {
+          "width": 12.45,
+          "height": 19.08,
+          "depth": 8.24
+        },
+        "warrantyInformation": "5 year warranty",
+        "shippingInformation": "Ships in 1-2 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Very pleased!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Jace Smith",
+            "reviewerEmail": "jace.smith@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Very happy with my purchase!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Zoe Bennett",
+            "reviewerEmail": "zoe.bennett@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Poor quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Michael Johnson",
+            "reviewerEmail": "michael.johnson@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "30 days return policy",
+        "minimumOrderQuantity": 39,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "3287134465440",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/lunch-box/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/lunch-box/thumbnail.webp"
+      },
+      {
+        "id": 66,
+        "title": "Microwave Oven",
+        "description": "The Microwave Oven is a versatile kitchen appliance for quick and efficient cooking, reheating, and defrosting. Its compact size makes it suitable for various kitchen setups.",
+        "category": "kitchen-accessories",
+        "price": 89.99,
+        "discountPercentage": 12.13,
+        "rating": 4.82,
+        "stock": 59,
+        "tags": [
+          "kitchen appliances",
+          "microwaves"
+        ],
+        "sku": "KIT-BRD-MIC-066",
+        "weight": 9,
+        "dimensions": {
+          "width": 16.31,
+          "height": 27.45,
+          "depth": 13.05
+        },
+        "warrantyInformation": "1 year warranty",
+        "shippingInformation": "Ships in 1 week",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 3,
+            "comment": "Very dissatisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Nora Russell",
+            "reviewerEmail": "nora.russell@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Fast shipping!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Alice Smith",
+            "reviewerEmail": "alice.smith@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Very disappointed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Ethan Fletcher",
+            "reviewerEmail": "ethan.fletcher@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 4,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "7578271198951",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/microwave-oven/1.webp",
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/microwave-oven/2.webp",
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/microwave-oven/3.webp",
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/microwave-oven/4.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/microwave-oven/thumbnail.webp"
+      },
+      {
+        "id": 67,
+        "title": "Mug Tree Stand",
+        "description": "The Mug Tree Stand is a stylish and space-saving solution for organizing your mugs. Keep your favorite mugs easily accessible and neatly displayed in your kitchen.",
+        "category": "kitchen-accessories",
+        "price": 15.99,
+        "discountPercentage": 9.25,
+        "rating": 2.64,
+        "stock": 88,
+        "tags": [
+          "kitchen tools",
+          "organization"
+        ],
+        "sku": "KIT-BRD-TRE-067",
+        "weight": 3,
+        "dimensions": {
+          "width": 18.99,
+          "height": 27.14,
+          "depth": 27.29
+        },
+        "warrantyInformation": "1 year warranty",
+        "shippingInformation": "Ships in 1 month",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 1,
+            "comment": "Very unhappy with my purchase!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Bella Grant",
+            "reviewerEmail": "bella.grant@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Highly recommended!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Paisley Bell",
+            "reviewerEmail": "paisley.bell@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Fast shipping!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "David Martinez",
+            "reviewerEmail": "david.martinez@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "30 days return policy",
+        "minimumOrderQuantity": 45,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "4136081478055",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/mug-tree-stand/1.webp",
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/mug-tree-stand/2.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/mug-tree-stand/thumbnail.webp"
+      },
+      {
+        "id": 68,
+        "title": "Pan",
+        "description": "The Pan is a versatile and essential cookware item for frying, saut\u00e9ing, and cooking various dishes. Its non-stick coating ensures easy food release and cleanup.",
+        "category": "kitchen-accessories",
+        "price": 24.99,
+        "discountPercentage": 3,
+        "rating": 2.79,
+        "stock": 90,
+        "tags": [
+          "cookware",
+          "pans"
+        ],
+        "sku": "KIT-BRD-PRD-068",
+        "weight": 8,
+        "dimensions": {
+          "width": 17.14,
+          "height": 21.7,
+          "depth": 25.75
+        },
+        "warrantyInformation": "1 year warranty",
+        "shippingInformation": "Ships in 3-5 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Highly impressed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Michael Johnson",
+            "reviewerEmail": "michael.johnson@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Highly recommended!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Adrian Flores",
+            "reviewerEmail": "adrian.flores@x.dummyjson.com"
+          },
+          {
+            "rating": 1,
+            "comment": "Not as described!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Nicholas Bailey",
+            "reviewerEmail": "nicholas.bailey@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "30 days return policy",
+        "minimumOrderQuantity": 17,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "5159803862015",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/pan/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/pan/thumbnail.webp"
+      },
+      {
+        "id": 69,
+        "title": "Plate",
+        "description": "The Plate is a classic and essential dishware item for serving meals. Its durable and stylish design makes it suitable for everyday use or special occasions.",
+        "category": "kitchen-accessories",
+        "price": 3.99,
+        "discountPercentage": 7.31,
+        "rating": 3.65,
+        "stock": 66,
+        "tags": [
+          "dinnerware",
+          "plates"
+        ],
+        "sku": "KIT-BRD-PLA-069",
+        "weight": 4,
+        "dimensions": {
+          "width": 16.46,
+          "height": 5.39,
+          "depth": 13.15
+        },
+        "warrantyInformation": "1 year warranty",
+        "shippingInformation": "Ships in 1-2 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 3,
+            "comment": "Disappointing product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Mia Miller",
+            "reviewerEmail": "mia.miller@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Great product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Henry Adams",
+            "reviewerEmail": "henry.adams@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Excellent quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Nora Russell",
+            "reviewerEmail": "nora.russell@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "90 days return policy",
+        "minimumOrderQuantity": 6,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "8084753475328",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/plate/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/plate/thumbnail.webp"
+      },
+      {
+        "id": 70,
+        "title": "Red Tongs",
+        "description": "The Red Tongs are versatile kitchen tongs suitable for various cooking and serving tasks. Their vibrant color adds a pop of excitement to your kitchen utensils.",
+        "category": "kitchen-accessories",
+        "price": 6.99,
+        "discountPercentage": 14.52,
+        "rating": 4.42,
+        "stock": 82,
+        "tags": [
+          "kitchen tools",
+          "tongs"
+        ],
+        "sku": "KIT-BRD-TON-070",
+        "weight": 7,
+        "dimensions": {
+          "width": 22.86,
+          "height": 26.2,
+          "depth": 17
+        },
+        "warrantyInformation": "No warranty",
+        "shippingInformation": "Ships in 1 week",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 4,
+            "comment": "Very satisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Xavier Wright",
+            "reviewerEmail": "xavier.wright@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Highly recommended!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Stella Hughes",
+            "reviewerEmail": "stella.hughes@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Excellent quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Jaxon Barnes",
+            "reviewerEmail": "jaxon.barnes@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "30 days return policy",
+        "minimumOrderQuantity": 23,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "1919888449594",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/red-tongs/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/red-tongs/thumbnail.webp"
+      },
+      {
+        "id": 71,
+        "title": "Silver Pot With Glass Cap",
+        "description": "The Silver Pot with Glass Cap is a stylish and functional cookware item for boiling, simmering, and preparing delicious meals. Its glass cap allows you to monitor cooking progress.",
+        "category": "kitchen-accessories",
+        "price": 39.99,
+        "discountPercentage": 5.7,
+        "rating": 3.22,
+        "stock": 40,
+        "tags": [
+          "cookware",
+          "pots"
+        ],
+        "sku": "KIT-BRD-SIL-071",
+        "weight": 7,
+        "dimensions": {
+          "width": 21.03,
+          "height": 11.7,
+          "depth": 6.69
+        },
+        "warrantyInformation": "1 year warranty",
+        "shippingInformation": "Ships in 1 month",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 4,
+            "comment": "Great product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Julian Newton",
+            "reviewerEmail": "julian.newton@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Excellent quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Noah Lewis",
+            "reviewerEmail": "noah.lewis@x.dummyjson.com"
+          },
+          {
+            "rating": 1,
+            "comment": "Disappointing product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Brayden Hill",
+            "reviewerEmail": "brayden.hill@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "90 days return policy",
+        "minimumOrderQuantity": 10,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "9757232943842",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/silver-pot-with-glass-cap/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/silver-pot-with-glass-cap/thumbnail.webp"
+      },
+      {
+        "id": 72,
+        "title": "Slotted Turner",
+        "description": "The Slotted Turner is a kitchen utensil designed for flipping and turning food items. Its slotted design allows excess liquid to drain, making it ideal for frying and saut\u00e9ing.",
+        "category": "kitchen-accessories",
+        "price": 8.99,
+        "discountPercentage": 13.35,
+        "rating": 3.4,
+        "stock": 88,
+        "tags": [
+          "kitchen tools",
+          "turners"
+        ],
+        "sku": "KIT-BRD-SLO-072",
+        "weight": 8,
+        "dimensions": {
+          "width": 14.41,
+          "height": 27.15,
+          "depth": 14.76
+        },
+        "warrantyInformation": "Lifetime warranty",
+        "shippingInformation": "Ships in 1-2 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 1,
+            "comment": "Would not recommend!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Ava Taylor",
+            "reviewerEmail": "ava.taylor@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Would not recommend!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Liam Smith",
+            "reviewerEmail": "liam.smith@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Very satisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Gabriel Mitchell",
+            "reviewerEmail": "gabriel.mitchell@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 34,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "4396291569672",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/slotted-turner/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/slotted-turner/thumbnail.webp"
+      },
+      {
+        "id": 73,
+        "title": "Spice Rack",
+        "description": "The Spice Rack is a convenient organizer for your spices and seasonings. Keep your kitchen essentials within reach and neatly arranged with this stylish spice rack.",
+        "category": "kitchen-accessories",
+        "price": 19.99,
+        "discountPercentage": 12.09,
+        "rating": 4.87,
+        "stock": 79,
+        "tags": [
+          "kitchen tools",
+          "organization"
+        ],
+        "sku": "KIT-BRD-SPI-073",
+        "weight": 7,
+        "dimensions": {
+          "width": 28.06,
+          "height": 22.43,
+          "depth": 26.34
+        },
+        "warrantyInformation": "1 week warranty",
+        "shippingInformation": "Ships overnight",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Very satisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Elena Baker",
+            "reviewerEmail": "elena.baker@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Excellent quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Owen Fisher",
+            "reviewerEmail": "owen.fisher@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Waste of money!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Sadie Morales",
+            "reviewerEmail": "sadie.morales@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 18,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "6149284465708",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/spice-rack/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/spice-rack/thumbnail.webp"
+      },
+      {
+        "id": 74,
+        "title": "Spoon",
+        "description": "The Spoon is a versatile kitchen utensil for stirring, serving, and tasting. Its ergonomic design and durable construction make it an essential tool for every kitchen.",
+        "category": "kitchen-accessories",
+        "price": 4.99,
+        "discountPercentage": 1.53,
+        "rating": 4.03,
+        "stock": 59,
+        "tags": [
+          "kitchen tools",
+          "utensils"
+        ],
+        "sku": "KIT-BRD-SPO-074",
+        "weight": 6,
+        "dimensions": {
+          "width": 8.49,
+          "height": 26.04,
+          "depth": 27.78
+        },
+        "warrantyInformation": "1 year warranty",
+        "shippingInformation": "Ships in 1-2 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 3,
+            "comment": "Waste of money!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Jackson Evans",
+            "reviewerEmail": "jackson.evans@x.dummyjson.com"
+          },
+          {
+            "rating": 1,
+            "comment": "Disappointing product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Elena Baker",
+            "reviewerEmail": "elena.baker@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Awesome product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Bella Gonzalez",
+            "reviewerEmail": "bella.gonzalez@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "90 days return policy",
+        "minimumOrderQuantity": 15,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "7769627934740",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/spoon/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/spoon/thumbnail.webp"
+      },
+      {
+        "id": 75,
+        "title": "Tray",
+        "description": "The Tray is a functional and decorative item for serving snacks, appetizers, or drinks. Its stylish design makes it a versatile accessory for entertaining guests.",
+        "category": "kitchen-accessories",
+        "price": 16.99,
+        "discountPercentage": 7.48,
+        "rating": 4.62,
+        "stock": 71,
+        "tags": [
+          "serveware",
+          "trays"
+        ],
+        "sku": "KIT-BRD-TRA-075",
+        "weight": 10,
+        "dimensions": {
+          "width": 12.7,
+          "height": 7.52,
+          "depth": 9.72
+        },
+        "warrantyInformation": "5 year warranty",
+        "shippingInformation": "Ships in 2 weeks",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Fast shipping!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Samantha Howard",
+            "reviewerEmail": "samantha.howard@x.dummyjson.com"
+          },
+          {
+            "rating": 3,
+            "comment": "Very disappointed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Benjamin Wilson",
+            "reviewerEmail": "benjamin.wilson@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Excellent quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Caleb Nelson",
+            "reviewerEmail": "caleb.nelson@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 23,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "5239514403214",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/tray/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/tray/thumbnail.webp"
+      }
+    ],
+    "total": 194,
+    "skip": 50,
+    "limit": 25
+  }
+}

--- a/.http_cache/6bd2e670e027986c.json
+++ b/.http_cache/6bd2e670e027986c.json
@@ -1,0 +1,61 @@
+{
+  "cookies": {
+    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwidXNlcm5hbWUiOiJlbWlseXMiLCJlbWFpbCI6ImVtaWx5LmpvaG5zb25AeC5kdW1teWpzb24uY29tIiwiZmlyc3ROYW1lIjoiRW1pbHkiLCJsYXN0TmFtZSI6IkpvaG5zb24iLCJnZW5kZXIiOiJmZW1hbGUiLCJpbWFnZSI6Imh0dHBzOi8vZHVtbXlqc29uLmNvbS9pY29uL2VtaWx5cy8xMjgiLCJpYXQiOjE3NzEzOTYyMzAsImV4cCI6MTc3MTM5ODAzMH0.PsP4SnDBPSZ7r2MIwCfHLJiI17pcUQOdrcTR22q98iI",
+    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwidXNlcm5hbWUiOiJlbWlseXMiLCJlbWFpbCI6ImVtaWx5LmpvaG5zb25AeC5kdW1teWpzb24uY29tIiwiZmlyc3ROYW1lIjoiRW1pbHkiLCJsYXN0TmFtZSI6IkpvaG5zb24iLCJnZW5kZXIiOiJmZW1hbGUiLCJpbWFnZSI6Imh0dHBzOi8vZHVtbXlqc29uLmNvbS9pY29uL2VtaWx5cy8xMjgiLCJpYXQiOjE3NzEzOTYyMzAsImV4cCI6MTc3Mzk4ODIzMH0.eA8ILrYJnJ8TO8JbmLrUYjMsLwYElFsBTU054JUu8-w"
+  },
+  "created_at": "2026-02-18T06:30:30.141020+00:00",
+  "elapsed": 0.448449,
+  "encoding": "utf-8",
+  "headers": {
+    "CF-RAY": "9cfb79e65ff8349c-ATL",
+    "Connection": "keep-alive",
+    "Content-Encoding": "zstd",
+    "Content-Type": "application/json; charset=utf-8",
+    "Date": "Wed, 18 Feb 2026 06:30:30 GMT",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=sUE%2Bg6VfGFs37dwC3pt75SO%2FnpPEp8vf30HbeLbDa0OYtaGgoya2XyXZkNUEBBCRbO28mOLI%2BqRJAVOI56dQr8AJ618HRZEcA6tV8mY%3D\"}]}",
+    "Server": "cloudflare",
+    "Set-Cookie": "accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwidXNlcm5hbWUiOiJlbWlseXMiLCJlbWFpbCI6ImVtaWx5LmpvaG5zb25AeC5kdW1teWpzb24uY29tIiwiZmlyc3ROYW1lIjoiRW1pbHkiLCJsYXN0TmFtZSI6IkpvaG5zb24iLCJnZW5kZXIiOiJmZW1hbGUiLCJpbWFnZSI6Imh0dHBzOi8vZHVtbXlqc29uLmNvbS9pY29uL2VtaWx5cy8xMjgiLCJpYXQiOjE3NzEzOTYyMzAsImV4cCI6MTc3MTM5ODAzMH0.PsP4SnDBPSZ7r2MIwCfHLJiI17pcUQOdrcTR22q98iI; Max-Age=1800; Path=/; Expires=Wed, 18 Feb 2026 07:00:30 GMT; HttpOnly; Secure, refreshToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwidXNlcm5hbWUiOiJlbWlseXMiLCJlbWFpbCI6ImVtaWx5LmpvaG5zb25AeC5kdW1teWpzb24uY29tIiwiZmlyc3ROYW1lIjoiRW1pbHkiLCJsYXN0TmFtZSI6IkpvaG5zb24iLCJnZW5kZXIiOiJmZW1hbGUiLCJpbWFnZSI6Imh0dHBzOi8vZHVtbXlqc29uLmNvbS9pY29uL2VtaWx5cy8xMjgiLCJpYXQiOjE3NzEzOTYyMzAsImV4cCI6MTc3Mzk4ODIzMH0.eA8ILrYJnJ8TO8JbmLrUYjMsLwYElFsBTU054JUu8-w; Max-Age=1800; Path=/; Expires=Wed, 18 Feb 2026 07:00:30 GMT; HttpOnly; Secure",
+    "Transfer-Encoding": "chunked",
+    "access-control-allow-origin": "*",
+    "cf-cache-status": "DYNAMIC",
+    "etag": "W/\"3a2-a+nG+t8gMy4+C/FaKY0+KC0Cekw\"",
+    "strict-transport-security": "max-age=15552000; includeSubDomains",
+    "vary": "Accept-Encoding",
+    "x-content-type-options": "nosniff",
+    "x-dns-prefetch-control": "off",
+    "x-download-options": "noopen",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ratelimit-limit": "100",
+    "x-ratelimit-remaining": "99",
+    "x-ratelimit-reset": "1771396234",
+    "x-xss-protection": "1; mode=block"
+  },
+  "reason": "OK",
+  "request": {
+    "body": "eyJleHBpcmVzSW5NaW5zIjogMzAsICJwYXNzd29yZCI6ICJlbWlseXNwYXNzIiwgInVzZXJuYW1lIjogImVtaWx5cyJ9",
+    "headers": {
+      "Accept": "*/*",
+      "Accept-Encoding": "gzip, deflate, zstd",
+      "Connection": "keep-alive",
+      "Content-Length": "69",
+      "Content-Type": "application/json",
+      "User-Agent": "python-requests/2.32.5"
+    },
+    "method": "POST",
+    "url": "https://dummyjson.com/auth/login"
+  },
+  "status_code": 200,
+  "url": "https://dummyjson.com/auth/login",
+  "_decoded_content": {
+    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwidXNlcm5hbWUiOiJlbWlseXMiLCJlbWFpbCI6ImVtaWx5LmpvaG5zb25AeC5kdW1teWpzb24uY29tIiwiZmlyc3ROYW1lIjoiRW1pbHkiLCJsYXN0TmFtZSI6IkpvaG5zb24iLCJnZW5kZXIiOiJmZW1hbGUiLCJpbWFnZSI6Imh0dHBzOi8vZHVtbXlqc29uLmNvbS9pY29uL2VtaWx5cy8xMjgiLCJpYXQiOjE3NzEzOTYyMzAsImV4cCI6MTc3MTM5ODAzMH0.PsP4SnDBPSZ7r2MIwCfHLJiI17pcUQOdrcTR22q98iI",
+    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwidXNlcm5hbWUiOiJlbWlseXMiLCJlbWFpbCI6ImVtaWx5LmpvaG5zb25AeC5kdW1teWpzb24uY29tIiwiZmlyc3ROYW1lIjoiRW1pbHkiLCJsYXN0TmFtZSI6IkpvaG5zb24iLCJnZW5kZXIiOiJmZW1hbGUiLCJpbWFnZSI6Imh0dHBzOi8vZHVtbXlqc29uLmNvbS9pY29uL2VtaWx5cy8xMjgiLCJpYXQiOjE3NzEzOTYyMzAsImV4cCI6MTc3Mzk4ODIzMH0.eA8ILrYJnJ8TO8JbmLrUYjMsLwYElFsBTU054JUu8-w",
+    "id": 1,
+    "username": "emilys",
+    "email": "emily.johnson@x.dummyjson.com",
+    "firstName": "Emily",
+    "lastName": "Johnson",
+    "gender": "female",
+    "image": "https://dummyjson.com/icon/emilys/128"
+  }
+}

--- a/.http_cache/72eb41476f0b2352.json
+++ b/.http_cache/72eb41476f0b2352.json
@@ -1,0 +1,1522 @@
+{
+  "created_at": "2026-02-18T06:37:09.300705+00:00",
+  "elapsed": 2.384607,
+  "encoding": "utf-8",
+  "headers": {
+    "CF-RAY": "9cfb83a478b024cb-ATL",
+    "Connection": "keep-alive",
+    "Content-Encoding": "zstd",
+    "Content-Type": "application/json; charset=utf-8",
+    "Date": "Wed, 18 Feb 2026 06:37:09 GMT",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=EUFkN2FmJJEPaTre%2BE2LfQsSHfA%2BGQ8uVpDCXaDnjIGkz6HmsoOVXJ0WJCZeDlHz0ovboD5P%2BA%2B48%2FaPTnwt9ji7bfSgxBw8tpAmMvc%3D\"}]}",
+    "Server": "cloudflare",
+    "Transfer-Encoding": "chunked",
+    "access-control-allow-origin": "*",
+    "cf-cache-status": "DYNAMIC",
+    "etag": "W/\"8a1d-wUlPWJTx2XItcLJW7OssPjIvkw0\"",
+    "strict-transport-security": "max-age=15552000; includeSubDomains",
+    "vary": "Accept-Encoding",
+    "x-content-type-options": "nosniff",
+    "x-dns-prefetch-control": "off",
+    "x-download-options": "noopen",
+    "x-frame-options": "SAMEORIGIN",
+    "x-ratelimit-limit": "100",
+    "x-ratelimit-remaining": "99",
+    "x-ratelimit-reset": "1771396634",
+    "x-xss-protection": "1; mode=block"
+  },
+  "reason": "OK",
+  "request": {
+    "body": null,
+    "headers": {
+      "Accept": "*/*",
+      "Accept-Encoding": "gzip, deflate, zstd",
+      "Authorization": "REDACTED",
+      "Connection": "keep-alive",
+      "User-Agent": "tap-dummyjson/0.0.0"
+    },
+    "method": "GET",
+    "url": "https://dummyjson.com/products?limit=25&skip=25"
+  },
+  "status_code": 200,
+  "url": "https://dummyjson.com/products?limit=25&skip=25",
+  "_decoded_content": {
+    "products": [
+      {
+        "id": 26,
+        "title": "Green Chili Pepper",
+        "description": "Spicy green chili pepper, ideal for adding heat to your favorite recipes.",
+        "category": "groceries",
+        "price": 0.99,
+        "discountPercentage": 1,
+        "rating": 3.66,
+        "stock": 3,
+        "tags": [
+          "vegetables"
+        ],
+        "sku": "GRO-BRD-GRE-026",
+        "weight": 7,
+        "dimensions": {
+          "width": 15.38,
+          "height": 18.12,
+          "depth": 19.92
+        },
+        "warrantyInformation": "2 year warranty",
+        "shippingInformation": "Ships in 1 week",
+        "availabilityStatus": "Low Stock",
+        "reviews": [
+          {
+            "rating": 4,
+            "comment": "Great product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Luna Russell",
+            "reviewerEmail": "luna.russell@x.dummyjson.com"
+          },
+          {
+            "rating": 1,
+            "comment": "Waste of money!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Noah Lewis",
+            "reviewerEmail": "noah.lewis@x.dummyjson.com"
+          },
+          {
+            "rating": 3,
+            "comment": "Very disappointed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Clara Berry",
+            "reviewerEmail": "clara.berry@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "30 days return policy",
+        "minimumOrderQuantity": 39,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "9335000538563",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/green-chili-pepper/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/green-chili-pepper/thumbnail.webp"
+      },
+      {
+        "id": 27,
+        "title": "Honey Jar",
+        "description": "Pure and natural honey in a convenient jar, perfect for sweetening beverages or drizzling over food.",
+        "category": "groceries",
+        "price": 6.99,
+        "discountPercentage": 14.4,
+        "rating": 3.97,
+        "stock": 34,
+        "tags": [
+          "condiments"
+        ],
+        "sku": "GRO-BRD-HON-027",
+        "weight": 2,
+        "dimensions": {
+          "width": 9.28,
+          "height": 21.72,
+          "depth": 17.74
+        },
+        "warrantyInformation": "1 month warranty",
+        "shippingInformation": "Ships in 1-2 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 1,
+            "comment": "Very disappointed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Autumn Gomez",
+            "reviewerEmail": "autumn.gomez@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Highly impressed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Benjamin Wilson",
+            "reviewerEmail": "benjamin.wilson@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Very disappointed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Nicholas Edwards",
+            "reviewerEmail": "nicholas.edwards@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "90 days return policy",
+        "minimumOrderQuantity": 47,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "6354306346329",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/honey-jar/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/honey-jar/thumbnail.webp"
+      },
+      {
+        "id": 28,
+        "title": "Ice Cream",
+        "description": "Creamy and delicious ice cream, available in various flavors for a delightful treat.",
+        "category": "groceries",
+        "price": 5.49,
+        "discountPercentage": 8.69,
+        "rating": 3.39,
+        "stock": 27,
+        "tags": [
+          "desserts"
+        ],
+        "sku": "GRO-BRD-CRE-028",
+        "weight": 1,
+        "dimensions": {
+          "width": 14.83,
+          "height": 15.07,
+          "depth": 24.2
+        },
+        "warrantyInformation": "1 month warranty",
+        "shippingInformation": "Ships in 2 weeks",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Very pleased!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Elijah Cruz",
+            "reviewerEmail": "elijah.cruz@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Excellent quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Jace Smith",
+            "reviewerEmail": "jace.smith@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Highly impressed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Sadie Morales",
+            "reviewerEmail": "sadie.morales@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 42,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "0788954559076",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/ice-cream/1.webp",
+          "https://cdn.dummyjson.com/product-images/groceries/ice-cream/2.webp",
+          "https://cdn.dummyjson.com/product-images/groceries/ice-cream/3.webp",
+          "https://cdn.dummyjson.com/product-images/groceries/ice-cream/4.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/ice-cream/thumbnail.webp"
+      },
+      {
+        "id": 29,
+        "title": "Juice",
+        "description": "Refreshing fruit juice, packed with vitamins and great for staying hydrated.",
+        "category": "groceries",
+        "price": 3.99,
+        "discountPercentage": 12.06,
+        "rating": 3.94,
+        "stock": 50,
+        "tags": [
+          "beverages"
+        ],
+        "sku": "GRO-BRD-JUI-029",
+        "weight": 1,
+        "dimensions": {
+          "width": 18.56,
+          "height": 21.46,
+          "depth": 28.02
+        },
+        "warrantyInformation": "6 months warranty",
+        "shippingInformation": "Ships in 1 week",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Excellent quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Nolan Gonzalez",
+            "reviewerEmail": "nolan.gonzalez@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Would buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Bella Grant",
+            "reviewerEmail": "bella.grant@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Awesome product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Aria Flores",
+            "reviewerEmail": "aria.flores@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 25,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "6936112580956",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/juice/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/juice/thumbnail.webp"
+      },
+      {
+        "id": 30,
+        "title": "Kiwi",
+        "description": "Nutrient-rich kiwi, perfect for snacking or adding a tropical twist to your dishes.",
+        "category": "groceries",
+        "price": 2.49,
+        "discountPercentage": 15.22,
+        "rating": 4.93,
+        "stock": 99,
+        "tags": [
+          "fruits"
+        ],
+        "sku": "GRO-BRD-KIW-030",
+        "weight": 5,
+        "dimensions": {
+          "width": 19.4,
+          "height": 18.67,
+          "depth": 17.13
+        },
+        "warrantyInformation": "6 months warranty",
+        "shippingInformation": "Ships overnight",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 4,
+            "comment": "Highly recommended!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Emily Brown",
+            "reviewerEmail": "emily.brown@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Would not buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Jackson Morales",
+            "reviewerEmail": "jackson.morales@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Fast shipping!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Nora Russell",
+            "reviewerEmail": "nora.russell@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 30,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "2530169917252",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/kiwi/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/kiwi/thumbnail.webp"
+      },
+      {
+        "id": 31,
+        "title": "Lemon",
+        "description": "Zesty and tangy lemons, versatile for cooking, baking, or making refreshing beverages.",
+        "category": "groceries",
+        "price": 0.79,
+        "discountPercentage": 9.7,
+        "rating": 3.53,
+        "stock": 31,
+        "tags": [
+          "fruits"
+        ],
+        "sku": "GRO-BRD-LEM-031",
+        "weight": 3,
+        "dimensions": {
+          "width": 23.77,
+          "height": 9.22,
+          "depth": 12.05
+        },
+        "warrantyInformation": "No warranty",
+        "shippingInformation": "Ships in 1 month",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Awesome product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Logan Lawson",
+            "reviewerEmail": "logan.lawson@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Highly impressed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Avery Perez",
+            "reviewerEmail": "avery.perez@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Very satisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Benjamin Foster",
+            "reviewerEmail": "benjamin.foster@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 29,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "4871812433378",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/lemon/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/lemon/thumbnail.webp"
+      },
+      {
+        "id": 32,
+        "title": "Milk",
+        "description": "Fresh and nutritious milk, a staple for various recipes and daily consumption.",
+        "category": "groceries",
+        "price": 3.49,
+        "discountPercentage": 13.74,
+        "rating": 2.61,
+        "stock": 27,
+        "tags": [
+          "dairy"
+        ],
+        "sku": "GRO-BRD-MIL-032",
+        "weight": 5,
+        "dimensions": {
+          "width": 12.92,
+          "height": 15.76,
+          "depth": 11.29
+        },
+        "warrantyInformation": "3 year warranty",
+        "shippingInformation": "Ships in 2 weeks",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 4,
+            "comment": "Very satisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Nicholas Bailey",
+            "reviewerEmail": "nicholas.bailey@x.dummyjson.com"
+          },
+          {
+            "rating": 3,
+            "comment": "Would not buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Harper Turner",
+            "reviewerEmail": "harper.turner@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Great value for money!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Autumn Gomez",
+            "reviewerEmail": "autumn.gomez@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 5,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "9835034508303",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/milk/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/milk/thumbnail.webp"
+      },
+      {
+        "id": 33,
+        "title": "Mulberry",
+        "description": "Sweet and juicy mulberries, perfect for snacking or adding to desserts and cereals.",
+        "category": "groceries",
+        "price": 4.99,
+        "discountPercentage": 12.87,
+        "rating": 4.95,
+        "stock": 99,
+        "tags": [
+          "fruits"
+        ],
+        "sku": "GRO-BRD-MUL-033",
+        "weight": 5,
+        "dimensions": {
+          "width": 12.8,
+          "height": 18.54,
+          "depth": 6.31
+        },
+        "warrantyInformation": "2 year warranty",
+        "shippingInformation": "Ships in 1 week",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Fast shipping!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Avery Barnes",
+            "reviewerEmail": "avery.barnes@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Not worth the price!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Sadie Morales",
+            "reviewerEmail": "sadie.morales@x.dummyjson.com"
+          },
+          {
+            "rating": 1,
+            "comment": "Would not buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Oscar Powers",
+            "reviewerEmail": "oscar.powers@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 43,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "2206629068605",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/mulberry/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/mulberry/thumbnail.webp"
+      },
+      {
+        "id": 34,
+        "title": "Nescafe Coffee",
+        "description": "Quality coffee from Nescafe, available in various blends for a rich and satisfying cup.",
+        "category": "groceries",
+        "price": 7.99,
+        "discountPercentage": 1.59,
+        "rating": 4.82,
+        "stock": 57,
+        "tags": [
+          "beverages",
+          "coffee"
+        ],
+        "sku": "GRO-BRD-NES-034",
+        "weight": 6,
+        "dimensions": {
+          "width": 20.54,
+          "height": 29.49,
+          "depth": 29.2
+        },
+        "warrantyInformation": "1 year warranty",
+        "shippingInformation": "Ships in 1-2 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Very pleased!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Gabriel Adams",
+            "reviewerEmail": "gabriel.adams@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Highly recommended!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Ella Cook",
+            "reviewerEmail": "ella.cook@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Would buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Logan Torres",
+            "reviewerEmail": "logan.torres@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "30 days return policy",
+        "minimumOrderQuantity": 8,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "8572637994159",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/nescafe-coffee/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/nescafe-coffee/thumbnail.webp"
+      },
+      {
+        "id": 35,
+        "title": "Potatoes",
+        "description": "Versatile and starchy potatoes, great for roasting, mashing, or as a side dish.",
+        "category": "groceries",
+        "price": 2.29,
+        "discountPercentage": 5.38,
+        "rating": 4.81,
+        "stock": 13,
+        "tags": [
+          "vegetables"
+        ],
+        "sku": "GRO-BRD-POT-035",
+        "weight": 9,
+        "dimensions": {
+          "width": 22.65,
+          "height": 9.83,
+          "depth": 21.75
+        },
+        "warrantyInformation": "3 year warranty",
+        "shippingInformation": "Ships in 3-5 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Highly impressed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Eleanor Collins",
+            "reviewerEmail": "eleanor.collins@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Fast shipping!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Lily Torres",
+            "reviewerEmail": "lily.torres@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Highly recommended!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Ariana Ross",
+            "reviewerEmail": "ariana.ross@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "90 days return policy",
+        "minimumOrderQuantity": 9,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "3590399655074",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/potatoes/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/potatoes/thumbnail.webp"
+      },
+      {
+        "id": 36,
+        "title": "Protein Powder",
+        "description": "Nutrient-packed protein powder, ideal for supplementing your diet with essential proteins.",
+        "category": "groceries",
+        "price": 19.99,
+        "discountPercentage": 7.59,
+        "rating": 4.18,
+        "stock": 80,
+        "tags": [
+          "health supplements"
+        ],
+        "sku": "GRO-BRD-PRO-036",
+        "weight": 9,
+        "dimensions": {
+          "width": 9.01,
+          "height": 12.53,
+          "depth": 22.35
+        },
+        "warrantyInformation": "1 week warranty",
+        "shippingInformation": "Ships in 1 month",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 3,
+            "comment": "Very unhappy with my purchase!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Aurora Rodriguez",
+            "reviewerEmail": "aurora.rodriguez@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Would buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Miles Stevenson",
+            "reviewerEmail": "miles.stevenson@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Very happy with my purchase!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Clara Berry",
+            "reviewerEmail": "clara.berry@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 6,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "0435397154434",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/protein-powder/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/protein-powder/thumbnail.webp"
+      },
+      {
+        "id": 37,
+        "title": "Red Onions",
+        "description": "Flavorful and aromatic red onions, perfect for adding depth to your savory dishes.",
+        "category": "groceries",
+        "price": 1.99,
+        "discountPercentage": 9.9,
+        "rating": 4.2,
+        "stock": 82,
+        "tags": [
+          "vegetables"
+        ],
+        "sku": "GRO-BRD-ONI-037",
+        "weight": 9,
+        "dimensions": {
+          "width": 16.01,
+          "height": 24.96,
+          "depth": 12.74
+        },
+        "warrantyInformation": "1 month warranty",
+        "shippingInformation": "Ships in 3-5 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 4,
+            "comment": "Fast shipping!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Maya Reed",
+            "reviewerEmail": "maya.reed@x.dummyjson.com"
+          },
+          {
+            "rating": 3,
+            "comment": "Very dissatisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Evelyn Gonzalez",
+            "reviewerEmail": "evelyn.gonzalez@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Awesome product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Jackson Evans",
+            "reviewerEmail": "jackson.evans@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 8,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "4716374115631",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/red-onions/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/red-onions/thumbnail.webp"
+      },
+      {
+        "id": 38,
+        "title": "Rice",
+        "description": "High-quality rice, a staple for various cuisines and a versatile base for many dishes.",
+        "category": "groceries",
+        "price": 5.99,
+        "discountPercentage": 9.29,
+        "rating": 3.18,
+        "stock": 59,
+        "tags": [
+          "grains"
+        ],
+        "sku": "GRO-BRD-RIC-038",
+        "weight": 5,
+        "dimensions": {
+          "width": 17.21,
+          "height": 9.88,
+          "depth": 17.16
+        },
+        "warrantyInformation": "6 months warranty",
+        "shippingInformation": "Ships overnight",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Would buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Sophia Brown",
+            "reviewerEmail": "sophia.brown@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Very satisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Grace Perry",
+            "reviewerEmail": "grace.perry@x.dummyjson.com"
+          },
+          {
+            "rating": 1,
+            "comment": "Very disappointed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Cameron Burke",
+            "reviewerEmail": "cameron.burke@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 20,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "7339757397015",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/rice/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/rice/thumbnail.webp"
+      },
+      {
+        "id": 39,
+        "title": "Soft Drinks",
+        "description": "Assorted soft drinks in various flavors, perfect for refreshing beverages.",
+        "category": "groceries",
+        "price": 1.99,
+        "discountPercentage": 17.48,
+        "rating": 4.75,
+        "stock": 53,
+        "tags": [
+          "beverages"
+        ],
+        "sku": "GRO-BRD-SOF-039",
+        "weight": 9,
+        "dimensions": {
+          "width": 19.75,
+          "height": 6.79,
+          "depth": 9.33
+        },
+        "warrantyInformation": "6 months warranty",
+        "shippingInformation": "Ships in 2 weeks",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 2,
+            "comment": "Would not recommend!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Zachary Lee",
+            "reviewerEmail": "zachary.lee@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Would not recommend!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Oscar Powers",
+            "reviewerEmail": "oscar.powers@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Highly recommended!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Hannah Robinson",
+            "reviewerEmail": "hannah.robinson@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 10,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "2991169581178",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/soft-drinks/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/soft-drinks/thumbnail.webp"
+      },
+      {
+        "id": 40,
+        "title": "Strawberry",
+        "description": "Sweet and succulent strawberries, great for snacking, desserts, or blending into smoothies.",
+        "category": "groceries",
+        "price": 3.99,
+        "discountPercentage": 1.12,
+        "rating": 3.08,
+        "stock": 46,
+        "tags": [
+          "fruits"
+        ],
+        "sku": "GRO-BRD-STR-040",
+        "weight": 1,
+        "dimensions": {
+          "width": 28.18,
+          "height": 21.25,
+          "depth": 28.54
+        },
+        "warrantyInformation": "1 week warranty",
+        "shippingInformation": "Ships in 1-2 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 3,
+            "comment": "Would not buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Amelia Perez",
+            "reviewerEmail": "amelia.perez@x.dummyjson.com"
+          },
+          {
+            "rating": 3,
+            "comment": "Would not buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Olivia Wilson",
+            "reviewerEmail": "olivia.wilson@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Would buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Hunter Gordon",
+            "reviewerEmail": "hunter.gordon@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 12,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "0792647462295",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/strawberry/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/strawberry/thumbnail.webp"
+      },
+      {
+        "id": 41,
+        "title": "Tissue Paper Box",
+        "description": "Convenient tissue paper box for everyday use, providing soft and absorbent tissues.",
+        "category": "groceries",
+        "price": 2.49,
+        "discountPercentage": 13.28,
+        "rating": 2.69,
+        "stock": 86,
+        "tags": [
+          "household essentials"
+        ],
+        "sku": "GRO-BRD-TIS-041",
+        "weight": 1,
+        "dimensions": {
+          "width": 18.75,
+          "height": 17.58,
+          "depth": 12.43
+        },
+        "warrantyInformation": "No warranty",
+        "shippingInformation": "Ships in 1-2 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 1,
+            "comment": "Not as described!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Ariana Ross",
+            "reviewerEmail": "ariana.ross@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Fast shipping!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Carter Baker",
+            "reviewerEmail": "carter.baker@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Great value for money!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Penelope Harper",
+            "reviewerEmail": "penelope.harper@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "90 days return policy",
+        "minimumOrderQuantity": 44,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "9446468291745",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/tissue-paper-box/1.webp",
+          "https://cdn.dummyjson.com/product-images/groceries/tissue-paper-box/2.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/tissue-paper-box/thumbnail.webp"
+      },
+      {
+        "id": 42,
+        "title": "Water",
+        "description": "Pure and refreshing bottled water, essential for staying hydrated throughout the day.",
+        "category": "groceries",
+        "price": 0.99,
+        "discountPercentage": 14.92,
+        "rating": 4.96,
+        "stock": 53,
+        "tags": [
+          "beverages"
+        ],
+        "sku": "GRO-BRD-WAT-042",
+        "weight": 4,
+        "dimensions": {
+          "width": 18.43,
+          "height": 7.4,
+          "depth": 17.79
+        },
+        "warrantyInformation": "3 months warranty",
+        "shippingInformation": "Ships in 1 month",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Highly impressed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Jonathan Pierce",
+            "reviewerEmail": "jonathan.pierce@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Would not recommend!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Grayson Coleman",
+            "reviewerEmail": "grayson.coleman@x.dummyjson.com"
+          },
+          {
+            "rating": 3,
+            "comment": "Not as described!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Ethan Fletcher",
+            "reviewerEmail": "ethan.fletcher@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "7 days return policy",
+        "minimumOrderQuantity": 28,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "2409829645213",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/groceries/water/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/groceries/water/thumbnail.webp"
+      },
+      {
+        "id": 43,
+        "title": "Decoration Swing",
+        "description": "The Decoration Swing is a charming addition to your home decor. Crafted with intricate details, it adds a touch of elegance and whimsy to any room.",
+        "category": "home-decoration",
+        "price": 59.99,
+        "discountPercentage": 10.41,
+        "rating": 3.16,
+        "stock": 47,
+        "tags": [
+          "home decor",
+          "swing"
+        ],
+        "sku": "HOM-BRD-DEC-043",
+        "weight": 4,
+        "dimensions": {
+          "width": 23.84,
+          "height": 15.19,
+          "depth": 26.05
+        },
+        "warrantyInformation": "1 week warranty",
+        "shippingInformation": "Ships in 1 month",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 1,
+            "comment": "Would not buy again!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Daniel Cook",
+            "reviewerEmail": "daniel.cook@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Poor quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Hunter Gordon",
+            "reviewerEmail": "hunter.gordon@x.dummyjson.com"
+          },
+          {
+            "rating": 3,
+            "comment": "Very unhappy with my purchase!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Stella Morris",
+            "reviewerEmail": "stella.morris@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "90 days return policy",
+        "minimumOrderQuantity": 8,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "9646971048759",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/home-decoration/decoration-swing/1.webp",
+          "https://cdn.dummyjson.com/product-images/home-decoration/decoration-swing/2.webp",
+          "https://cdn.dummyjson.com/product-images/home-decoration/decoration-swing/3.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/home-decoration/decoration-swing/thumbnail.webp"
+      },
+      {
+        "id": 44,
+        "title": "Family Tree Photo Frame",
+        "description": "The Family Tree Photo Frame is a sentimental and stylish way to display your cherished family memories. With multiple photo slots, it tells the story of your loved ones.",
+        "category": "home-decoration",
+        "price": 29.99,
+        "discountPercentage": 14.87,
+        "rating": 4.53,
+        "stock": 77,
+        "tags": [
+          "home decor",
+          "photo frame"
+        ],
+        "sku": "HOM-BRD-FAM-044",
+        "weight": 1,
+        "dimensions": {
+          "width": 17.27,
+          "height": 14.81,
+          "depth": 29.11
+        },
+        "warrantyInformation": "1 month warranty",
+        "shippingInformation": "Ships in 2 weeks",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 4,
+            "comment": "Highly impressed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Oscar Powers",
+            "reviewerEmail": "oscar.powers@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Excellent quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Austin Hudson",
+            "reviewerEmail": "austin.hudson@x.dummyjson.com"
+          },
+          {
+            "rating": 2,
+            "comment": "Very dissatisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Luke Cooper",
+            "reviewerEmail": "luke.cooper@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 15,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "5398738320864",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/home-decoration/family-tree-photo-frame/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/home-decoration/family-tree-photo-frame/thumbnail.webp"
+      },
+      {
+        "id": 45,
+        "title": "House Showpiece Plant",
+        "description": "The House Showpiece Plant is an artificial plant that brings a touch of nature to your home without the need for maintenance. It adds greenery and style to any space.",
+        "category": "home-decoration",
+        "price": 39.99,
+        "discountPercentage": 7.46,
+        "rating": 4.67,
+        "stock": 28,
+        "tags": [
+          "home decor",
+          "artificial plants"
+        ],
+        "sku": "HOM-BRD-HOU-045",
+        "weight": 8,
+        "dimensions": {
+          "width": 8.55,
+          "height": 14.62,
+          "depth": 17.25
+        },
+        "warrantyInformation": "1 year warranty",
+        "shippingInformation": "Ships in 1 week",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Very happy with my purchase!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Natalie Harris",
+            "reviewerEmail": "natalie.harris@x.dummyjson.com"
+          },
+          {
+            "rating": 1,
+            "comment": "Poor quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Max Russell",
+            "reviewerEmail": "max.russell@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Very pleased!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Nolan Gonzalez",
+            "reviewerEmail": "nolan.gonzalez@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "No return policy",
+        "minimumOrderQuantity": 3,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "8433795204995",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/home-decoration/house-showpiece-plant/1.webp",
+          "https://cdn.dummyjson.com/product-images/home-decoration/house-showpiece-plant/2.webp",
+          "https://cdn.dummyjson.com/product-images/home-decoration/house-showpiece-plant/3.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/home-decoration/house-showpiece-plant/thumbnail.webp"
+      },
+      {
+        "id": 46,
+        "title": "Plant Pot",
+        "description": "The Plant Pot is a stylish container for your favorite plants. With a sleek design, it complements your indoor or outdoor garden, adding a modern touch to your plant display.",
+        "category": "home-decoration",
+        "price": 14.99,
+        "discountPercentage": 6.84,
+        "rating": 3.01,
+        "stock": 59,
+        "tags": [
+          "home decor",
+          "plant accessories"
+        ],
+        "sku": "HOM-BRD-PLA-046",
+        "weight": 9,
+        "dimensions": {
+          "width": 9.83,
+          "height": 20.28,
+          "depth": 13.49
+        },
+        "warrantyInformation": "Lifetime warranty",
+        "shippingInformation": "Ships in 3-5 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 4,
+            "comment": "Fast shipping!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Vivian Carter",
+            "reviewerEmail": "vivian.carter@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Very satisfied!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Ella Adams",
+            "reviewerEmail": "ella.adams@x.dummyjson.com"
+          },
+          {
+            "rating": 3,
+            "comment": "Poor quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Liam Smith",
+            "reviewerEmail": "liam.smith@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "30 days return policy",
+        "minimumOrderQuantity": 31,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "8477070578398",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/home-decoration/plant-pot/1.webp",
+          "https://cdn.dummyjson.com/product-images/home-decoration/plant-pot/2.webp",
+          "https://cdn.dummyjson.com/product-images/home-decoration/plant-pot/3.webp",
+          "https://cdn.dummyjson.com/product-images/home-decoration/plant-pot/4.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/home-decoration/plant-pot/thumbnail.webp"
+      },
+      {
+        "id": 47,
+        "title": "Table Lamp",
+        "description": "The Table Lamp is a functional and decorative lighting solution for your living space. With a modern design, it provides both ambient and task lighting, enhancing the atmosphere.",
+        "category": "home-decoration",
+        "price": 49.99,
+        "discountPercentage": 7.09,
+        "rating": 3.55,
+        "stock": 9,
+        "tags": [
+          "home decor",
+          "lighting"
+        ],
+        "sku": "HOM-BRD-TAB-047",
+        "weight": 4,
+        "dimensions": {
+          "width": 8.98,
+          "height": 13.41,
+          "depth": 5.65
+        },
+        "warrantyInformation": "3 months warranty",
+        "shippingInformation": "Ships in 1-2 business days",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Excellent quality!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Benjamin Foster",
+            "reviewerEmail": "benjamin.foster@x.dummyjson.com"
+          },
+          {
+            "rating": 3,
+            "comment": "Would not recommend!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Sophia Jones",
+            "reviewerEmail": "sophia.jones@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Awesome product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Natalie Harris",
+            "reviewerEmail": "natalie.harris@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "90 days return policy",
+        "minimumOrderQuantity": 2,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "8806138916048",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/home-decoration/table-lamp/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/home-decoration/table-lamp/thumbnail.webp"
+      },
+      {
+        "id": 48,
+        "title": "Bamboo Spatula",
+        "description": "The Bamboo Spatula is a versatile kitchen tool made from eco-friendly bamboo. Ideal for flipping, stirring, and serving various dishes.",
+        "category": "kitchen-accessories",
+        "price": 7.99,
+        "discountPercentage": 2.84,
+        "rating": 3.27,
+        "stock": 37,
+        "tags": [
+          "kitchen tools",
+          "utensils"
+        ],
+        "sku": "KIT-BRD-BAM-048",
+        "weight": 3,
+        "dimensions": {
+          "width": 21.32,
+          "height": 23.03,
+          "depth": 25.94
+        },
+        "warrantyInformation": "1 month warranty",
+        "shippingInformation": "Ships overnight",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 5,
+            "comment": "Awesome product!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Lucas Ramirez",
+            "reviewerEmail": "lucas.ramirez@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Highly recommended!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Caleb Perkins",
+            "reviewerEmail": "caleb.perkins@x.dummyjson.com"
+          },
+          {
+            "rating": 4,
+            "comment": "Highly recommended!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Nolan Gonzalez",
+            "reviewerEmail": "nolan.gonzalez@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "60 days return policy",
+        "minimumOrderQuantity": 29,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "3988181417733",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/bamboo-spatula/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/bamboo-spatula/thumbnail.webp"
+      },
+      {
+        "id": 49,
+        "title": "Black Aluminium Cup",
+        "description": "The Black Aluminium Cup is a stylish and durable cup suitable for both hot and cold beverages. Its sleek black design adds a modern touch to your drinkware collection.",
+        "category": "kitchen-accessories",
+        "price": 5.99,
+        "discountPercentage": 15.65,
+        "rating": 4.46,
+        "stock": 75,
+        "tags": [
+          "drinkware",
+          "cups"
+        ],
+        "sku": "KIT-BRD-BLA-049",
+        "weight": 7,
+        "dimensions": {
+          "width": 5.88,
+          "height": 5.11,
+          "depth": 10.03
+        },
+        "warrantyInformation": "1 year warranty",
+        "shippingInformation": "Ships overnight",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 3,
+            "comment": "Very disappointed!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Alexander Hernandez",
+            "reviewerEmail": "alexander.hernandez@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Great value for money!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Aurora Rodriguez",
+            "reviewerEmail": "aurora.rodriguez@x.dummyjson.com"
+          },
+          {
+            "rating": 1,
+            "comment": "Not worth the price!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Benjamin Foster",
+            "reviewerEmail": "benjamin.foster@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "30 days return policy",
+        "minimumOrderQuantity": 48,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "5606164195748",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/black-aluminium-cup/1.webp",
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/black-aluminium-cup/2.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/black-aluminium-cup/thumbnail.webp"
+      },
+      {
+        "id": 50,
+        "title": "Black Whisk",
+        "description": "The Black Whisk is a kitchen essential for whisking and beating ingredients. Its ergonomic handle and sleek design make it a practical and stylish tool.",
+        "category": "kitchen-accessories",
+        "price": 9.99,
+        "discountPercentage": 10.24,
+        "rating": 3.9,
+        "stock": 73,
+        "tags": [
+          "kitchen tools",
+          "utensils"
+        ],
+        "sku": "KIT-BRD-BLA-050",
+        "weight": 1,
+        "dimensions": {
+          "width": 13.03,
+          "height": 5.99,
+          "depth": 20.64
+        },
+        "warrantyInformation": "3 months warranty",
+        "shippingInformation": "Ships in 1 month",
+        "availabilityStatus": "In Stock",
+        "reviews": [
+          {
+            "rating": 3,
+            "comment": "Not worth the price!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Cameron Perez",
+            "reviewerEmail": "cameron.perez@x.dummyjson.com"
+          },
+          {
+            "rating": 1,
+            "comment": "Waste of money!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Benjamin Foster",
+            "reviewerEmail": "benjamin.foster@x.dummyjson.com"
+          },
+          {
+            "rating": 5,
+            "comment": "Very pleased!",
+            "date": "2025-04-30T09:41:02.053Z",
+            "reviewerName": "Paisley Bell",
+            "reviewerEmail": "paisley.bell@x.dummyjson.com"
+          }
+        ],
+        "returnPolicy": "30 days return policy",
+        "minimumOrderQuantity": 40,
+        "meta": {
+          "createdAt": "2025-04-30T09:41:02.053Z",
+          "updatedAt": "2025-04-30T09:41:02.053Z",
+          "barcode": "3112495795209",
+          "qrCode": "https://cdn.dummyjson.com/public/qr-code.png"
+        },
+        "images": [
+          "https://cdn.dummyjson.com/product-images/kitchen-accessories/black-whisk/1.webp"
+        ],
+        "thumbnail": "https://cdn.dummyjson.com/product-images/kitchen-accessories/black-whisk/thumbnail.webp"
+      }
+    ],
+    "total": 194,
+    "skip": 25,
+    "limit": 25
+  }
+}

--- a/packages/meltano-tap-dummyjson/tap_dummyjson/auth.py
+++ b/packages/meltano-tap-dummyjson/tap_dummyjson/auth.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+AUTH_TIMEOUT_SECONDS = 5
 EXPIRES_IN_MINS = 30
 
 
@@ -85,7 +86,7 @@ class DummyJSONAuthenticator(requests.auth.AuthBase, metaclass=SingletonMeta):
                         "password": self.password,
                         "expiresInMins": EXPIRES_IN_MINS,
                     },
-                    timeout=0.1,
+                    timeout=AUTH_TIMEOUT_SECONDS,
                 )
                 logger.info("Response status code: %s", response.status_code)
                 self._token = self._handle_response(response)
@@ -99,7 +100,7 @@ class DummyJSONAuthenticator(requests.auth.AuthBase, metaclass=SingletonMeta):
                         "refreshToken": refresh_token,
                         "expiresInMins": EXPIRES_IN_MINS,
                     },
-                    timeout=0.1,
+                    timeout=AUTH_TIMEOUT_SECONDS,
                 )
                 self._token = self._handle_response(response)
                 return self._token.access_token

--- a/packages/meltano-tap-dummyjson/tap_dummyjson/auth.py
+++ b/packages/meltano-tap-dummyjson/tap_dummyjson/auth.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 import logging
+import sys
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-import requests
+import requests.auth
+from requests_cache import CachedSession
 from singer_sdk.authenticators import SingletonMeta
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 if TYPE_CHECKING:
     from requests import PreparedRequest, Response
@@ -15,73 +23,89 @@ logger = logging.getLogger(__name__)
 EXPIRES_IN_MINS = 30
 
 
-class DummyJSONAuthenticator(metaclass=SingletonMeta):
+@dataclass(slots=True, kw_only=True)
+class _Token:
+    access_token: str
+    refresh_token: str
+    expires: float
+
+    def is_expired(self) -> bool:
+        return self.expires < time.time()
+
+
+class DummyJSONAuthenticator(requests.auth.AuthBase, metaclass=SingletonMeta):
     """DummyJSON authenticator class."""
 
     def __init__(
         self,
-        auth_url: str,
-        refresh_token_url: str,
+        *,
+        base_url: str,
         username: str,
         password: str,
     ) -> None:
-        self.auth_url = auth_url
-        self.refresh_token_url = refresh_token_url
+        self.auth_url = f"{base_url}/auth/login"
+        self.refresh_token_url = f"{base_url}/refresh"
         self.username = username
         self.password = password
 
-        self.token: str | None = None
-        self.refresh_token: str | None = None
+        self._token: _Token | None = None
+        self.session = CachedSession(
+            ".http_cache",
+            backend="filesystem",
+            serializer="json",
+            allowable_methods=("POST",),
+        )
 
-        self.expires: float | None = None
-        self.session = requests.Session()
+    @override
+    def __call__(self, r: PreparedRequest) -> PreparedRequest:
+        logger.info("Authenticating request: %s", r.url)
+        r.headers["Authorization"] = f"Bearer {self._get_access_token()}"
+        return r
 
-    def __call__(self, request: PreparedRequest) -> PreparedRequest:
-        if not self.refresh_token:
-            logger.info("Retrieving token")
-            self.auth()
-            request.headers["Authorization"] = f"Bearer {self.token}"
-            return request
-
-        if self.needs_refresh():
-            logger.info("Refreshing token")
-            self.refresh()
-            request.headers["Authorization"] = f"Bearer {self.token}"
-            return request
-
-        return request
-
-    def needs_refresh(self) -> bool:
-        return self.expires is None or self.expires < time.time()
-
-    def _handle_response(self, response: Response) -> None:
+    @staticmethod
+    def _handle_response(response: Response) -> _Token:
         if response.status_code != 200:
             logger.error("Error: %s", response.text)
             response.raise_for_status()
 
+        logger.info("Response status code: %s", response.status_code)
         data = response.json()
-        self.token = data["accessToken"]
-        self.refresh_token = data["refreshToken"]
-        self.expires = time.time() + EXPIRES_IN_MINS * 60
-        logger.info("Authenticated")
-
-    def refresh(self) -> None:
-        response = self.session.post(
-            self.refresh_token_url,
-            json={
-                "refreshToken": self.refresh_token,
-                "expiresInMins": EXPIRES_IN_MINS,
-            },
+        logger.info("Token data: %s", data)
+        return _Token(
+            access_token=data["accessToken"],
+            refresh_token=data["refreshToken"],
+            expires=time.time() + EXPIRES_IN_MINS * 60,
         )
-        self._handle_response(response)
 
-    def auth(self) -> None:
-        response = self.session.post(
-            self.auth_url,
-            json={
-                "username": self.username,
-                "password": self.password,
-                "expiresInMins": EXPIRES_IN_MINS,
-            },
-        )
-        self._handle_response(response)
+    def _get_access_token(self) -> str:
+        match self._token:
+            case None:  # No token, need to authenticate
+                logger.info("No token, authenticating")
+                response = self.session.post(
+                    self.auth_url,
+                    json={
+                        "username": self.username,
+                        "password": self.password,
+                        "expiresInMins": EXPIRES_IN_MINS,
+                    },
+                    timeout=0.1,
+                )
+                logger.info("Response status code: %s", response.status_code)
+                self._token = self._handle_response(response)
+                return self._token.access_token
+
+            case _Token(refresh_token=refresh_token) if self._token.is_expired():
+                logger.info("Token expired, refreshing")
+                response = self.session.post(
+                    self.refresh_token_url,
+                    json={
+                        "refreshToken": refresh_token,
+                        "expiresInMins": EXPIRES_IN_MINS,
+                    },
+                    timeout=0.1,
+                )
+                self._token = self._handle_response(response)
+                return self._token.access_token
+
+            case _Token(access_token=access_token):  # Token is still valid
+                return access_token

--- a/packages/meltano-tap-dummyjson/tap_dummyjson/auth.py
+++ b/packages/meltano-tap-dummyjson/tap_dummyjson/auth.py
@@ -58,7 +58,6 @@ class DummyJSONAuthenticator(requests.auth.AuthBase, metaclass=SingletonMeta):
 
     @override
     def __call__(self, r: PreparedRequest) -> PreparedRequest:
-        logger.info("Authenticating request: %s", r.url)
         r.headers["Authorization"] = f"Bearer {self._get_access_token()}"
         return r
 
@@ -68,9 +67,7 @@ class DummyJSONAuthenticator(requests.auth.AuthBase, metaclass=SingletonMeta):
             logger.error("Error: %s", response.text)
             response.raise_for_status()
 
-        logger.info("Response status code: %s", response.status_code)
         data = response.json()
-        logger.info("Token data: %s", data)
         return _Token(
             access_token=data["accessToken"],
             refresh_token=data["refreshToken"],

--- a/packages/meltano-tap-dummyjson/tap_dummyjson/client.py
+++ b/packages/meltano-tap-dummyjson/tap_dummyjson/client.py
@@ -26,6 +26,7 @@ class DummyJSONStream(RESTStream):
     """DummyJSON stream class."""
 
     records_jsonpath: str = "$[*]"
+    timeout = 1
 
     @property
     @override
@@ -36,18 +37,13 @@ class DummyJSONStream(RESTStream):
     @property
     @override
     def requests_session(self) -> CachedSession:
-        return CachedSession(
-            ".http_cache",
-            backend="filesystem",
-            serializer="json",
-        )
+        return CachedSession(".http_cache", backend="filesystem", serializer="json")
 
     @property
     @override
     def authenticator(self) -> DummyJSONAuthenticator:
         return DummyJSONAuthenticator(
-            auth_url=f"{self.url_base}/auth/login",
-            refresh_token_url=f"{self.url_base}/refresh",
+            base_url=self.config["api_url"],
             username=self.config["username"],
             password=self.config["password"],
         )

--- a/packages/meltano-tap-dummyjson/tap_dummyjson/tap.py
+++ b/packages/meltano-tap-dummyjson/tap_dummyjson/tap.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 from singer_sdk import Tap
 from singer_sdk import typing as th  # JSON schema typing helpers
 
 from . import streams
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 if TYPE_CHECKING:
     from singer_sdk import Stream
@@ -48,6 +54,7 @@ class TapDummyJSON(Tap):
         ),
     ).to_dict()
 
+    @override
     def discover_streams(self) -> list[Stream]:
         """Return a list of discovered streams.
 

--- a/tests/external/test_tap_dummyjson.py
+++ b/tests/external/test_tap_dummyjson.py
@@ -12,5 +12,5 @@ CONFIG = {
 TestTapDummyJSON = get_tap_test_class(
     tap_class=TapDummyJSON,
     config=CONFIG,
-    suite_config=SuiteConfig(max_records_limit=15),
+    suite_config=SuiteConfig(max_records_limit=60),
 )


### PR DESCRIPTION
- Partially extracted from https://github.com/meltano/sdk/pull/3483

## Summary by Sourcery

Refine the DummyJSON tap authentication and HTTP behavior and expand its external test coverage to exercise pagination.

New Features:
- Introduce a dataclass-backed token model to manage access and refresh tokens with expiry tracking for the DummyJSON authenticator.

Enhancements:
- Refactor DummyJSONAuthenticator to integrate with the requests auth interface, use a cached HTTP session, and centralize token acquisition and refresh logic.
- Set a request timeout on the DummyJSON REST stream to make HTTP interactions more robust.
- Align type-override usage across the tap and authenticator for compatibility across Python versions.

Tests:
- Increase the DummyJSON tap test suite record limit to validate pagination behavior more thoroughly.

Chores:
- Check in HTTP cache artifacts used by the DummyJSON tap tests.