### PR TITLE
refactor: Consolidate exception definitions into the `singer_sdk.exceptions` module

### DIFF
--- a/docs/implementation/errors/design.md
+++ b/docs/implementation/errors/design.md
@@ -4,8 +4,9 @@ This document specifies the design of a clean, hierarchical exception taxonomy f
 the Meltano Singer SDK. It covers the pre-Phase-1 state, design principles, the
 implemented hierarchy, recovery semantics, and a phased implementation roadmap.
 
-**Implementation status:** Phase 1 (hierarchy scaffold) is complete. See §7 for the
-full roadmap and the status of each phase.
+**Implementation status:** Phase 1 (hierarchy scaffold) and Phase 2 (consolidate
+scattered exceptions) are complete. See §7 for the full roadmap and the status of
+each phase.
 
 ______________________________________________________________________
 
@@ -85,22 +86,24 @@ ______________________________________________________________________
 
 ## 3. Implemented Hierarchy
 
-### 3.1 Annotated tree (Phase 1)
+### 3.1 Annotated tree (Phases 1 + 2)
 
-The tree below reflects the hierarchy as implemented. Nodes marked *(Phase 2+)* are
-migration candidates that will be wired in once they are moved into
-`singer_sdk/exceptions.py`. Names with the `Exception` suffix are preserved from the
-original codebase; `Error`-suffixed aliases may be introduced in a later phase (§7).
+The tree below reflects the hierarchy as implemented after Phase 2. Names with the
+`Exception` suffix are preserved from the original codebase; `Error`-suffixed aliases
+may be introduced in a later phase (§7).
 
 ```
 SingerSDKError                             ← base for everything SDK-specific
 ├── ConfigurationError                     ← invalid/missing plugin configuration
-│   └── ConfigValidationError              ← JSON Schema validation failed
+│   ├── ConfigValidationError              ← JSON Schema validation failed
+│   └── MapperNotInitialized               ← mapper not set up before use
 ├── DiscoveryError                         ← schema catalog discovery
+│   ├── EmptySchemaTypeError               ← type detection on empty schema dict
 │   ├── InvalidReplicationKeyException     ← replication key not in schema properties
-│   ├── SchemaNotFoundError                ← (Phase 2+, currently in schema/source.py)
-│   ├── SchemaNotValidError                ← (Phase 2+, currently in schema/source.py)
-│   └── UnsupportedSchemaFormatError       ← (Phase 2+, currently in schema/source.py)
+│   ├── SchemaNotFoundError                ← schema component could not be found
+│   ├── SchemaNotValidError                ← schema is not a valid JSON object
+│   └── UnsupportedSchemaFormatError       ← schema source format not supported
+│       (alias: UnsupportedOpenAPISpec)
 ├── MappingError                           ← stream map configuration/evaluation
 │   ├── ConformedNameClashException        ← two columns conform to the same name
 │   ├── MapExpressionError                 ← jinja/eval expression failed
@@ -116,7 +119,7 @@ SingerSDKError                             ← base for everything SDK-specific
 │   ├── RetriableSyncError                 ← retry with exponential backoff
 │   │   └── RetriableAPIError              ← retriable HTTP/API error
 │   ├── IgnorableSyncError                 ← log + skip current record/page, continue
-│   │   ├── IgnorableAPIError              ← expected non-fatal API response (NEW)
+│   │   ├── IgnorableAPIError              ← expected non-fatal API response
 │   │   └── InvalidRecord                  ← record fails schema validation
 │   └── DataError                          ← data quality / schema violations
 │       └── InvalidJSONSchema              ← malformed JSON Schema
@@ -128,19 +131,27 @@ SingerSDKError                             ← base for everything SDK-specific
         └── AbortedSyncPausedException     ← stopped with resumable state artifact
 ```
 
-### 3.2 Phase 2+ migration candidates
+### 3.2 Singer-protocol hierarchy (singerlib — intentionally separate)
 
-The following exceptions are defined outside `singer_sdk/exceptions.py` and are not
-yet placed in the hierarchy. `InvalidInputLine` is already re-exported from
-`singer_sdk/exceptions.py` (and included in `__all__`) but has not yet been moved or
-re-based. The rest will be migrated in Phase 2:
+`singer_sdk/singerlib/exceptions.py` maintains its own lightweight hierarchy for
+exceptions that belong to the Singer *protocol* layer rather than the SDK layer.
+These are **not** subclasses of `SingerSDKError` and are intentionally kept
+separate to reflect the layered architecture:
 
-| Current location | Class | Proposed placement |
-|---|---|---|
-| `singerlib/exceptions.py` | `InvalidInputLine` | `SyncError` → `FatalSyncError` |
-| `schema/source.py` | `UnsupportedOpenAPISpec` | `DiscoveryError` → `UnsupportedSchemaFormatError` |
-| `helpers/_typing.py` | `EmptySchemaTypeError` | `DiscoveryError` (schema introspection) |
-| `plugin_base.py` | `MapperNotInitialized` | `ConfigurationError` |
+```
+SingerError                    ← root for all Singer protocol exceptions
+└── SingerReadError            ← errors while reading a Singer message stream
+    └── InvalidInputLine       ← an input line is not a valid Singer message
+```
+
+`InvalidInputLine` was deliberately **not** migrated into `singer_sdk/exceptions.py`
+in Phase 2. It lives at the Singer protocol level and is raised deep in the message
+parsing stack before the SDK's sync machinery takes over.
+
+### 3.3 Phase 3+ migration candidates
+
+All originally scattered exceptions have been consolidated. No further migrations are
+planned at this time.
 
 ______________________________________________________________________
 
@@ -302,15 +313,25 @@ ______________________________________________________________________
 - Added `tests/core/test_exceptions.py` with 80 hierarchy assertions
 - No behavior changes; all existing tests pass unchanged
 
-### PR 2 — Consolidate scattered exceptions
+### PR 2 — Consolidate scattered exceptions ✅ Complete
 
 **Files:** `singer_sdk/exceptions.py`, `singerlib/exceptions.py`,
-`schema/source.py`, `helpers/_typing.py`, `plugin_base.py`
+`schema/source.py`, `helpers/_typing.py`, `plugin_base.py`,
+`tests/core/test_exceptions.py`
 
-- Move `InvalidInputLine`, `UnsupportedOpenAPISpec`, `EmptySchemaTypeError`,
-  `MapperNotInitialized` into `singer_sdk/exceptions.py`
-- Keep re-exports in original files for one release cycle (with `# noqa: F401`)
-- Wire migrated exceptions into the hierarchy
+- Moved `UnsupportedOpenAPISpec` → `UnsupportedSchemaFormatError(DiscoveryError)`;
+  old name kept as a module-level alias for backward compatibility
+- Moved `EmptySchemaTypeError` → `DiscoveryError` subclass
+- Moved `MapperNotInitialized` → `ConfigurationError` subclass
+- Moved `SchemaNotFoundError` and `SchemaNotValidError` (already `DiscoveryError`
+  subclasses in `schema/source.py`) into `singer_sdk/exceptions.py`
+- Re-exports remain in original files for one release cycle (`# noqa: F401`)
+- **`InvalidInputLine` intentionally not migrated**: kept in `singerlib/exceptions.py`
+  under its own Singer-protocol hierarchy (`SingerError → SingerReadError → InvalidInputLine`); see §3.2
+- `singerlib/exceptions.py` expanded with `SingerError` and `SingerReadError` root
+  classes to make the protocol layer hierarchy explicit
+- Added `TestPhase2Migrations` and `TestSingerlibHierarchy` in
+  `tests/core/test_exceptions.py` (89 assertions total)
 
 ### PR 3 — `IgnorableAPIError` handling in REST stream
 

--- a/docs/implementation/errors/hierarchy.md
+++ b/docs/implementation/errors/hierarchy.md
@@ -4,14 +4,19 @@ The Singer SDK defines a structured exception hierarchy rooted at `SingerSDKErro
 Every exception raised by the SDK is a subclass of this root, so you can always catch
 all SDK-level errors with a single `except SingerSDKError` clause.
 
-## Full hierarchy
+## SDK hierarchy (`singer_sdk.exceptions`)
 
 ```
 SingerSDKError
 ├── ConfigurationError
-│   └── ConfigValidationError
+│   ├── ConfigValidationError
+│   └── MapperNotInitialized
 ├── DiscoveryError
-│   └── InvalidReplicationKeyException
+│   ├── EmptySchemaTypeError
+│   ├── InvalidReplicationKeyException
+│   ├── SchemaNotFoundError
+│   ├── SchemaNotValidError
+│   └── UnsupportedSchemaFormatError  (alias: UnsupportedOpenAPISpec)
 ├── MappingError
 │   ├── ConformedNameClashException
 │   ├── MapExpressionError
@@ -41,6 +46,20 @@ SingerSDKError
 
 All of these names can be imported from `singer_sdk.exceptions`.
 
+## Singer-protocol hierarchy (`singer_sdk.singerlib.exceptions`)
+
+A separate, lighter hierarchy covers exceptions that belong to the Singer *protocol*
+layer — raised during message parsing before the SDK's sync machinery is involved.
+These are **not** subclasses of `SingerSDKError`.
+
+```
+SingerError
+└── SingerReadError
+    └── InvalidInputLine
+```
+
+Import these from `singer_sdk.singerlib.exceptions`.
+
 ______________________________________________________________________
 
 ## Exception groups
@@ -53,6 +72,7 @@ required values.
 | Class | When raised |
 |---|---|
 | `ConfigValidationError` | The config dict fails JSON Schema validation. Carries `.errors` (list of messages) and `.schema` (the schema that was checked). |
+| `MapperNotInitialized` | `setup_mapper()` was not called before the mapper was accessed. |
 
 **Tap developers** — you do not normally raise these directly. The SDK raises
 `ConfigValidationError` automatically when `Tap.config_jsonschema` validation fails.
@@ -66,7 +86,11 @@ Raised during catalog discovery (the `--discover` run) before any records are sy
 | Class | When raised |
 |---|---|
 | `DiscoveryError` | Generic discovery failure; subclass for specific cases. |
+| `EmptySchemaTypeError` | Type detection was attempted on an empty schema dict (likely a missing property definition). |
 | `InvalidReplicationKeyException` | The stream's `replication_key` is not present in the stream's schema properties. |
+| `SchemaNotFoundError` | A schema component could not be found in the schema source. |
+| `SchemaNotValidError` | A fetched schema is not a valid JSON object. |
+| `UnsupportedSchemaFormatError` | The schema source file format is not supported. Also available as `UnsupportedOpenAPISpec` for backward compatibility. |
 
 ______________________________________________________________________
 

--- a/singer_sdk/exceptions.py
+++ b/singer_sdk/exceptions.py
@@ -16,9 +16,15 @@ __all__ = [  # noqa: RUF022
     # Configuration
     "ConfigurationError",
     "ConfigValidationError",
+    "MapperNotInitialized",
     # Discovery
     "DiscoveryError",
+    "EmptySchemaTypeError",
     "InvalidReplicationKeyException",
+    "SchemaNotFoundError",
+    "SchemaNotValidError",
+    "UnsupportedOpenAPISpec",
+    "UnsupportedSchemaFormatError",
     # Mapping
     "MappingError",
     "ConformedNameClashException",
@@ -96,6 +102,14 @@ class ConfigValidationError(ConfigurationError):
         self.schema: dict | None = schema
 
 
+class MapperNotInitialized(ConfigurationError):
+    """Raised when the mapper is not initialized."""
+
+    def __init__(self) -> None:
+        """Initialize the exception."""
+        super().__init__("Mapper not initialized. Please call setup_mapper() first.")
+
+
 # ---------------------------------------------------------------------------
 # Discovery
 # ---------------------------------------------------------------------------
@@ -105,8 +119,36 @@ class DiscoveryError(SingerSDKError):
     """Raised when a schema discovery error occurs."""
 
 
+class EmptySchemaTypeError(DiscoveryError):
+    """Exception for when trying to detect type from empty type_dict."""
+
+    def __init__(self, *args: object) -> None:
+        """Initialize the exception."""
+        msg = (
+            "Could not detect type from empty type_dict. "
+            "Did you forget to define a property in the stream schema?"
+        )
+        super().__init__(msg, *args)
+
+
 class InvalidReplicationKeyException(DiscoveryError):
     """Exception to raise if the replication key is not in the stream properties."""
+
+
+class SchemaNotFoundError(DiscoveryError):
+    """Raised when a schema is not found."""
+
+
+class SchemaNotValidError(DiscoveryError):
+    """Raised when a schema is not valid."""
+
+
+class UnsupportedSchemaFormatError(DiscoveryError):
+    """Raised when the schema source format is not supported."""
+
+
+# Backward-compatible alias (previously UnsupportedOpenAPISpec in schema/source.py)
+UnsupportedOpenAPISpec = UnsupportedSchemaFormatError
 
 
 # ---------------------------------------------------------------------------

--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -12,6 +12,8 @@ import uuid
 from enum import Enum
 from functools import lru_cache
 
+from singer_sdk.exceptions import EmptySchemaTypeError
+
 _MAX_TIMESTAMP = "9999-12-31 23:59:59.999999"
 _MAX_TIME = "23:59:59.999999"
 JSONSCHEMA_ANNOTATION_SECRET = "secret"  # noqa: S105
@@ -27,17 +29,6 @@ class DatetimeErrorTreatmentEnum(Enum):
     ERROR = "error"
     MAX = "max"
     NULL = "null"
-
-
-class EmptySchemaTypeError(Exception):
-    """Exception for when trying to detect type from empty type_dict."""
-
-    def __init__(self, *args: object) -> None:
-        msg = (
-            "Could not detect type from empty type_dict. Did you forget to define a "
-            "property in the stream schema?"
-        )
-        super().__init__(msg, *args)
 
 
 def to_json_compatible(val: t.Any) -> t.Any:  # noqa: ANN401

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -25,7 +25,7 @@ from singer_sdk.configuration._dict_config import (
     merge_missing_config_jsonschema,
     parse_environment_config,
 )
-from singer_sdk.exceptions import ConfigValidationError
+from singer_sdk.exceptions import ConfigValidationError, MapperNotInitialized
 from singer_sdk.helpers._classproperty import classproperty
 from singer_sdk.helpers._compat import SingerSDKDeprecationWarning, deprecated
 from singer_sdk.helpers._packaging import SDK_PACKAGE_NAME, get_package_version
@@ -57,14 +57,6 @@ if t.TYPE_CHECKING:
 DEFAULT_LOG_LEVEL = "INFO"
 
 JSONSchemaValidator = extend_validator_with_defaults(DEFAULT_JSONSCHEMA_VALIDATOR)
-
-
-class MapperNotInitialized(Exception):
-    """Raised when the mapper is not initialized."""
-
-    def __init__(self) -> None:
-        """Initialize the exception."""
-        super().__init__("Mapper not initialized. Please call setup_mapper() first.")
 
 
 @dataclasses.dataclass

--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -15,7 +15,13 @@ from urllib.parse import urlparse
 
 import requests
 
-from singer_sdk.exceptions import DiscoveryError
+from singer_sdk.exceptions import (  # noqa: F401
+    DiscoveryError,
+    SchemaNotFoundError,
+    SchemaNotValidError,
+    UnsupportedOpenAPISpec,
+    UnsupportedSchemaFormatError,
+)
 from singer_sdk.singerlib.schema import resolve_schema_references
 
 if sys.version_info >= (3, 11):
@@ -41,18 +47,6 @@ if t.TYPE_CHECKING:
 
 
 Schema: t.TypeAlias = dict[str, t.Any]
-
-
-class SchemaNotFoundError(DiscoveryError):
-    """Raised when a schema is not found."""
-
-
-class SchemaNotValidError(DiscoveryError):
-    """Raised when a schema is not valid."""
-
-
-class UnsupportedOpenAPISpec(Exception):
-    """Raised when the OpenAPI specification is not supported."""
 
 
 _TKey = TypeVar("_TKey", bound=t.Hashable, default=str)

--- a/singer_sdk/singerlib/exceptions.py
+++ b/singer_sdk/singerlib/exceptions.py
@@ -4,8 +4,18 @@ from __future__ import annotations
 
 __all__ = [
     "InvalidInputLine",
+    "SingerError",
+    "SingerReadError",
 ]
 
 
-class InvalidInputLine(Exception):
+class SingerError(Exception):
+    """Root base class for all Singer exceptions."""
+
+
+class SingerReadError(SingerError):
+    """Root base class for all Singer read errors."""
+
+
+class InvalidInputLine(SingerReadError):
     """Raised when an input line is not a valid Singer message."""

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import abc
 
-import pytest
-
 import singer_sdk.exceptions as exc
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+from singer_sdk.singerlib.exceptions import (
+    InvalidInputLine,
+    SingerError,
+    SingerReadError,
+)
 
 
 def assert_hierarchy(*chain: type) -> None:
@@ -23,56 +22,7 @@ def assert_hierarchy(*chain: type) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Root
-# ---------------------------------------------------------------------------
-
-
-class TestRoot:
-    def test_singer_sdk_error_is_exception(self) -> None:
-        assert issubclass(exc.SingerSDKError, Exception)
-
-
-# ---------------------------------------------------------------------------
-# Every existing exception is still an Exception and now a SingerSDKError
-# ---------------------------------------------------------------------------
-
-
-EXISTING_EXCEPTIONS = [
-    exc.ConfigValidationError,
-    exc.DiscoveryError,
-    exc.FatalAPIError,
-    exc.InvalidReplicationKeyException,
-    exc.InvalidStreamSortException,
-    exc.MapExpressionError,
-    exc.RequestedAbortException,
-    exc.MaxRecordsLimitException,
-    exc.AbortedSyncExceptionBase,
-    exc.AbortedSyncFailedException,
-    exc.AbortedSyncPausedException,
-    exc.RecordsWithoutSchemaException,
-    exc.RetriableAPIError,
-    exc.StreamMapConfigError,
-    exc.TapStreamConnectionFailure,
-    exc.TooManyRecordsException,
-    exc.ConformedNameClashException,
-    exc.MissingKeyPropertiesError,
-    exc.InvalidJSONSchema,
-    exc.InvalidRecord,
-]
-
-
-@pytest.mark.parametrize("cls", EXISTING_EXCEPTIONS, ids=lambda c: c.__name__)
-def test_existing_still_exception(cls: type) -> None:
-    assert issubclass(cls, Exception)
-
-
-@pytest.mark.parametrize("cls", EXISTING_EXCEPTIONS, ids=lambda c: c.__name__)
-def test_existing_now_singer_sdk_error(cls: type) -> None:
-    assert issubclass(cls, exc.SingerSDKError)
-
-
-# ---------------------------------------------------------------------------
-# Configuration group
+# Configuration
 # ---------------------------------------------------------------------------
 
 
@@ -88,7 +38,7 @@ class TestConfigurationGroup:
             exc.ConfigValidationError,
         )
 
-    def test_config_validation_error_preserves_init(self) -> None:
+    def test_config_validation_error_init(self) -> None:
         err = exc.ConfigValidationError(
             "bad config", errors=["e1"], schema={"type": "object"}
         )
@@ -101,9 +51,22 @@ class TestConfigurationGroup:
         assert err.errors == []
         assert err.schema is None
 
+    def test_mapper_not_initialized_chain(self) -> None:
+        assert_hierarchy(
+            Exception,
+            exc.SingerSDKError,
+            exc.ConfigurationError,
+            exc.MapperNotInitialized,
+        )
+
+    def test_mapper_not_initialized_message(self) -> None:
+        err = exc.MapperNotInitialized()
+        assert "Mapper not initialized" in str(err)
+        assert "setup_mapper()" in str(err)
+
 
 # ---------------------------------------------------------------------------
-# Discovery group
+# Discovery
 # ---------------------------------------------------------------------------
 
 
@@ -119,9 +82,49 @@ class TestDiscoveryGroup:
             exc.InvalidReplicationKeyException,
         )
 
+    def test_empty_schema_type_error_chain(self) -> None:
+        assert_hierarchy(
+            Exception,
+            exc.SingerSDKError,
+            exc.DiscoveryError,
+            exc.EmptySchemaTypeError,
+        )
+
+    def test_empty_schema_type_error_message(self) -> None:
+        err = exc.EmptySchemaTypeError()
+        assert "Could not detect type from empty type_dict" in str(err)
+        assert "Did you forget to define a property in the stream schema?" in str(err)
+
+    def test_schema_not_found_error_chain(self) -> None:
+        assert_hierarchy(
+            Exception,
+            exc.SingerSDKError,
+            exc.DiscoveryError,
+            exc.SchemaNotFoundError,
+        )
+
+    def test_schema_not_valid_error_chain(self) -> None:
+        assert_hierarchy(
+            Exception,
+            exc.SingerSDKError,
+            exc.DiscoveryError,
+            exc.SchemaNotValidError,
+        )
+
+    def test_unsupported_schema_format_error_chain(self) -> None:
+        assert_hierarchy(
+            Exception,
+            exc.SingerSDKError,
+            exc.DiscoveryError,
+            exc.UnsupportedSchemaFormatError,
+        )
+
+    def test_unsupported_open_api_spec_is_alias(self) -> None:
+        assert exc.UnsupportedOpenAPISpec is exc.UnsupportedSchemaFormatError
+
 
 # ---------------------------------------------------------------------------
-# Mapping group
+# Mapping
 # ---------------------------------------------------------------------------
 
 
@@ -146,16 +149,6 @@ class TestMappingGroup:
             exc.MappingError,
             exc.ConformedNameClashException,
         )
-
-
-# ---------------------------------------------------------------------------
-# Sync — base
-# ---------------------------------------------------------------------------
-
-
-class TestSyncBase:
-    def test_sync_error_chain(self) -> None:
-        assert_hierarchy(Exception, exc.SingerSDKError, exc.SyncError)
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +237,7 @@ class TestRetriableSync:
             exc.RetriableAPIError,
         )
 
-    def test_retriable_api_error_preserves_init(self) -> None:
+    def test_retriable_api_error_init(self) -> None:
         err = exc.RetriableAPIError("retry me", response=None)
         assert str(err) == "retry me"
         assert err.response is None
@@ -270,11 +263,6 @@ class TestIgnorableSync:
             exc.IgnorableAPIError,
         )
 
-    def test_ignorable_api_error_is_leaf(self) -> None:
-        """IgnorableAPIError should be directly instantiable (no abstract methods)."""
-        err = exc.IgnorableAPIError("skipping this one")
-        assert str(err) == "skipping this one"
-
     def test_invalid_record_chain(self) -> None:
         assert_hierarchy(
             Exception,
@@ -284,7 +272,7 @@ class TestIgnorableSync:
             exc.InvalidRecord,
         )
 
-    def test_invalid_record_preserves_init(self) -> None:
+    def test_invalid_record_init(self) -> None:
         record = {"id": 1}
         err = exc.InvalidRecord("missing field", record)
         assert "missing field" in str(err)
@@ -371,33 +359,13 @@ class TestLifecycleSignals:
 
 
 # ---------------------------------------------------------------------------
-# __all__ completeness
+# Singerlib Singer-protocol hierarchy (intentionally separate from SDK hierarchy)
 # ---------------------------------------------------------------------------
 
 
-class TestAll:
-    def test_all_defined(self) -> None:
-        assert hasattr(exc, "__all__")
+class TestSingerlibHierarchy:
+    def test_singerlib_hierarchy(self) -> None:
+        assert_hierarchy(Exception, SingerError, SingerReadError, InvalidInputLine)
 
-    def test_new_classes_in_all(self) -> None:
-        new_classes = [
-            "SingerSDKError",
-            "ConfigurationError",
-            "MappingError",
-            "SyncError",
-            "FatalSyncError",
-            "RetriableSyncError",
-            "IgnorableSyncError",
-            "IgnorableAPIError",
-            "DataError",
-            "SyncLifecycleSignal",
-        ]
-        for name in new_classes:
-            assert name in exc.__all__, f"{name} missing from __all__"
-
-    def test_existing_classes_in_all(self) -> None:
-        for cls in EXISTING_EXCEPTIONS:
-            assert cls.__name__ in exc.__all__, f"{cls.__name__} missing from __all__"
-
-    def test_invalid_input_line_in_all(self) -> None:
-        assert "InvalidInputLine" in exc.__all__
+    def test_singerlib_not_in_sdk_hierarchy(self) -> None:
+        assert not issubclass(InvalidInputLine, exc.SingerSDKError)


### PR DESCRIPTION
## Links

## Summary by Sourcery

Consolidate and document the exception hierarchies for the SDK and Singer protocol layers while centralizing scattered exceptions into `singer_sdk.exceptions` and clarifying their usage.

Enhancements:
- Move discovery- and configuration-related exceptions (`MapperNotInitialized`, `EmptySchemaTypeError`, `SchemaNotFoundError`, `SchemaNotValidError`, `UnsupportedSchemaFormatError`) into the unified `singer_sdk.exceptions` hierarchy and expose a backward-compatible `UnsupportedOpenAPISpec` alias.
- Introduce a dedicated Singer protocol exception hierarchy in `singer_sdk.singerlib.exceptions` (`SingerError` → `SingerReadError` → `InvalidInputLine`) and keep it separate from `SingerSDKError`.
- Simplify and realign exception tests to cover the expanded hierarchy, including new configuration and discovery errors and the Singer protocol hierarchy, while removing obsolete `__all__` and leaf-instantiation checks.

Documentation:
- Update error design and hierarchy documentation to reflect completed Phase 2, the consolidated SDK exception tree, and the separate Singer protocol exception hierarchy.