### PR TITLE
fix(templates): Remove `# noqa: ERA001` comments from templates

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/other-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/other-client.py
@@ -39,8 +39,8 @@ class {{ cookiecutter.source_name }}Stream(Stream):
             NotImplementedError: If the implementation is TODO
         """
         # TODO: Write logic to extract data from the upstream source.
-        # records = mysource.getall()  # noqa: ERA001
+        # records = mysource.getall()
         # for record in records:
-        #     yield record.to_dict()  # noqa: ERA001
+        #     yield record.to_dict()
         errmsg = "The method is not yet implemented (TODO)"
         raise NotImplementedError(errmsg)

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
@@ -165,7 +165,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
         """
 {%- if cookiecutter.auth_method not in ("OAuth2", "JWT") %}
         # If not using an authenticator, you may also provide inline auth headers:
-        # headers["Private-Token"] = self.config.get("auth_token")  # noqa: ERA001
+        # headers["Private-Token"] = self.config.get("auth_token")
 {%- endif %}
         return {}
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
@@ -94,8 +94,8 @@ class {{ cookiecutter.source_name }}SQLToJSONSchema(SQLToJSONSchema):
     #     for specific SQLAlchemy column types.
     #     """
     #     if self.custom_config_option:
-    #         return {"type": ["string", "null"]}  # noqa: ERA001
-    #     return {"type": ["object", "null"], "additionalProperties": True}  # noqa: ERA001
+    #         return {"type": ["string", "null"]}
+    #     return {"type": ["object", "null"], "additionalProperties": True}
 
 
 class {{ cookiecutter.source_name }}Connector(SQLConnector):
@@ -230,7 +230,7 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
         query = super().apply_query_filters(query, table, context=context)
 
         # Add custom WHERE clauses from configuration, etc.
-        # query = query.where(...)  # noqa: ERA001
+        # query = query.where(...)
 
         return query  # noqa: RET504
 
@@ -273,4 +273,4 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
                 yield dict(record)
 
         # Alternative: Use the default implementation
-        # yield from super().get_records(context)  # noqa: ERA001
+        # yield from super().get_records(context)

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/streams.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/streams.py
@@ -17,7 +17,7 @@ class UsersStream({{ cookiecutter.source_name }}Stream):
 
     name = "users"
     # Optionally, you may also use `schema_filepath` in place of `schema`:
-    # schema_filepath = SCHEMAS_DIR / "users.json"  # noqa: ERA001
+    # schema_filepath = SCHEMAS_DIR / "users.json"
     schema = th.PropertiesList(
         th.Property("name", th.StringType),
         th.Property(
@@ -103,7 +103,7 @@ class UsersStream({{ cookiecutter.source_name }}Stream):
     primary_keys = ("id",)
     replication_key = None
     # Optionally, you may also use `schema_filepath` in place of `schema`:
-    # schema_filepath = SCHEMAS_DIR / "users.json"  # noqa: ERA001
+    # schema_filepath = SCHEMAS_DIR / "users.json"
     schema = th.PropertiesList(
         th.Property("name", th.StringType),
         th.Property(

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_record.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_record.py
@@ -17,4 +17,4 @@ class {{ cookiecutter.destination_name }}Sink(RecordSink):
         """
         # Sample:
         # ------
-        # client.write(record)  # noqa: ERA001
+        # client.write(record)

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,6 +28,8 @@ extend-ignore = [
   "TD002",
   "TD003",
   "FIX002",
+  # Commented code
+  "ERA001",
 ]
 """
 


### PR DESCRIPTION
SSIA, this will prompt developers to remove unused code early.

## Summary by Sourcery

Remove lint-ignore markers for commented-out example code in cookiecutter templates and configure the linter to allow commented code globally.

Enhancements:
- Clean up example comments in tap and target cookiecutter templates by removing ERA001 noqa tags to encourage early removal or implementation of placeholder code.

Build:
- Update linting configuration in noxfile to ignore the ERA001 rule for commented-out code across the project.