### PR TITLE
refactor: Updated type annotation for `Stream.state_partitioning_keys` to allow a tuple of strings

### DIFF
--- a/singer_sdk/streams/_state.py
+++ b/singer_sdk/streams/_state.py
@@ -42,7 +42,7 @@ class StreamStateManager:
         tap_name: str,
         stream_name: str,
         tap_state: types.TapState,
-        state_partitioning_keys: list[str] | None = None,
+        state_partitioning_keys: t.Sequence[str] | None = None,
     ) -> None:
         """Initialize the StreamStateManager.
 

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -149,7 +149,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
         self.forced_replication_method: str | None = None
         self._replication_key: str | None = None
         self._primary_keys: t.Sequence[str] | None = None
-        self._state_partitioning_keys: list[str] | None = None
+        self._state_partitioning_keys: t.Sequence[str] | None = None
         self._schema_filepath: Path | Traversable | None = None
         self._metadata: singer.MetadataMapping | None = None
         self._mask: singer.SelectionMask | None = None
@@ -545,11 +545,11 @@ class Stream(abc.ABC):  # noqa: PLR0904
         self._primary_keys = new_value
 
     @property
-    def state_partitioning_keys(self) -> list[str] | None:
+    def state_partitioning_keys(self) -> t.Sequence[str] | None:
         """Get state partition keys.
 
         If not set, a default partitioning will be inherited from the stream's context.
-        If an empty list is set (`[]`), state will be held in one bookmark per stream.
+        If an empty list or tuple is set, state will be held in one bookmark per stream.
 
         Returns:
             Partition keys for the stream state bookmarks.
@@ -557,11 +557,11 @@ class Stream(abc.ABC):  # noqa: PLR0904
         return self._state_partitioning_keys
 
     @state_partitioning_keys.setter
-    def state_partitioning_keys(self, new_value: list[str] | None) -> None:
+    def state_partitioning_keys(self, new_value: t.Sequence[str] | None) -> None:
         """Set partition keys for the stream state bookmarks.
 
         If not set, a default partitioning will be inherited from the stream's context.
-        If an empty list is set (`[]`), state will be held in one bookmark per stream.
+        If an empty list or tuple is set, state will be held in one bookmark per stream.
 
         Args:
             new_value: the new list of keys


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Enhancements:
- Update Stream.state_partitioning_keys and related state manager parameter to use a generic string sequence type annotation.