### PR TITLE
refactor: Update `RESTStream.get_url_params` return type annotation to only support dictionaries

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -352,7 +352,7 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
         self,
         context: Context | None,  # noqa: ARG002
         next_page_token: _TToken | None,  # noqa: ARG002
-    ) -> dict[str, t.Any] | str:
+    ) -> dict[str, t.Any]:
         """Return a dictionary or string of URL query parameters.
 
         If paging is supported, developers may override with specific paging logic.
@@ -377,8 +377,7 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
                 next page of data.
 
         Returns:
-            Dictionary or encoded string with URL query parameters to use in the
-                request.
+            Dictionary with URL query parameters to use in the request.
         """
         return {}
 


### PR DESCRIPTION
This was introduced originally to indicate support for custom encoding of quyer parameters, as an alternative to https://github.com/meltano/sdk/issues/1666. No one really uses it tho, and it causes annoying type errors in subclasses, so lets get rid of it.

## Related

- #1666
- #3483

## Summary by Sourcery

Restrict RESTStream.get_url_params to return only dictionaries instead of allowing string values and update its documentation accordingly.