### PR TITLE
feat(templates): Use dynamic versioning in tap, target and mapper templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   push:
+    tags: ["*"]
 
 concurrency:
   group: {{ '${{ github.workflow }}-${{ github.head_ref || github.run_id }}' }}
@@ -23,6 +24,8 @@ jobs:
       version: {{ '${{ steps.baipp.outputs.package_version }}' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
     - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
       id: baipp
 
@@ -36,7 +39,6 @@ jobs:
     # environment:
     #   name: pypi
     #   url: https://pypi.org/project/{{ '${{ needs.build.outputs.name }}' }}/{{ '${{ needs.build.outputs.version }}' }}
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
     - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
@@ -29,18 +29,27 @@ env:
   FORCE_COLOR: 1
 
 jobs:
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+    outputs:
+      supported-python-versions: {{ '${{ steps.baipp.outputs.supported_python_classifiers_json_array }}' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
+        id: baipp
+
   pytest:
-    name: Integration Tests / Python {{ '${{ matrix.python-version }}' }}
+    name: Integration
+    needs: [build-package]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-        - "3.10"
-        - "3.11"
-        - "3.12"
-        - "3.13"
-        - "3.14"
+        python-version: {{ '${{ fromJson(needs.build-package.outputs.supported-python-versions) }}' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python {{ '${{ matrix.python-version }}' }}
@@ -64,8 +73,6 @@ jobs:
         python-version: 3.x
     - name: Setup uv
       uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
-      with:
-        version: ">=0.10"
     - name: Run Tox
       run: |
         uvx --with=tox-uv tox -e typing

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -1,3 +1,10 @@
+[build-system]
+requires = [
+    "hatchling>=1,<2",
+    "hatch-vcs>=0.5",
+]
+build-backend = "hatchling.build"
+
 [project]
 {%- if cookiecutter.variant != "None (Skip)" %}
 name = "{{cookiecutter.variant}}-{{cookiecutter.mapper_id}}"
@@ -57,8 +64,8 @@ test = [
     "singer-sdk[testing]",
 ]
 typing = [
-    "mypy>=1.16.0",
-    "ty>=0.0.15",
+    "mypy>=1.19.1",
+    "ty>=0.0.18",
 ]
 
 {%- if cookiecutter.variant != "None (Skip)" %}
@@ -67,6 +74,10 @@ packages = [
     "{{cookiecutter.library_name}}",
 ]
 {%- endif %}
+
+[tool.hatch.version]
+fallback-version = "0.1.0.dev0"
+source = "vcs"
 
 [tool.pytest]
 addopts = [
@@ -117,26 +128,18 @@ allow-star-arg-any = true
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[build-system]
-requires = [
-    "hatchling>=1,<2",
-]
-build-backend = "hatchling.build"
-
 # This configuration can be used to customize tox environments
 [tool.tox]
-min_version = "4.32"
+min_version = "4.43"
 requires = [
-    "tox>=4.32",
+    "tox>=4.43",
     "tox-uv",
 ]
 env_list = [
     "typing",
-    "py314",
-    "py313",
-    "py312",
-    "py311",
-    "py310",
+    { product = [
+        { prefix = "3.", start = 10 },
+    ] },
 ]
 
 [tool.tox.env_run_base]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   push:
+    tags: ["*"]
 
 concurrency:
   group: {{ '${{ github.workflow }}-${{ github.head_ref || github.run_id }}' }}
@@ -23,6 +24,8 @@ jobs:
       version: {{ '${{ steps.baipp.outputs.package_version }}' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
     - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
       id: baipp
 
@@ -36,7 +39,6 @@ jobs:
     # environment:
     #   name: pypi
     #   url: https://pypi.org/project/{{ '${{ needs.build.outputs.name }}' }}/{{ '${{ needs.build.outputs.version }}' }}
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
     - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
@@ -29,18 +29,27 @@ env:
   FORCE_COLOR: 1
 
 jobs:
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+    outputs:
+      supported-python-versions: {{ '${{ steps.baipp.outputs.supported_python_classifiers_json_array }}' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
+        id: baipp
+
   pytest:
-    name: Integration Tests / Python {{ '${{ matrix.python-version }}' }}
+    name: Integration
+    needs: [build-package]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-        - "3.10"
-        - "3.11"
-        - "3.12"
-        - "3.13"
-        - "3.14"
+        python-version: {{ '${{ fromJson(needs.build-package.outputs.supported-python-versions) }}' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python {{ '${{ matrix.python-version }}' }}
@@ -64,8 +73,6 @@ jobs:
         python-version: 3.x
     - name: Setup uv
       uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
-      with:
-        version: ">=0.10"
     - name: Run Tox
       run: |
         uvx --with=tox-uv tox -e typing

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -2,6 +2,13 @@
 {%- if cookiecutter.faker_extra -%}{%- set extras = extras + ["faker"] -%}{%- endif -%}
 {%- if cookiecutter.auth_method == "JWT" -%}{%- set extras = extras + ["jwt"] -%}{%- endif -%}
 
+[build-system]
+requires = [
+    "hatchling>=1,<2",
+    "hatch-vcs>=0.5",
+]
+build-backend = "hatchling.build"
+
 [project]
 {%- if cookiecutter.variant != "None (Skip)" %}
 name = "{{cookiecutter.variant}}-{{cookiecutter.tap_id}}"
@@ -66,8 +73,8 @@ test = [
     "singer-sdk[testing]",
 ]
 typing = [
-    "mypy>=1.16.0",
-    "ty>=0.0.15",
+    "mypy>=1.19.1",
+    "ty>=0.0.18",
     {%- if cookiecutter.stream_type == "SQL" %}
     "sqlalchemy-stubs",
     {%- else %}
@@ -81,6 +88,10 @@ packages = [
     "{{cookiecutter.library_name}}",
 ]
 {%- endif %}
+
+[tool.hatch.version]
+fallback-version = "0.1.0.dev0"
+source = "vcs"
 
 [tool.pytest]
 addopts = [
@@ -131,26 +142,18 @@ allow-star-arg-any = true
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[build-system]
-requires = [
-    "hatchling>=1,<2",
-]
-build-backend = "hatchling.build"
-
 # This configuration can be used to customize tox environments
 [tool.tox]
-min_version = "4.32"
+min_version = "4.43"
 requires = [
-    "tox>=4.32",
+    "tox>=4.43",
     "tox-uv",
 ]
 env_list = [
     "typing",
-    "py314",
-    "py313",
-    "py312",
-    "py311",
-    "py310",
+    { product = [
+        { prefix = "3.", start = 10 },
+    ] },
 ]
 
 [tool.tox.env_run_base]

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   push:
+    tags: ["*"]
 
 concurrency:
   group: {{ '${{ github.workflow }}-${{ github.head_ref || github.run_id }}' }}
@@ -23,6 +24,8 @@ jobs:
       version: {{ '${{ steps.baipp.outputs.package_version }}' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
     - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
       id: baipp
 
@@ -36,7 +39,6 @@ jobs:
     # environment:
     #   name: pypi
     #   url: https://pypi.org/project/{{ '${{ needs.build.outputs.name }}' }}/{{ '${{ needs.build.outputs.version }}' }}
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
     - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
@@ -29,18 +29,27 @@ env:
   FORCE_COLOR: 1
 
 jobs:
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+    outputs:
+      supported-python-versions: {{ '${{ steps.baipp.outputs.supported_python_classifiers_json_array }}' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
+        id: baipp
+
   pytest:
-    name: Integration Tests / Python {{ '${{ matrix.python-version }}' }}
+    name: Integration
+    needs: [build-package]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-        - "3.10"
-        - "3.11"
-        - "3.12"
-        - "3.13"
-        - "3.14"
+        python-version: {{ '${{ fromJson(needs.build-package.outputs.supported-python-versions) }}' }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python {{ '${{ matrix.python-version }}' }}
@@ -64,8 +73,6 @@ jobs:
         python-version: 3.x
     - name: Setup uv
       uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
-      with:
-        version: ">=0.10"
     - name: Run Tox
       run: |
         uvx --with=tox-uv tox -e typing

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -1,3 +1,10 @@
+[build-system]
+requires = [
+    "hatchling>=1,<2",
+    "hatch-vcs>=0.5",
+]
+build-backend = "hatchling.build"
+
 [project]
 {%- if cookiecutter.variant != "None (Skip)" %}
 name = "{{cookiecutter.variant}}-{{cookiecutter.target_id}}"
@@ -61,8 +68,8 @@ test = [
     "singer-sdk[testing]",
 ]
 typing = [
-    "mypy>=1.16.0",
-    "ty>=0.0.15",
+    "mypy>=1.19.1",
+    "ty>=0.0.18",
     {%- if cookiecutter.serialization_method == "SQL" %}
     "sqlalchemy-stubs",
     {%- else %}
@@ -76,6 +83,10 @@ packages = [
     "{{cookiecutter.library_name}}",
 ]
 {%- endif %}
+
+[tool.hatch.version]
+fallback-version = "0.1.0.dev0"
+source = "vcs"
 
 [tool.pytest]
 addopts = [
@@ -126,26 +137,18 @@ allow-star-arg-any = true
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[build-system]
-requires = [
-    "hatchling>=1,<2",
-]
-build-backend = "hatchling.build"
-
 # This configuration can be used to customize tox environments
 [tool.tox]
-min_version = "4.32"
+min_version = "4.43"
 requires = [
-    "tox>=4.32",
+    "tox>=4.43",
     "tox-uv",
 ]
 env_list = [
     "typing",
-    "py314",
-    "py313",
-    "py312",
-    "py311",
-    "py310",
+    { product = [
+        { prefix = "3.", start = 10 },
+    ] },
 ]
 
 [tool.tox.env_run_base]

--- a/noxfile.py
+++ b/noxfile.py
@@ -489,6 +489,7 @@ def templates(session: nox.Session, replay_file_path: Path) -> None:
     session.run("git", "init", "-b", "main", external=True)
     session.run("git", "add", "-A", external=True)
     session.run("uvx", "prek", "run", "--all-files")
+    session.run("uvx", "--with=tox-uv", "tox", "-l")
     session.run("uvx", "--with=tox-uv", "tox", "-e=typing")
 
 


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Adopt VCS-driven dynamic versioning and classifier-based Python matrix generation across tap, target, and mapper templates, while modernizing tooling and CI workflows.

New Features:
- Enable VCS-based dynamic package versioning for tap, target, and mapper cookiecutter templates via hatch-vcs.
- Derive CI test Python version matrices from built package classifiers instead of hardcoding versions.

Enhancements:
- Upgrade typing-related development dependencies (mypy and ty) in all cookiecutter templates.
- Update tox configuration to newer versions and use product-based Python environment definitions in generated projects.
- Extend the templates nox session to list tox environments before running typing checks.

CI:
- Introduce a build-and-inspect job in template test workflows to build packages and export supported Python versions for downstream matrix tests.
- Adjust test workflow job naming and dependency ordering to run integration tests against the dynamically detected Python versions.
- Modify release workflows in templates to build from full git history and trigger on tag pushes while simplifying the publish job condition.