### PR TITLE
docs: Sort `Returns`, `Yields` and `Raises` sections in docstrings in a consistent way

### DIFF
--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -78,11 +78,11 @@ def is_secret_type(type_dict: dict) -> bool:
     Args:
         type_dict: The JSON Schema type to check.
 
-    Raises:
-        ValueError: If type_dict is None or empty.
-
     Returns:
         True if we detect any sensitive property nodes.
+
+    Raises:
+        ValueError: If type_dict is None or empty.
     """
     if type_dict.get(JSONSCHEMA_ANNOTATION_WRITEONLY) or type_dict.get(
         JSONSCHEMA_ANNOTATION_SECRET,
@@ -153,11 +153,11 @@ def is_date_or_datetime_type(type_dict: dict) -> bool:
     Args:
         type_dict: The JSON Schema definition.
 
-    Raises:
-        ValueError: If type is empty or null.
-
     Returns:
         True if date or date-time, else False.
+
+    Raises:
+        ValueError: If type is empty or null.
     """
     if "anyOf" in type_dict:
         return any(is_date_or_datetime_type(option) for option in type_dict["anyOf"])

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -579,12 +579,12 @@ class PluginBase(abc.ABC):  # noqa: PLR0904
         Args:
             args: CLI arguments.
 
-        Raises:
-            FileNotFoundError: If the config file does not exist.
-
         Returns:
             A tuple containing the config dictionary and a boolean indicating whether
             the config file was found.
+
+        Raises:
+            FileNotFoundError: If the config file does not exist.
         """
         config_files = []
         parse_env_config = False

--- a/singer_sdk/sql/connector.py
+++ b/singer_sdk/sql/connector.py
@@ -783,11 +783,11 @@ class SQLConnector:  # noqa: PLR0904
             sql_type: The string representation of the SQL type, a SQLAlchemy
                 TypeEngine class or object, or a custom-specified object.
 
-        Raises:
-            ValueError: If the type received could not be translated to jsonschema.
-
         Returns:
             The JSON Schema representation of the provided type.
+
+        Raises:
+            ValueError: If the type received could not be translated to jsonschema.
 
         .. versionchanged:: 0.40.0
            Support for SQLAlchemy type classes and strings in the ``sql_type`` argument

--- a/singer_sdk/sql/stream.py
+++ b/singer_sdk/sql/stream.py
@@ -133,11 +133,11 @@ class SQLStream(Stream, abc.ABC):
     def fully_qualified_name(self) -> FullyQualifiedName:
         """Generate the fully qualified version of the table name.
 
-        Raises:
-            ValueError: If table_name is not able to be detected.
-
         Returns:
             The fully qualified name.
+
+        Raises:
+            ValueError: If table_name is not able to be detected.
         """
         catalog_entry = self._singer_catalog_entry
         if not catalog_entry.table:

--- a/singer_sdk/sql/target.py
+++ b/singer_sdk/sql/target.py
@@ -124,11 +124,11 @@ class SQLTarget(Target):
         Args:
             stream_name: Name of the stream.
 
-        Raises:
-            ValueError: If no :class:`singer_sdk.sinks.Sink` class is defined.
-
         Returns:
             The sink class to be used with the stream.
+
+        Raises:
+            ValueError: If no :class:`singer_sdk.sinks.Sink` class is defined.
         """
         if self.default_sink_class:
             return self.default_sink_class

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -1207,12 +1207,12 @@ class Stream(abc.ABC):  # noqa: PLR0904
             context: Stream partition or context dictionary.
             write_messages: Whether to write Singer messages to stdout.
 
+        Yields:
+            Each record from the source.
+
         Raises:
             InvalidStreamSortException: Raised if sorting errors are found while
                 syncing the records.
-
-        Yields:
-            Each record from the source.
         """
         # Type definitions
         context_element: types.Context | None

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -200,11 +200,11 @@ class Target(BaseSingerReader, abc.ABC):
         Args:
             stream_name: Name of the stream.
 
-        Raises:
-            ValueError: If no :class:`singer_sdk.sinks.Sink` class is defined.
-
         Returns:
             The sink class to be used with the stream.
+
+        Raises:
+            ValueError: If no :class:`singer_sdk.sinks.Sink` class is defined.
         """
         if self.default_sink_class:
             return self.default_sink_class

--- a/singer_sdk/typing.py
+++ b/singer_sdk/typing.py
@@ -1343,11 +1343,11 @@ def to_jsonschema_type(
         from_type: The SQL type as a string or as a TypeEngine. If a TypeEngine is
             provided, it may be provided as a class or a specific object instance.
 
-    Raises:
-        ValueError: If the `from_type` value is not of type `str` or `TypeEngine`.
-
     Returns:
         A compatible JSON Schema type definition.
+
+    Raises:
+        ValueError: If the `from_type` value is not of type `str` or `TypeEngine`.
     """
     import sqlalchemy.types  # noqa: PLC0415
 


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Documentation:
- Reorder Returns, Yields, and Raises sections in multiple function and method docstrings to align with the preferred documentation convention.