### PR TITLE
test: Update `singer_sdk.sql` imports in tests

### DIFF
--- a/packages/meltano-tap-sqlite/tap_sqlite/tap.py
+++ b/packages/meltano-tap-sqlite/tap_sqlite/tap.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import typing as t
 
-from singer_sdk import SQLConnector, SQLStream, SQLTap
 from singer_sdk import typing as th
 from singer_sdk.contrib.msgspec import MsgSpecWriter
+from singer_sdk.sql import SQLConnector, SQLStream, SQLTap
 
 DB_PATH_CONFIG = "path_to_db"
 

--- a/packages/meltano-target-sqlite/target_sqlite/target.py
+++ b/packages/meltano-target-sqlite/target_sqlite/target.py
@@ -8,9 +8,9 @@ import json
 import sqlite3
 import typing as t
 
-from singer_sdk import SQLConnector, SQLSink, SQLTarget
 from singer_sdk import typing as th
 from singer_sdk.contrib.msgspec import MsgSpecReader
+from singer_sdk.sql import SQLConnector, SQLSink, SQLTarget
 
 DB_PATH_CONFIG = "path_to_db"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,11 @@ import typing as t
 
 import pytest
 
-from singer_sdk import SQLTarget
 from singer_sdk import typing as th
-from singer_sdk.connectors.sql import SQLConnector
 from singer_sdk.helpers._typing import DatetimeErrorTreatmentEnum
 from singer_sdk.helpers.capabilities import PluginCapabilities
 from singer_sdk.sinks import BatchSink
-from singer_sdk.sinks.sql import SQLSink
+from singer_sdk.sql import SQLConnector, SQLSink, SQLTarget
 from singer_sdk.target_base import Target
 
 if t.TYPE_CHECKING:

--- a/tests/core/test_target_class.py
+++ b/tests/core/test_target_class.py
@@ -6,9 +6,9 @@ from contextlib import nullcontext
 import pytest
 from click.testing import CliRunner
 
-from singer_sdk import SQLTarget
 from singer_sdk import typing as th
 from singer_sdk.exceptions import ConfigValidationError
+from singer_sdk.sql import SQLTarget
 
 
 class DummyTarget(SQLTarget):

--- a/tests/sql/test_connector.py
+++ b/tests/sql/test_connector.py
@@ -15,13 +15,13 @@ import sqlalchemy.types
 from sqlalchemy.dialects import registry, sqlite
 from sqlalchemy.engine.default import DefaultDialect
 
-from singer_sdk.connectors import SQLConnector
-from singer_sdk.connectors.sql import (
+from singer_sdk.exceptions import ConfigValidationError
+from singer_sdk.sql import SQLConnector
+from singer_sdk.sql.connector import (
     FullyQualifiedName,
     JSONSchemaToSQL,
     SQLToJSONSchema,
 )
-from singer_sdk.exceptions import ConfigValidationError
 
 if sys.version_info >= (3, 12):
     from typing import override  # noqa: ICN003

--- a/tests/sql/test_sink.py
+++ b/tests/sql/test_sink.py
@@ -8,9 +8,7 @@ import sqlalchemy
 import sqlalchemy.engine
 import sqlalchemy.types
 
-from singer_sdk import SQLTarget
-from singer_sdk.connectors.sql import SQLConnector
-from singer_sdk.sinks.sql import SQLSink
+from singer_sdk.sql import SQLConnector, SQLSink, SQLTarget
 
 if t.TYPE_CHECKING:
     from singer_sdk.sql.connector import FullyQualifiedName

--- a/tests/sql/test_target.py
+++ b/tests/sql/test_target.py
@@ -5,7 +5,7 @@ import typing as t
 import pytest
 
 from singer_sdk.helpers.capabilities import TargetCapabilities
-from singer_sdk.target_base import SQLTarget
+from singer_sdk.sql import SQLTarget
 
 if t.TYPE_CHECKING:
     from singer_sdk.helpers.capabilities import CapabilitiesEnum


### PR DESCRIPTION
SSIA

## Related

- #3269 

## Summary by Sourcery

Tests:
- Update test imports to use `singer_sdk.sql` and `singer_sdk.sql.connector` namespaces for SQLConnector, SQLSink, SQLTarget, and related types.

## Summary by Sourcery

Align SQL-related tests and example plugins with the updated `singer_sdk.sql` import namespaces.

Enhancements:
- Update SQL-related imports in example tap and target implementations to use the `singer_sdk.sql` namespace for SQLConnector, SQLSink, SQLStream, SQLTap, and SQLTarget.

Tests:
- Update SQL-related test imports to reference `singer_sdk.sql` and `singer_sdk.sql.connector` for SQLConnector, SQLSink, SQLTarget, and associated helper types.