### PR TITLE
fix: Correctly load private key with passphrase in JWT-based authenticator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ packages = [
 testing = [
     "backports-zstd>=1.0.0; python_version < '3.14'",
     "coverage[toml]>=7.9",
+    "dirty-equals>=0.11",
     "fastjsonschema>=2.19.1",
     "pytest>=9",
     "pytest-benchmark>=4.0.0",

--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -781,15 +781,21 @@ class OAuthJWTAuthenticator(OAuthAuthenticator):
             msg = "Missing 'private_key' property for OAuth payload."
             raise ValueError(msg)
 
-        private_key: bytes | t.Any = bytes(self.private_key, "UTF-8")
+        private_key_bytes = bytes(self.private_key, "UTF-8")
         if self.private_key_passphrase:
             passphrase = bytes(self.private_key_passphrase, "UTF-8")
-            private_key = serialization.load_pem_private_key(
-                private_key,
+            pkey = serialization.load_pem_private_key(
+                private_key_bytes,
                 password=passphrase,
                 backend=default_backend(),
             )
-        private_key_string: str | t.Any = private_key.decode("UTF-8")  # ty: ignore[possibly-missing-attribute]
+            private_key_bytes = pkey.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+
+        private_key_string: str | t.Any = private_key_bytes.decode("UTF-8")
         return {
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
             "assertion": jwt.encode(

--- a/tests/core/rest/test_authenticators.py
+++ b/tests/core/rest/test_authenticators.py
@@ -284,21 +284,29 @@ def public_key_string(public_key: RSAPublicKey) -> str:
 
 
 def test_oauth_jwt_authenticator_payload(
-    rest_tap: Tap,
     private_key_string: str,
     public_key_string: str,
 ):
-    class _FakeOAuthJWTAuthenticator(OAuthJWTAuthenticator):
-        private_key = private_key_string
-        oauth_request_body = {"some": "payload"}  # noqa: RUF012
-
-    authenticator = _FakeOAuthJWTAuthenticator(stream=rest_tap.streams["some_stream"])
+    authenticator = OAuthJWTAuthenticator(
+        client_id="client-id",
+        private_key=private_key_string,
+        auth_endpoint="https://example.com/oauth",
+        oauth_scopes="scope",
+    )
 
     body = authenticator.oauth_request_body
     payload = authenticator.oauth_request_payload
     token = payload["assertion"]
 
-    assert jwt.decode(token, public_key_string, algorithms=["RS256"]) == body
+    assert (
+        jwt.decode(
+            token,
+            public_key_string,
+            algorithms=["RS256"],
+            audience="https://example.com/oauth",
+        )
+        == body
+    )
 
 
 def test_requests_library_auth(rest_tap: Tap):

--- a/tests/core/rest/test_authenticators.py
+++ b/tests/core/rest/test_authenticators.py
@@ -24,6 +24,7 @@ from cryptography.hazmat.primitives.serialization import (
     PrivateFormat,
     PublicFormat,
 )
+from dirty_equals import IsPositiveInt
 
 from singer_sdk.authenticators import (
     APIAuthenticatorBase,
@@ -302,26 +303,32 @@ def test_oauth_jwt_authenticator_payload(
     private_key_string: str,
     public_key_string: str,
 ):
+    client_id = "client-id"
+    oauth_scopes = "one,two,three"
+    auth_endpoint = "https://example.com/oauth"
+
     authenticator = OAuthJWTAuthenticator(
-        client_id="client-id",
+        client_id=client_id,
         private_key=private_key_string,
-        auth_endpoint="https://example.com/oauth",
-        oauth_scopes="scope",
+        auth_endpoint=auth_endpoint,
+        oauth_scopes=oauth_scopes,
     )
 
-    body = authenticator.oauth_request_body
     payload = authenticator.oauth_request_payload
     token = payload["assertion"]
 
-    assert (
-        jwt.decode(
-            token,
-            public_key_string,
-            algorithms=["RS256"],
-            audience="https://example.com/oauth",
-        )
-        == body
-    )
+    assert jwt.decode(
+        token,
+        public_key_string,
+        algorithms=["RS256"],
+        audience="https://example.com/oauth",
+    ) == {
+        "aud": auth_endpoint,
+        "exp": IsPositiveInt(),
+        "iat": IsPositiveInt(),
+        "iss": client_id,
+        "scope": oauth_scopes,
+    }
 
 
 def test_oauth_jwt_authenticator_payload_with_passphrase(
@@ -329,26 +336,33 @@ def test_oauth_jwt_authenticator_payload_with_passphrase(
     private_key_with_passphrase: str,
     passphrase: str,
 ):
+    auth_endpoint = "https://example.com/oauth"
+    client_id = "client-id"
+    oauth_scopes = "one,two,three"
+
     authenticator = OAuthJWTAuthenticator(
-        client_id="client-id",
-        auth_endpoint="https://example.com/oauth",
+        client_id=client_id,
+        auth_endpoint=auth_endpoint,
         private_key=private_key_with_passphrase,
         private_key_passphrase=passphrase,
+        oauth_scopes=oauth_scopes,
     )
 
-    body = authenticator.oauth_request_body
     payload = authenticator.oauth_request_payload
     token = payload["assertion"]
 
-    assert (
-        jwt.decode(
-            token,
-            public_key_string,
-            algorithms=["RS256"],
-            audience="https://example.com/oauth",
-        )
-        == body
-    )
+    assert jwt.decode(
+        token,
+        public_key_string,
+        algorithms=["RS256"],
+        audience="https://example.com/oauth",
+    ) == {
+        "aud": auth_endpoint,
+        "exp": IsPositiveInt(),
+        "iat": IsPositiveInt(),
+        "iss": client_id,
+        "scope": oauth_scopes,
+    }
 
 
 def test_requests_library_auth(rest_tap: Tap):

--- a/tests/core/rest/test_authenticators.py
+++ b/tests/core/rest/test_authenticators.py
@@ -18,6 +18,7 @@ import responses.registries
 import time_machine
 from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
 from cryptography.hazmat.primitives.serialization import (
+    BestAvailableEncryption,
     Encoding,
     NoEncryption,
     PrivateFormat,
@@ -283,6 +284,20 @@ def public_key_string(public_key: RSAPublicKey) -> str:
     ).decode("utf-8")
 
 
+@pytest.fixture
+def passphrase() -> str:
+    return "private-key-passphrase"
+
+
+@pytest.fixture
+def private_key_with_passphrase(private_key: RSAPrivateKey, passphrase: str) -> str:
+    return private_key.private_bytes(
+        Encoding.PEM,
+        format=PrivateFormat.PKCS8,
+        encryption_algorithm=BestAvailableEncryption(passphrase.encode("utf-8")),
+    ).decode("utf-8")
+
+
 def test_oauth_jwt_authenticator_payload(
     private_key_string: str,
     public_key_string: str,
@@ -292,6 +307,33 @@ def test_oauth_jwt_authenticator_payload(
         private_key=private_key_string,
         auth_endpoint="https://example.com/oauth",
         oauth_scopes="scope",
+    )
+
+    body = authenticator.oauth_request_body
+    payload = authenticator.oauth_request_payload
+    token = payload["assertion"]
+
+    assert (
+        jwt.decode(
+            token,
+            public_key_string,
+            algorithms=["RS256"],
+            audience="https://example.com/oauth",
+        )
+        == body
+    )
+
+
+def test_oauth_jwt_authenticator_payload_with_passphrase(
+    public_key_string: str,
+    private_key_with_passphrase: str,
+    passphrase: str,
+):
+    authenticator = OAuthJWTAuthenticator(
+        client_id="client-id",
+        auth_endpoint="https://example.com/oauth",
+        private_key=private_key_with_passphrase,
+        private_key_passphrase=passphrase,
     )
 
     body = authenticator.oauth_request_body

--- a/uv.lock
+++ b/uv.lock
@@ -902,6 +902,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dirty-equals"
+version = "0.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/1d/c5913ac9d6615515a00f4bdc71356d302437cb74ff2e9aaccd3c14493b78/dirty_equals-0.11.tar.gz", hash = "sha256:f4ac74ee88f2d11e2fa0f65eb30ee4f07105c5f86f4dc92b09eb1138775027c3", size = 128067, upload-time = "2025-11-17T01:51:24.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/8d/dbff05239043271dbeace563a7686212a3dd517864a35623fe4d4a64ca19/dirty_equals-0.11-py3-none-any.whl", hash = "sha256:b1d7093273fc2f9be12f443a8ead954ef6daaf6746fd42ef3a5616433ee85286", size = 28051, upload-time = "2025-11-17T01:51:22.849Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2815,6 +2824,7 @@ testing = [
 benchmark = [
     { name = "backports-zstd", marker = "python_full_version < '3.14'" },
     { name = "coverage", extra = ["toml"] },
+    { name = "dirty-equals" },
     { name = "fastjsonschema" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
@@ -2835,6 +2845,7 @@ dev = [
     { name = "backports-zstd", marker = "python_full_version < '3.14'" },
     { name = "coverage", extra = ["toml"] },
     { name = "deptry" },
+    { name = "dirty-equals" },
     { name = "fastjsonschema" },
     { name = "furo" },
     { name = "mypy" },
@@ -2900,6 +2911,7 @@ packages = [
 testing = [
     { name = "backports-zstd", marker = "python_full_version < '3.14'" },
     { name = "coverage", extra = ["toml"] },
+    { name = "dirty-equals" },
     { name = "fastjsonschema" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
@@ -2918,6 +2930,7 @@ testing = [
 typing = [
     { name = "backports-zstd", marker = "python_full_version < '3.14'" },
     { name = "coverage", extra = ["toml"] },
+    { name = "dirty-equals" },
     { name = "fastjsonschema" },
     { name = "mypy" },
     { name = "pyarrow-stubs" },
@@ -2980,6 +2993,7 @@ provides-extras = ["faker", "jwt", "msgspec", "parquet", "s3", "sql", "ssh", "te
 benchmark = [
     { name = "backports-zstd", marker = "python_full_version < '3.14'", specifier = ">=1.0.0" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.9" },
+    { name = "dirty-equals", specifier = ">=0.11" },
     { name = "fastjsonschema", specifier = ">=2.19.1" },
     { name = "pytest", specifier = ">=9" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
@@ -3000,6 +3014,7 @@ dev = [
     { name = "backports-zstd", marker = "python_full_version < '3.14'", specifier = ">=1.0.0" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.9" },
     { name = "deptry", specifier = ">=0.15.0" },
+    { name = "dirty-equals", specifier = ">=0.11" },
     { name = "fastjsonschema", specifier = ">=2.19.1" },
     { name = "furo", specifier = ">=2024.5.6" },
     { name = "mypy", specifier = ">=1.17" },
@@ -3057,6 +3072,7 @@ packages = [
 testing = [
     { name = "backports-zstd", marker = "python_full_version < '3.14'", specifier = ">=1.0.0" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.9" },
+    { name = "dirty-equals", specifier = ">=0.11" },
     { name = "fastjsonschema", specifier = ">=2.19.1" },
     { name = "pytest", specifier = ">=9" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
@@ -3075,6 +3091,7 @@ testing = [
 typing = [
     { name = "backports-zstd", marker = "python_full_version < '3.14'", specifier = ">=1.0.0" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.9" },
+    { name = "dirty-equals", specifier = ">=0.11" },
     { name = "fastjsonschema", specifier = ">=2.19.1" },
     { name = "mypy", specifier = ">=1.17" },
     { name = "pyarrow-stubs", specifier = ">=19.1" },


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Fix OAuth JWT authenticator handling of PEM private keys with optional passphrases and expand test coverage for JWT payload generation.

Bug Fixes:
- Correct loading and serialization of PEM private keys when a passphrase is configured in the OAuth JWT authenticator.

Tests:
- Update OAuth JWT authenticator tests to construct the authenticator via its public API and validate JWT audience along with payload contents.