### PR TITLE
docs: Fix links from porting and parent-child guide to API reference

### DIFF
--- a/docs/guides/porting.md
+++ b/docs/guides/porting.md
@@ -133,7 +133,7 @@ _Important: If you've gotten this far, this is a good time to commit your code b
 
 Pagination is generally unique for almost every API. There's no single method that solves for very different API's approach to pagination.
 
-Most likely you will use [get_new_paginator](singer_sdk.RESTStream.get_new_paginator) to instantiate a [pagination class](./../classes/singer_sdk.pagination.BaseAPIPaginator.rst) for your source, and you'll use `get_url_params` to define how to pass the "next page" token back to the API when asking for subsequent pages.
+Most likely you will use [`get_new_paginator`](singer_sdk.RESTStream.get_new_paginator) to instantiate a [pagination class](./../classes/singer_sdk.pagination.BaseAPIPaginator.rst) for your source, and you'll override [`get_url_params`](singer_sdk.RESTStream.get_url_params) to define how to pass the "next page" token back to the API when asking for subsequent pages.
 
 When you think you have it right, run `poetry run tap-mysource`/`uv run tap-mysource` again, and debug until you are confident the result is including multiple pages back from the API.
 

--- a/docs/parent_streams.md
+++ b/docs/parent_streams.md
@@ -6,7 +6,7 @@ from a parent record each time the child stream is invoked.
 
 ## If you do want to utilize parent-child streams
 
-1. Set `parent_stream_type` in the child-stream's class to the class of the parent.
+1. Set [`parent_stream_type`](singer_sdk.Stream.parent_stream_type) in the child-stream's class to the class of the parent.
 1. Implement one of the below methods to pass context from the parent to the child:
    1. Override [`get_child_context`](singer_sdk.Stream.get_child_context) to return a new
       child context object based on records and any existing context from the parent stream.
@@ -70,7 +70,7 @@ class EpicIssuesStream(GitlabStream):
 
 In the example above, the `path` contains placeholders like `{group_id}` and `{epic_iid}`. These are **not** instance properties—they're context variables that get automatically replaced.
 
-The SDK's `get_url_params()` method extracts these values from the context dictionary returned by the parent's `get_child_context()`. For each parent record, the child stream receives a context like:
+The SDK's [`get_url()`](singer_sdk.RESTStream.get_url) method extracts these values from each context dictionary yielded by the parent's [`generate_child_contexts()`](singer_sdk.Stream.generate_child_contexts). For each parent record, the child stream receives one or more context dictionaries like:
 
 ```python
 {


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Update documentation to correctly reference API methods and clarify parent-child stream context handling.

Documentation:
- Fix links in parent-child streams guide to point to the correct API reference for parent_stream_type, get_url, and generate_child_contexts.
- Clarify pagination porting guide to reference get_new_paginator and overriding get_url_params with accurate API links.