### PR TITLE
fix(templates): Remove references to legacy `user_agent` setting

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.env.example
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.env.example
@@ -12,9 +12,3 @@
 
 # Optional: API URL (defaults to https://api.mysample.com)
 {{ cookiecutter.tap_id.upper().replace('-', '_') }}_API_URL=https://api.mysample.com
-
-{%- if cookiecutter.stream_type in ("GraphQL", "REST") %}
-
-# Optional: Custom User-Agent header
-{{ cookiecutter.tap_id.upper().replace('-', '_') }}_USER_AGENT={{ cookiecutter.tap_id }}/1.0.0
-{%- endif %}

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/AGENTS.md
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/AGENTS.md
@@ -211,7 +211,6 @@ config_jsonschema = th.PropertiesList(
     th.Property("api_url", th.StringType, required=True),
     th.Property("api_key", th.StringType, required=True, secret=True),
     th.Property("start_date", th.DateTimeType),
-    th.Property("user_agent", th.StringType, default="tap-mysource"),
 ).to_dict()
 ```
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/non-sql-tap.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/non-sql-tap.py
@@ -50,16 +50,6 @@ class Tap{{ cookiecutter.source_name }}(Tap):
             default="https://api.mysample.com",
             description="The url for the API service",
         ),
-        {%- if cookiecutter.stream_type in ("GraphQL", "REST") %}
-        th.Property(
-            "user_agent",
-            th.StringType(nullable=True),
-            description=(
-                "A custom User-Agent header to send with each request. Default is "
-                "'<tap_name>/<tap_version>'"
-            ),
-        ),
-        {%- endif %}
     ).to_dict()
 
     @override


### PR DESCRIPTION
## Summary by Sourcery

Remove legacy user_agent configuration from the tap cookiecutter templates and associated documentation.

Bug Fixes:
- Eliminate outdated user_agent config option from generated taps to prevent use of deprecated settings.

Enhancements:
- Align tap template configuration schema and docs with current recommended settings by dropping the user_agent field.