### PR TITLE
refactor: Deprecate `RESTStream.prepare_request` in favor of `RESTStream.get_http_request`

### DIFF
--- a/packages/meltano-tap-dummyjson/tap_dummyjson/client.py
+++ b/packages/meltano-tap-dummyjson/tap_dummyjson/client.py
@@ -12,6 +12,8 @@ from singer_sdk.streams import RESTStream
 from .auth import DummyJSONAuthenticator
 
 if TYPE_CHECKING:
+    import requests
+    from singer_sdk.helpers.types import Context
     from singer_sdk.streams.rest import HTTPRequest, HTTPRequestContext
 
 if sys.version_info >= (3, 12):
@@ -59,7 +61,25 @@ class DummyJSONStream(RESTStream):
         return BaseOffsetPaginator(start_value=0, page_size=PAGE_SIZE)
 
     @override
-    def get_http_request(self, *, context: HTTPRequestContext[int]) -> HTTPRequest:
+    def get_http_request(
+        self,
+        *,
+        context: HTTPRequestContext[BaseOffsetPaginator],
+    ) -> HTTPRequest:
         request = super().get_http_request(context=context)
-        request.params = {"skip": context.next_page, "limit": PAGE_SIZE}
+        request.params = {
+            "skip": context.paginator.current_value,
+            "limit": context.paginator.page_size,
+        }
+        return request
+
+    @override
+    def prepare_request(
+        self,
+        context: Context | None,
+        next_page_token: int | None,
+    ) -> requests.PreparedRequest:
+        request = super().prepare_request(context, next_page_token)
+        if next_page_token is not None:
+            request.headers["X-Custom-Header"] = "value"
         return request

--- a/packages/meltano-tap-gitlab/tap_gitlab/streams.py
+++ b/packages/meltano-tap-gitlab/tap_gitlab/streams.py
@@ -68,11 +68,15 @@ class GitlabStream(RESTStream[str]):
         )
 
     @override
-    def get_http_request(self, *, context: HTTPRequestContext[str]) -> HTTPRequest:
+    def get_http_request(
+        self,
+        *,
+        context: HTTPRequestContext[SimpleHeaderPaginator],
+    ) -> HTTPRequest:
         """Get the HTTP request for the given context."""
         request = super().get_http_request(context=context)
-        if context.next_page:
-            request.params["page"] = context.next_page
+        if context.paginator.current_value:
+            request.params["page"] = context.paginator.current_value
         if self.replication_key:
             request.params["sort"] = "asc"
             request.params["order_by"] = self.replication_key
@@ -225,7 +229,11 @@ class EpicIssuesStream(GitlabStream):
     parent_stream_type = EpicsStream  # Stream should wait for parents to complete.
 
     @override
-    def get_http_request(self, *, context: HTTPRequestContext[str]) -> HTTPRequest:
+    def get_http_request(
+        self,
+        *,
+        context: HTTPRequestContext[SimpleHeaderPaginator],
+    ) -> HTTPRequest:
         """Get the HTTP request for the given context."""
         request = super().get_http_request(context=context)
         if not context.stream_context or "epic_id" not in context.stream_context:

--- a/singer_sdk/pagination.py
+++ b/singer_sdk/pagination.py
@@ -393,6 +393,11 @@ class BaseOffsetPaginator(BaseAPIPaginator[int], ABC):
         super().__init__(start_value, *args, **kwargs)
         self._page_size = page_size
 
+    @property
+    def page_size(self) -> int:
+        """The page size."""
+        return self._page_size
+
     @override
     def get_next(self, response: requests.Response) -> int | None:
         """Get the next page offset.

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -71,6 +71,7 @@ DEFAULT_REQUEST_TIMEOUT = 300  # 5 minutes
 
 _TToken = TypeVar("_TToken", default=t.Any)
 _TNum = t.TypeVar("_TNum", int, float)
+_TPag = TypeVar("_TPag", bound="BaseAPIPaginator")
 
 
 @dataclass(slots=True)
@@ -123,7 +124,7 @@ class HTTPRequest:
 
 
 @dataclass(slots=True)
-class HTTPRequestContext(t.Generic[_TToken]):
+class HTTPRequestContext(t.Generic[_TPag]):
     """Context for an HTTP request.
 
     .. versionadded:: NEXT_VERSION
@@ -132,8 +133,8 @@ class HTTPRequestContext(t.Generic[_TToken]):
     #: The stream partition or context dictionary.
     stream_context: Context | None
 
-    #: The next page token, if applicable.
-    next_page: _TToken | None
+    #: The active paginator instance, if applicable.
+    paginator: _TPag
 
 
 class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
@@ -523,11 +524,11 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
             headers=self.http_headers,
             params=self.get_url_params(
                 context.stream_context,
-                context.next_page,
+                context.paginator.current_value,
             ),
             data=self.prepare_request_payload(
                 context.stream_context,
-                context.next_page,
+                context.paginator.current_value,
             ),
         )
 
@@ -551,10 +552,36 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
             Build a request with the stream's URL, path, query parameters,
             HTTP headers and authenticator.
         """
+        http_method = self.http_method
+        url: str = self.get_url(context)
+        params: dict | str = self.get_url_params(context, next_page_token)
+        request_data = self.prepare_request_payload(context, next_page_token)
+        headers = self.http_headers
+
+        prepare_kwargs: dict[str, t.Any] = {
+            "method": http_method,
+            "url": url,
+            "params": params,
+            "headers": headers,
+        }
+
+        if self.payload_as_json:
+            prepare_kwargs["json"] = request_data
+        else:
+            prepare_kwargs["data"] = request_data
+
+        return self.build_prepared_request(**prepare_kwargs)
+
+    def _prepare_request(
+        self,
+        *,
+        context: Context | None,
+        paginator: _TPag,
+    ) -> requests.PreparedRequest:
         http_request = self.get_http_request(
             context=HTTPRequestContext(
                 stream_context=context,
-                next_page=next_page_token,
+                paginator=paginator,
             )
         )
 
@@ -601,10 +628,22 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
             request_counter.with_context(context)
 
             while not paginator.finished:
-                prepared_request = self.prepare_request(
-                    context,
-                    next_page_token=paginator.current_value,
-                )
+                if type(self).prepare_request is not _HTTPStream.prepare_request:
+                    warn(
+                        "prepare_request is deprecated, use get_http_request instead",
+                        SingerSDKDeprecationWarning,
+                        stacklevel=2,
+                    )
+                    prepared_request = self.prepare_request(
+                        context,
+                        paginator.current_value,
+                    )
+                else:
+                    prepared_request = self._prepare_request(
+                        context=context,
+                        paginator=paginator,
+                    )
+
                 resp = decorated_request(prepared_request, context)
                 request_counter.increment()
                 self.update_sync_costs(prepared_request, resp, context)
@@ -784,7 +823,7 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
         ...
 
     @abc.abstractmethod
-    def get_new_paginator(self) -> BaseAPIPaginator | None:
+    def get_new_paginator(self) -> BaseAPIPaginator[_TToken] | None:
         """Get a fresh paginator for this endpoint.
 
         Returns:
@@ -965,7 +1004,15 @@ class RESTStream(_HTTPStream, abc.ABC, t.Generic[_TToken]):
             input=response.json(parse_float=decimal.Decimal),
         )
 
-    def get_new_paginator(self) -> BaseAPIPaginator | None:
+    def get_new_paginator(
+        self,
+    ) -> (
+        BaseAPIPaginator[_TToken]
+        | LegacyStreamPaginator[_TToken]
+        | JSONPathPaginator
+        | SimpleHeaderPaginator
+        | None
+    ):
         """Get a fresh paginator for this API endpoint.
 
         Returns:

--- a/tests/core/rest/test_pagination.py
+++ b/tests/core/rest/test_pagination.py
@@ -374,10 +374,13 @@ def test_break_pagination(tap: Tap, caplog: pytest.LogCaptureFixture):
             return BasePageNumberPaginator(1)
 
         @override
-        def get_http_request(self, *, context: HTTPRequestContext[int]) -> HTTPRequest:
+        def get_http_request(
+            self,
+            *,
+            context: HTTPRequestContext[BasePageNumberPaginator],
+        ) -> HTTPRequest:
             request = super().get_http_request(context=context)
-            if context.next_page is not None:
-                request.params["page"] = context.next_page
+            request.params["page"] = context.paginator.current_value
             return request
 
         @override
@@ -450,10 +453,13 @@ def test_continue_if_empty(tap: Tap):
             return _TestPaginator(1)
 
         @override
-        def get_http_request(self, *, context: HTTPRequestContext[int]) -> HTTPRequest:
+        def get_http_request(
+            self,
+            *,
+            context: HTTPRequestContext[BasePageNumberPaginator],
+        ) -> HTTPRequest:
             request = super().get_http_request(context=context)
-            if context.next_page is not None:
-                request.params["page"] = context.next_page
+            request.params["page"] = context.paginator.current_value
             return request
 
         @override
@@ -516,10 +522,11 @@ def test_no_paginator(tap: Tap):
             return None
 
         @override
-        def get_http_request(self, *, context: HTTPRequestContext[None]) -> HTTPRequest:
+        def get_http_request(
+            self, *, context: HTTPRequestContext[SinglePagePaginator]
+        ) -> HTTPRequest:
             request = super().get_http_request(context=context)
-            if context.next_page is not None:
-                request.params["page"] = context.next_page
+            assert context.paginator.current_value is None
             return request
 
         @override


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Deprecate RESTStream.prepare_request in favor of RESTStream.get_http_request and update pagination handling to operate on paginator instances instead of raw page tokens.

New Features:
- Allow HTTPRequestContext to carry a paginator instance, enabling richer pagination-aware request construction.
- Expose the page_size attribute on BaseOffsetPaginator for use in request parameter building.

Enhancements:
- Adjust REST stream request construction to use paginator.current_value via the new HTTPRequestContext paginator field.
- Introduce an internal helper to build PreparedRequest objects from HTTPRequestContext while keeping backward compatibility with overridden prepare_request implementations.
- Tighten typing on get_new_paginator and related HTTPRequestContext generics to bind them to concrete paginator types across the SDK and example taps.
- Update example taps and tests to construct HTTP requests using paginator instances rather than raw next_page tokens.

Tests:
- Adapt REST pagination tests to the new HTTPRequestContext paginator API and ensure backward compatibility paths are covered.