### PR TITLE
refactor: Make the base `Target` class generic on its associated `Sink` class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,8 @@ testing = [
 ]
 typing = [
     {"include-group" = "testing"},
+    "backports-datetime-fromisoformat>=2.0.1",
+    "importlib-metadata>=6.5",
     "mypy>=1.17",
     "pyarrow-stubs>=19.1",
     "ty>=0.0.15",

--- a/singer_sdk/sql/target.py
+++ b/singer_sdk/sql/target.py
@@ -14,7 +14,6 @@ from singer_sdk.target_base import Target
 
 if t.TYPE_CHECKING:
     from singer_sdk.helpers.capabilities import CapabilitiesEnum
-    from singer_sdk.sinks.core import Sink
     from singer_sdk.sql.connector import SQLConnector
     from singer_sdk.sql.sink import SQLSink
 
@@ -88,7 +87,7 @@ class SQLTarget(Target):
         stream_name: str,
         schema: dict,
         key_properties: t.Sequence[str] | None = None,
-    ) -> Sink:
+    ) -> SQLSink:
         """Create a sink and register it.
 
         This method is internal to the SDK and should not need to be overridden.
@@ -124,11 +123,11 @@ class SQLTarget(Target):
         Args:
             stream_name: Name of the stream.
 
-        Raises:
-            ValueError: If no :class:`singer_sdk.sinks.Sink` class is defined.
-
         Returns:
             The sink class to be used with the stream.
+
+        Raises:
+            ValueError: If no :class:`singer_sdk.sinks.Sink` class is defined.
         """
         if self.default_sink_class:
             return self.default_sink_class
@@ -146,7 +145,7 @@ class SQLTarget(Target):
         record: dict | None = None,
         schema: dict | None = None,
         key_properties: t.Sequence[str] | None = None,
-    ) -> Sink:
+    ) -> SQLSink:
         """Return a sink for the given stream name.
 
         A new sink will be created if `schema` is provided and if either `schema` or

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -28,6 +28,7 @@ from singer_sdk.helpers.capabilities import (
 )
 from singer_sdk.io_base import SingerReader
 from singer_sdk.plugin_base import BaseSingerReader, _ConfigInput
+from singer_sdk.sinks import Sink
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterable
@@ -37,13 +38,14 @@ if t.TYPE_CHECKING:
     from singer_sdk.helpers.capabilities import CapabilitiesEnum
     from singer_sdk.mapper import PluginMapper
     from singer_sdk.singerlib.encoding.base import GenericSingerReader
-    from singer_sdk.sinks import Sink
     from singer_sdk.sql import SQLTarget  # noqa: F401
 
 _MAX_PARALLELISM = 8
 
+_TSink = t.TypeVar("_TSink", bound=Sink)
 
-class Target(BaseSingerReader, abc.ABC):
+
+class Target(BaseSingerReader, abc.ABC, t.Generic[_TSink]):
     """Abstract base class for targets.
 
     The `Target` class manages config information and is responsible for processing the
@@ -57,7 +59,7 @@ class Target(BaseSingerReader, abc.ABC):
 
     # Default class to use for creating new sink objects.
     # Required if `Target.get_sink_class()` is not defined.
-    default_sink_class: type[Sink]
+    default_sink_class: type[_TSink]
 
     message_reader_class: type[GenericSingerReader] = SingerReader
     """The message reader class to use for reading messages."""
@@ -101,8 +103,8 @@ class Target(BaseSingerReader, abc.ABC):
 
         self._latest_state: dict[str, dict] | None = None
         self._drained_state: dict[str, dict] = {}
-        self._sinks_active: dict[str, Sink] = {}
-        self._sinks_to_clear: list[Sink] = []
+        self._sinks_active: dict[str, _TSink] = {}
+        self._sinks_to_clear: list[_TSink] = []
         self._max_parallelism: int | None = _MAX_PARALLELISM
 
         # Approximated for max record age enforcement
@@ -191,7 +193,7 @@ class Target(BaseSingerReader, abc.ABC):
 
         return existing_sink
 
-    def get_sink_class(self, stream_name: str) -> type[Sink]:
+    def get_sink_class(self, stream_name: str) -> type[_TSink]:
         """Get sink for a stream.
 
         Developers can override this method to return a custom Sink type depending
@@ -200,11 +202,11 @@ class Target(BaseSingerReader, abc.ABC):
         Args:
             stream_name: Name of the stream.
 
-        Raises:
-            ValueError: If no :class:`singer_sdk.sinks.Sink` class is defined.
-
         Returns:
             The sink class to be used with the stream.
+
+        Raises:
+            ValueError: If no :class:`singer_sdk.sinks.Sink` class is defined.
         """
         if self.default_sink_class:
             return self.default_sink_class

--- a/uv.lock
+++ b/uv.lock
@@ -1139,7 +1139,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.12'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1208,6 +1208,9 @@ name = "jsonpath-ng"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/32/58/250751940d75c8019659e15482d548a4aa3b6ce122c515102a4bfdac50e3/jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3", size = 74513, upload-time = "2026-02-24T14:42:06.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/99/33c7d78a3fb70d545fd5411ac67a651c81602cc09c9cf0df383733f068c5/jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138", size = 67844, upload-time = "2026-02-28T00:53:19.637Z" },
+]
 
 [[package]]
 name = "jsonschema"
@@ -2839,12 +2842,14 @@ benchmark = [
     { name = "xdoctest", extra = ["colors"] },
 ]
 dev = [
+    { name = "backports-datetime-fromisoformat" },
     { name = "backports-zstd", marker = "python_full_version < '3.14'" },
     { name = "coverage", extra = ["toml"] },
     { name = "deptry" },
     { name = "dirty-equals" },
     { name = "fastjsonschema" },
     { name = "furo" },
+    { name = "importlib-metadata" },
     { name = "mypy" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -2925,10 +2930,12 @@ testing = [
     { name = "xdoctest", extra = ["colors"] },
 ]
 typing = [
+    { name = "backports-datetime-fromisoformat" },
     { name = "backports-zstd", marker = "python_full_version < '3.14'" },
     { name = "coverage", extra = ["toml"] },
     { name = "dirty-equals" },
     { name = "fastjsonschema" },
+    { name = "importlib-metadata" },
     { name = "mypy" },
     { name = "pyarrow-stubs" },
     { name = "pytest" },
@@ -3008,12 +3015,14 @@ benchmark = [
     { name = "xdoctest", extras = ["colors"], specifier = ">=1.1.1" },
 ]
 dev = [
+    { name = "backports-datetime-fromisoformat", specifier = ">=2.0.1" },
     { name = "backports-zstd", marker = "python_full_version < '3.14'", specifier = ">=1.0.0" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.9" },
     { name = "deptry", specifier = ">=0.15.0" },
     { name = "dirty-equals", specifier = ">=0.11" },
     { name = "fastjsonschema", specifier = ">=2.19.1" },
     { name = "furo", specifier = ">=2024.5.6" },
+    { name = "importlib-metadata", specifier = ">=6.5" },
     { name = "mypy", specifier = ">=1.17" },
     { name = "myst-parser", specifier = ">=3" },
     { name = "pyarrow-stubs", specifier = ">=19.1" },
@@ -3086,10 +3095,12 @@ testing = [
     { name = "xdoctest", extras = ["colors"], specifier = ">=1.1.1" },
 ]
 typing = [
+    { name = "backports-datetime-fromisoformat", specifier = ">=2.0.1" },
     { name = "backports-zstd", marker = "python_full_version < '3.14'", specifier = ">=1.0.0" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.9" },
     { name = "dirty-equals", specifier = ">=0.11" },
     { name = "fastjsonschema", specifier = ">=2.19.1" },
+    { name = "importlib-metadata", specifier = ">=6.5" },
     { name = "mypy", specifier = ">=1.17" },
     { name = "pyarrow-stubs", specifier = ">=19.1" },
     { name = "pytest", specifier = ">=9" },


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Make the base Target class generic over its associated Sink type and tighten sink typing for SQL targets.

Enhancements:
- Parameterize the Target base class with a generic Sink type and update related attributes and methods to use the generic type.
- Refine SQLTarget sink-related method type hints to use SQLSink instead of the generic Sink.
- Improve type-checking support by adding typing-only dependencies for datetime ISO parsing and importlib metadata.