### PR TITLE
feat: Deprecate `BasePageNumberPaginator` and `BaseOffsetPaginator` in favor of `PageNumberPaginator` and `OffsetPaginator`, respectively

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/AGENTS.md
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/AGENTS.md
@@ -133,9 +133,9 @@ The SDK provides built-in pagination classes. **Use these instead of overriding 
 For complex pagination logic, create a custom paginator class:
 
 ```python
-from singer_sdk.pagination import BasePageNumberPaginator
+from singer_sdk.pagination import PageNumberPaginator
 
-class MyCustomPaginator(BasePageNumberPaginator):
+class MyCustomPaginator(PageNumberPaginator):
     def has_more(self, response):
         """Check if there are more pages."""
         data = response.json()
@@ -156,10 +156,10 @@ class MyStream({{ cookiecutter.source_name }}Stream):
 
 **Common Pagination Patterns:**
 
-- **Offset-based**: Extend `BaseOffsetPaginator`
-- **Page-based**: Extend `BasePageNumberPaginator`
-- **Cursor-based**: Extend `BaseAPIPaginator` with custom logic
-- **HATEOAS/HAL**: Use `JSONPathPaginator` with appropriate JSON path
+- **Offset-based**: Use `OffsetPaginator`
+- **Page-based**: Use `PageNumberPaginator`
+- **Cursor-based**: Use or extend `JSONPathPaginator`
+- **HATEOAS/HAL**: Extend `BaseHATEOASPaginator` with a custom `get_next_url()` method to extract the next URL from the response.
 
 Only override `get_next_page_token()` as a last resort for very simple cases.
 

--- a/docs/classes/singer_sdk.pagination.OffsetPaginator.rst
+++ b/docs/classes/singer_sdk.pagination.OffsetPaginator.rst
@@ -1,0 +1,8 @@
+﻿singer_sdk.pagination.OffsetPaginator
+=====================================
+
+.. currentmodule:: singer_sdk.pagination
+
+.. autoclass:: OffsetPaginator
+    :members:
+    :special-members: __init__, __call__

--- a/docs/classes/singer_sdk.pagination.PageNumberPaginator.rst
+++ b/docs/classes/singer_sdk.pagination.PageNumberPaginator.rst
@@ -1,0 +1,8 @@
+﻿singer_sdk.pagination.PageNumberPaginator
+=========================================
+
+.. currentmodule:: singer_sdk.pagination
+
+.. autoclass:: PageNumberPaginator
+    :members:
+    :special-members: __init__, __call__

--- a/docs/guides/pagination-classes.md
+++ b/docs/guides/pagination-classes.md
@@ -77,18 +77,18 @@ class MyStream(RESTStream):
 ### Example: Offset pagination
 
 Another common pattern is to use an `offset` parameter to indicate the starting point of the next
-page of results. The [`BaseOffsetPaginator`](../../classes/singer_sdk.pagination.BaseOffsetPaginator)
+page of results. The [`OffsetPaginator`](../../classes/singer_sdk.pagination.OffsetPaginator)
 class can be used to handle this pattern.
 
 ```python
 # New implementation
 
-from singer_sdk.pagination import BaseOffsetPaginator
+from singer_sdk.pagination import OffsetPaginator
 
 
 class MyStream(RESTStream):
     def get_new_paginator(self):
-        return BaseOffsetPaginator(start_value=0, page_size=250)
+        return OffsetPaginator(start_value=0, page_size=250)
 
     def get_url_params(self, context, next_page_token):
         params = {}

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -133,6 +133,8 @@ Pagination
     pagination.BaseOffsetPaginator
     pagination.LegacyPaginatedStreamProtocol
     pagination.LegacyStreamPaginator
+    pagination.OffsetPaginator
+    pagination.PageNumberPaginator
 
 Batch
 -----

--- a/packages/meltano-tap-dummyjson/tap_dummyjson/client.py
+++ b/packages/meltano-tap-dummyjson/tap_dummyjson/client.py
@@ -6,7 +6,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from requests_cache import CachedSession
-from singer_sdk.pagination import BaseOffsetPaginator
+from singer_sdk.pagination import OffsetPaginator
 from singer_sdk.streams import RESTStream
 
 from .auth import DummyJSONAuthenticator
@@ -55,8 +55,8 @@ class DummyJSONStream(RESTStream):
         )
 
     @override
-    def get_new_paginator(self) -> BaseOffsetPaginator:
-        return BaseOffsetPaginator(start_value=0, page_size=PAGE_SIZE)
+    def get_new_paginator(self) -> OffsetPaginator:
+        return OffsetPaginator(start_value=0, page_size=PAGE_SIZE)
 
     @override
     def get_url_params(

--- a/singer_sdk/helpers/_compat.py
+++ b/singer_sdk/helpers/_compat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import sys
+from functools import partial
 from importlib import resources as importlib_resources
 
 if sys.version_info >= (3, 13):
@@ -33,6 +34,9 @@ time_fromisoformat = datetime.time.fromisoformat
 
 class SingerSDKDeprecationWarning(DeprecationWarning):
     """Custom deprecation warning for the Singer SDK."""
+
+
+singer_sdk_deprecated = partial(deprecated, category=SingerSDKDeprecationWarning)
 
 
 __all__ = [

--- a/singer_sdk/pagination.py
+++ b/singer_sdk/pagination.py
@@ -7,6 +7,7 @@ import typing as t
 from abc import ABC, abstractmethod
 from urllib.parse import ParseResult, urlparse
 
+from singer_sdk.helpers._compat import singer_sdk_deprecated
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 
 if sys.version_info >= (3, 12):
@@ -355,7 +356,7 @@ class SimpleHeaderPaginator(BaseAPIPaginator[str | None]):
         return response.headers.get(self._key, None)
 
 
-class BasePageNumberPaginator(BaseAPIPaginator[int], ABC):
+class PageNumberPaginator(BaseAPIPaginator[int]):
     """Paginator class for APIs that use page number."""
 
     @override
@@ -371,7 +372,18 @@ class BasePageNumberPaginator(BaseAPIPaginator[int], ABC):
         return self._value + 1
 
 
-class BaseOffsetPaginator(BaseAPIPaginator[int], ABC):
+@singer_sdk_deprecated(
+    "BasePageNumberPaginator is deprecated and will be removed in a future version. "
+    "Use PageNumberPaginator instead."
+)
+class BasePageNumberPaginator(PageNumberPaginator):
+    """DEPRECATED.
+
+    Use :class:`singer_sdk.pagination.PageNumberPaginator` instead.
+    """
+
+
+class OffsetPaginator(BaseAPIPaginator[int], ABC):
     """Paginator class for APIs that use page offset."""
 
     def __init__(
@@ -392,6 +404,11 @@ class BaseOffsetPaginator(BaseAPIPaginator[int], ABC):
         super().__init__(start_value, *args, **kwargs)
         self._page_size = page_size
 
+    @property
+    def page_size(self) -> int:
+        """The page size."""
+        return self._page_size
+
     @override
     def get_next(self, response: requests.Response) -> int | None:
         """Get the next page offset.
@@ -403,6 +420,17 @@ class BaseOffsetPaginator(BaseAPIPaginator[int], ABC):
             The next page offset.
         """
         return self._value + self._page_size
+
+
+@singer_sdk_deprecated(
+    "BaseOffsetPaginator is deprecated and will be removed in a future version. "
+    "Use OffsetPaginator instead."
+)
+class BaseOffsetPaginator(OffsetPaginator):
+    """DEPRECATED   .
+
+    Use :class:`singer_sdk.pagination.OffsetPaginator` instead.
+    """
 
 
 class LegacyPaginatedStreamProtocol(t.Protocol[TPageToken]):

--- a/singer_sdk/pagination.py
+++ b/singer_sdk/pagination.py
@@ -427,7 +427,7 @@ class OffsetPaginator(BaseAPIPaginator[int], ABC):
     "Use OffsetPaginator instead."
 )
 class BaseOffsetPaginator(OffsetPaginator):
-    """DEPRECATED   .
+    """DEPRECATED.
 
     Use :class:`singer_sdk.pagination.OffsetPaginator` instead.
     """

--- a/tests/core/rest/test_pagination.py
+++ b/tests/core/rest/test_pagination.py
@@ -190,6 +190,8 @@ def test_paginator_offset():
 
     response = Response()
     paginator = _TestOffsetPaginator(0, 2, "$[*]")
+    assert paginator.page_size == 2
+
     assert not paginator.finished
     assert paginator.current_value == 0
     assert paginator.count == 0

--- a/tests/core/rest/test_pagination.py
+++ b/tests/core/rest/test_pagination.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+import sys
 import typing as t
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import ParseResult, parse_qs, urlparse
 
 import pytest
 from requests import Response
 
+from singer_sdk.helpers._compat import SingerSDKDeprecationWarning
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk.pagination import (
     BaseAPIPaginator,
@@ -17,15 +19,23 @@ from singer_sdk.pagination import (
     BasePageNumberPaginator,
     HeaderLinkPaginator,
     JSONPathPaginator,
+    OffsetPaginator,
+    PageNumberPaginator,
     SimpleHeaderPaginator,
     SinglePagePaginator,
     first,
 )
 from singer_sdk.streams.rest import RESTStream
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     from requests import PreparedRequest
 
+    from singer_sdk.helpers.types import Context
     from singer_sdk.tap_base import Tap
 
 
@@ -99,7 +109,8 @@ def test_paginator_loop():
 def test_paginator_page_number():
     """Validate paginator that uses the page number."""
 
-    class _TestPageNumberPaginator(BasePageNumberPaginator):
+    class _TestPageNumberPaginator(PageNumberPaginator):
+        @override
         def has_more(self, response: Response) -> bool:
             return response.json()["hasMore"]
 
@@ -130,10 +141,20 @@ def test_paginator_page_number():
     assert paginator.count == 3
 
 
+def test_paginator_page_number_deprecated():
+    """Validate that BasePageNumberPaginator is deprecated."""
+
+    with pytest.warns(
+        SingerSDKDeprecationWarning,
+        match="BasePageNumberPaginator is deprecated",
+    ):
+        BasePageNumberPaginator(0)
+
+
 def test_paginator_offset():
     """Validate paginator that uses the page offset."""
 
-    class _TestOffsetPaginator(BaseOffsetPaginator):
+    class _TestOffsetPaginator(OffsetPaginator):
         def __init__(
             self,
             start_value: int,
@@ -145,6 +166,7 @@ def test_paginator_offset():
             super().__init__(start_value, page_size, *args, **kwargs)
             self._records_jsonpath = records_jsonpath
 
+        @override
         def has_more(self, response: Response) -> bool:
             """Check if response has any records.
 
@@ -190,6 +212,16 @@ def test_paginator_offset():
     assert paginator.count == 3
 
 
+def test_paginator_offset_deprecated():
+    """Validate that BaseOffsetPaginator is deprecated."""
+
+    with pytest.warns(
+        SingerSDKDeprecationWarning,
+        match="BaseOffsetPaginator is deprecated",
+    ):
+        BaseOffsetPaginator(0, 2)
+
+
 def test_paginator_jsonpath():
     """Validate paginator that uses JSONPath."""
 
@@ -227,7 +259,7 @@ def test_paginator_header():
     assert paginator.current_value == "abc"
     assert paginator.count == 1
 
-    response.headers[key] = None
+    del response.headers[key]
     paginator.advance(response)
     assert paginator.finished
     assert paginator.count == 2
@@ -250,6 +282,7 @@ def test_paginator_header_links():
     )
     paginator.advance(response)
     assert not paginator.finished
+    assert isinstance(paginator.current_value, ParseResult)
     assert paginator.current_value.hostname == api_hostname
     assert paginator.current_value.path == resource_path
     assert paginator.current_value.query == "page=2&limit=100"
@@ -265,6 +298,7 @@ def test_paginator_header_links():
     )
     paginator.advance(response)
     assert not paginator.finished
+    assert isinstance(paginator.current_value, ParseResult)
     assert paginator.current_value.hostname == api_hostname
     assert paginator.current_value.path == resource_path
     assert paginator.current_value.query == "page=3&limit=100"
@@ -282,6 +316,7 @@ def test_paginator_custom_hateoas():
     """Validate paginator that uses HATEOAS links."""
 
     class _CustomHATEOASPaginator(BaseHATEOASPaginator):
+        @override
         def get_next_url(self, response: Response) -> str | None:
             """Get a parsed HATEOAS link for the next, if the response has one."""
 
@@ -315,6 +350,7 @@ def test_paginator_custom_hateoas():
     ).encode()
     paginator.advance(response)
     assert not paginator.finished
+    assert isinstance(paginator.current_value, ParseResult)
     assert paginator.current_value.path == resource_path
     assert paginator.current_value.query == "page=2&limit=100"
     assert paginator.count == 1
@@ -331,6 +367,7 @@ def test_paginator_custom_hateoas():
     ).encode()
     paginator.advance(response)
     assert not paginator.finished
+    assert isinstance(paginator.current_value, ParseResult)
     assert paginator.current_value.path == resource_path
     assert paginator.current_value.query == "page=3&limit=100"
     assert paginator.count == 2
@@ -351,27 +388,31 @@ def test_break_pagination(tap: Tap, caplog: pytest.LogCaptureFixture):
         records_jsonpath = "$.data[*]"
         schema = {"type": "object", "properties": {"id": {"type": "integer"}}}  # noqa: RUF012
 
-        def get_new_paginator(self) -> BasePageNumberPaginator:
-            return BasePageNumberPaginator(1)
+        @override
+        def get_new_paginator(self) -> PageNumberPaginator:
+            return PageNumberPaginator(1)
 
+        @override
         def get_url_params(
             self,
-            context: dict | None,  # noqa: ARG002
+            context: Context | None,
             next_page_token: int | None,
-        ) -> dict[str, t.Any] | str:
+        ) -> dict[str, t.Any] | str:  # ty:ignore[invalid-method-override]
             params = {}
             if next_page_token:
                 params["page"] = next_page_token
             return params
 
+        @override
         def _request(
             self,
             prepared_request: PreparedRequest,
-            context: dict | None,  # noqa: ARG002
+            context: Context | None,
         ) -> Response:
             r = Response()
             r.status_code = 200
 
+            assert isinstance(prepared_request.url, str)
             parsed = urlparse(prepared_request.url)
             query = parse_qs(parsed.query)
 
@@ -387,8 +428,7 @@ def test_break_pagination(tap: Tap, caplog: pytest.LogCaptureFixture):
             return r
 
     stream = MyAPIStream(tap=tap)
-
-    records_iter = stream.request_records(context=None)
+    records_iter = iter(stream.request_records(context=None))
 
     assert next(records_iter) == {"id": 1}
     assert next(records_iter) == {"id": 2}
@@ -406,11 +446,13 @@ def test_break_pagination(tap: Tap, caplog: pytest.LogCaptureFixture):
 
 
 def test_continue_if_empty(tap: Tap):
-    class _TestPaginator(BasePageNumberPaginator):
+    class _TestPaginator(PageNumberPaginator):
+        @override
         def has_more(self, response: Response) -> bool:
             return response.json().get("hasMore", False)
 
-        def continue_if_empty(self, response: Response) -> bool:  # noqa: ARG002
+        @override
+        def continue_if_empty(self, response: Response) -> bool:
             return True
 
     class MyAPIStream(RESTStream[int]):
@@ -422,27 +464,31 @@ def test_continue_if_empty(tap: Tap):
         records_jsonpath = "$.data[*]"
         schema = {"type": "object", "properties": {"id": {"type": "integer"}}}  # noqa: RUF012
 
-        def get_new_paginator(self) -> BasePageNumberPaginator:
+        @override
+        def get_new_paginator(self) -> _TestPaginator:
             return _TestPaginator(1)
 
+        @override
         def get_url_params(
             self,
-            context: dict | None,  # noqa: ARG002
+            context: Context | None,
             next_page_token: int | None,
-        ) -> dict[str, t.Any] | str:
+        ) -> dict[str, t.Any] | str:  # ty:ignore[invalid-method-override]
             params = {}
             if next_page_token:
                 params["page"] = next_page_token
             return params
 
+        @override
         def _request(
             self,
             prepared_request: PreparedRequest,
-            context: dict | None,  # noqa: ARG002
+            context: Context | None,
         ) -> Response:
             r = Response()
             r.status_code = 200
 
+            assert isinstance(prepared_request.url, str)
             parsed = urlparse(prepared_request.url)
             query = parse_qs(parsed.query)
 
@@ -464,7 +510,7 @@ def test_continue_if_empty(tap: Tap):
             return r
 
     stream = MyAPIStream(tap=tap)
-    records_iter = stream.request_records(context=None)
+    records_iter = iter(stream.request_records(context=None))
 
     assert next(records_iter) == {"id": 1}
     assert next(records_iter) == {"id": 2}
@@ -485,23 +531,26 @@ def test_no_paginator(tap: Tap):
         records_jsonpath = "$.data[*]"
         schema = {"type": "object", "properties": {"id": {"type": "integer"}}}  # noqa: RUF012
 
+        @override
         def get_new_paginator(self) -> None:
             return None
 
+        @override
         def get_url_params(
             self,
-            context: dict | None,  # noqa: ARG002
+            context: Context | None,
             next_page_token: None,
-        ) -> dict[str, t.Any] | str:
+        ) -> dict[str, t.Any] | str:  # ty:ignore[invalid-method-override]
             params = {}
             if next_page_token:
                 params["page"] = next_page_token
             return params
 
+        @override
         def _request(
             self,
-            prepared_request: PreparedRequest,  # noqa: ARG002
-            context: dict | None,  # noqa: ARG002
+            prepared_request: PreparedRequest,
+            context: Context | None,
         ) -> Response:
             r = Response()
             r.status_code = 200
@@ -510,7 +559,7 @@ def test_no_paginator(tap: Tap):
             return r
 
     stream = MyAPIStream(tap=tap)
-    records_iter = stream.request_records(context=None)
+    records_iter = iter(stream.request_records(context=None))
 
     assert next(records_iter) == {"id": 1}
     assert next(records_iter) == {"id": 2}


### PR DESCRIPTION
These were made "base" classes with the expectation that users would override them, but https://github.com/meltano/sdk/pull/1918 made that redundant.

## Related

- https://github.com/meltano/sdk/pull/1918
- https://github.com/meltano/sdk/pull/2989
- https://github.com/meltano/sdk/pull/3483

## Summary by Sourcery

Deprecate the base paginator classes in favor of concrete PageNumberPaginator and OffsetPaginator and update usages, tests, and docs accordingly.

New Features:
- Introduce PageNumberPaginator and OffsetPaginator as the primary paginator implementations for page-number and offset-based pagination.
- Add a shared singer_sdk_deprecated decorator helper preconfigured with the SDK's deprecation warning type.

Bug Fixes:
- Tighten paginator-related tests by asserting concrete types and cleaning up header handling in header-based pagination tests.

Enhancements:
- Mark BasePageNumberPaginator and BaseOffsetPaginator as deprecated wrappers around the new paginator classes, exposing page_size as a property on OffsetPaginator.
- Update REST stream examples, cookiecutter templates, and dummyjson tap client to use the new paginator classes and type hints, including explicit override annotations and typed Context usage.

Documentation:
- Revise pagination documentation and cookiecutter guidance to recommend PageNumberPaginator and OffsetPaginator, and add reference stubs for their API documentation.

Tests:
- Extend and adjust pagination tests to cover deprecation warnings for the base paginator classes and to use the new PageNumberPaginator and OffsetPaginator implementations.

## Summary by Sourcery

Deprecate legacy base pagination classes in favor of concrete page-number and offset paginator implementations and update usages, tests, and docs accordingly.

New Features:
- Introduce PageNumberPaginator and OffsetPaginator as the primary page-number and offset-based paginator implementations.
- Add a shared singer_sdk_deprecated helper preconfigured with the SDK's deprecation warning type for consistent deprecation messaging.

Bug Fixes:
- Tighten header-based and link-based pagination tests by asserting concrete types and correcting header handling edge cases.

Enhancements:
- Mark BasePageNumberPaginator and BaseOffsetPaginator as deprecated wrappers around the new paginator classes, exposing page_size as a property on OffsetPaginator.
- Update REST stream examples, cookiecutter templates, and the dummyjson tap client to use the new paginator classes, override annotations, and typed Context parameters.

Documentation:
- Revise pagination guides and cookiecutter documentation to recommend PageNumberPaginator and OffsetPaginator and add API reference stubs for their classes.

Tests:
- Extend pagination tests to cover deprecation warnings for the base paginator classes and to exercise the new concrete paginator implementations.