### PR TITLE
fix(templates): Remove legacy license classifier from project metadata (made redundant by PEP 639 metadata)

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -15,9 +15,6 @@ keywords = [
 ]
 classifiers = [
     "Intended Audience :: Developers",
-{%- if cookiecutter.license == "Apache-2.0" %}
-    "License :: OSI Approved :: Apache Software License",
-{%- endif %}
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -18,9 +18,6 @@ keywords = [
 ]
 classifiers = [
     "Intended Audience :: Developers",
-{%- if cookiecutter.license == "Apache-2.0" %}
-    "License :: OSI Approved :: Apache Software License",
-{%- endif %}
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -14,9 +14,6 @@ keywords = [
 ]
 classifiers = [
     "Intended Audience :: Developers",
-{%- if cookiecutter.license == "Apache-2.0" %}
-    "License :: OSI Approved :: Apache Software License",
-{%- endif %}
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
SSIA