### PR TITLE
refactor: Moved `DatetimeErrorTreatmentEnum` and `TypeConformanceLevel` from private `singer_sdk.helpers._typing` to a public `singer_sdk.helpers.conforming` module

### DIFF
--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -9,10 +9,18 @@ import logging
 import math
 import typing as t
 import uuid
-from enum import Enum
+import warnings
 from functools import lru_cache
 
 from singer_sdk.exceptions import EmptySchemaTypeError
+from singer_sdk.helpers import conform
+from singer_sdk.helpers._compat import SingerSDKDeprecationWarning
+
+if t.TYPE_CHECKING:
+    from singer_sdk.helpers.conform import (
+        DatetimeErrorTreatmentEnum,  # noqa: F401
+        TypeConformanceLevel,  # noqa: F401
+    )
 
 _MAX_TIMESTAMP = "9999-12-31 23:59:59.999999"
 _MAX_TIME = "23:59:59.999999"
@@ -23,12 +31,34 @@ UTC = datetime.timezone.utc
 logger = logging.getLogger(__name__)
 
 
-class DatetimeErrorTreatmentEnum(Enum):
-    """Enum for treatment options for date parsing error."""
+def __getattr__(name: str) -> t.Any:  # noqa: ANN401
+    """Provide backward compatibility for classes with deprecation warnings.
 
-    ERROR = "error"
-    MAX = "max"
-    NULL = "null"
+    Args:
+        name: The name of the attribute to import.
+
+    Returns:
+        The imported attribute.
+
+    Raises:
+        AttributeError: If the attribute is not found.
+    """
+    exports = {
+        "DatetimeErrorTreatmentEnum": conform.DatetimeErrorTreatmentEnum,
+        "TypeConformanceLevel": conform.TypeConformanceLevel,
+    }
+    if export := exports.get(name):
+        warnings.warn(
+            f"Importing {name} from singer_sdk.helpers._typing is deprecated. "
+            f"Please import from singer_sdk.helpers.conform instead: "
+            f"from singer_sdk.helpers.conform import {name}",
+            SingerSDKDeprecationWarning,
+            stacklevel=2,
+        )
+        return export
+
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
 
 
 def to_json_compatible(val: t.Any) -> t.Any:  # noqa: ANN401
@@ -208,20 +238,20 @@ def handle_invalid_timestamp_in_record(
     invalid_value: str,
     datelike_typename: str,
     ex: Exception,
-    treatment: DatetimeErrorTreatmentEnum | None,
+    treatment: conform.DatetimeErrorTreatmentEnum | None,
     logger: logging.Logger,
 ) -> t.Any:  # noqa: ANN401
     """Apply treatment or raise an error for invalid time values."""
-    treatment = treatment or DatetimeErrorTreatmentEnum.ERROR
+    treatment = treatment or conform.DatetimeErrorTreatmentEnum.ERROR
     msg = (
         f"Could not parse value '{invalid_value}' for "
         f"field '{':'.join(key_breadcrumb)}'."
     )
-    if treatment == DatetimeErrorTreatmentEnum.MAX:
+    if treatment == conform.DatetimeErrorTreatmentEnum.MAX:
         logger.warning("%s. Replacing with MAX value.\n%s\n", msg, ex)
         return _MAX_TIMESTAMP if datelike_typename != "time" else _MAX_TIME
 
-    if treatment == DatetimeErrorTreatmentEnum.NULL:
+    if treatment == conform.DatetimeErrorTreatmentEnum.NULL:
         logger.warning("%s. Replacing with NULL.\n%s\n", msg, ex)
         return None
 
@@ -364,39 +394,11 @@ def _warn_unmapped_properties(
     )
 
 
-class TypeConformanceLevel(Enum):
-    """Used to configure how data is conformed to json compatible types.
-
-    Before outputting data as JSON, it is conformed to types that are valid in json,
-    based on the current types and the schema. For example, dates are converted to
-    strings.
-
-    By default, all data is conformed recursively. If this is not necessary (because
-    data is already valid types, or you are manually converting it) then it may be more
-    performant to use a lesser conformance level.
-    """
-
-    RECURSIVE = 1
-    """
-    All data is recursively conformed
-    """
-
-    ROOT_ONLY = 2
-    """
-    Only properties on the root object, excluding array elements, are conformed
-    """
-
-    NONE = 3
-    """
-    No conformance is performed
-    """
-
-
 def conform_record_data_types(
     stream_name: str,
     record: dict[str, t.Any],
     schema: dict,
-    level: TypeConformanceLevel,
+    level: conform.TypeConformanceLevel,
     logger: logging.Logger,
 ) -> dict[str, t.Any]:
     """Translate values in record dictionary to singer-compatible data types.
@@ -416,7 +418,7 @@ def conform_record_data_types(
 def _conform_record_data_types(
     input_object: dict[str, t.Any],
     schema: dict,
-    level: TypeConformanceLevel,
+    level: conform.TypeConformanceLevel,
     parent: str | None,
 ) -> tuple[dict[str, t.Any], list[str]]:
     """Translate values in record dictionary to singer-compatible data types.
@@ -435,7 +437,7 @@ def _conform_record_data_types(
     output_object: dict[str, t.Any] = {}
     unmapped_properties: list[str] = []
 
-    if level == TypeConformanceLevel.NONE:
+    if level == conform.TypeConformanceLevel.NONE:
         return input_object, unmapped_properties
 
     for property_name, elem in input_object.items():
@@ -449,7 +451,7 @@ def _conform_record_data_types(
 
         property_schema = schema["properties"][property_name]
         if isinstance(elem, list) and is_uniform_list(property_schema):
-            if level == TypeConformanceLevel.RECURSIVE:
+            if level == conform.TypeConformanceLevel.RECURSIVE:
                 output, sub_unmapped_properties = _conform_uniform_list(
                     elem,
                     path=property_path,
@@ -465,7 +467,7 @@ def _conform_record_data_types(
             and is_object_type(property_schema)
             and "properties" in property_schema
         ):
-            if level == TypeConformanceLevel.RECURSIVE:
+            if level == conform.TypeConformanceLevel.RECURSIVE:
                 (
                     output_object[property_name],
                     sub_unmapped_properties,
@@ -491,7 +493,7 @@ def _conform_uniform_list(
     *,
     path: str,
     schema: dict,
-    level: TypeConformanceLevel,
+    level: conform.TypeConformanceLevel,
 ) -> tuple[list, list[str]]:
     item_schema = schema["items"]
     unmapped_properties = []

--- a/singer_sdk/helpers/conform.py
+++ b/singer_sdk/helpers/conform.py
@@ -1,0 +1,57 @@
+"""Record conforming helpers, for both the tap and target."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = [
+    "DatetimeErrorTreatmentEnum",
+    "TypeConformanceLevel",
+]
+
+
+class DatetimeErrorTreatmentEnum(Enum):
+    """Enum for treatment options for date parsing error."""
+
+    ERROR = "error"
+    """
+    Raise an error for invalid time values.
+    """
+
+    MAX = "max"
+    """
+    Replace invalid time values with the maximum timestamp value.
+    """
+
+    NULL = "null"
+    """
+    Replace invalid time values with a null value.
+    """
+
+
+class TypeConformanceLevel(Enum):
+    """Used to configure how data is conformed to json compatible types.
+
+    Before outputting data as JSON, it is conformed to types that are valid in json,
+    based on the current types and the schema. For example, dates are converted to
+    strings.
+
+    By default, all data is conformed recursively. If this is not necessary (because
+    data is already valid types, or you are manually converting it) then it may be more
+    performant to use a lesser conformance level.
+    """
+
+    RECURSIVE = 1
+    """
+    All data is recursively conformed
+    """
+
+    ROOT_ONLY = 2
+    """
+    Only properties on the root object, excluding array elements, are conformed
+    """
+
+    NONE = 3
+    """
+    No conformance is performed
+    """

--- a/tests/core/test_record_typing.py
+++ b/tests/core/test_record_typing.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 import logging
 import typing as t
 from datetime import datetime
+from functools import partial
 
 import pytest
 
 from singer_sdk.helpers._compat import datetime_fromisoformat as parse
 from singer_sdk.helpers._typing import (
+    DatetimeErrorTreatmentEnum,
     TypeConformanceLevel,
     conform_record_data_types,
     get_datelike_property_type,
+    handle_invalid_timestamp_in_record,
     to_json_compatible,
 )
 
@@ -139,3 +142,63 @@ def test_to_json_compatible(datetime_val, expected):
 def test_get_datelike_property_type(schema, expected):
     actual = get_datelike_property_type(schema)
     assert actual == expected
+
+
+def test_handle_invalid_timestamp_in_record(
+    caplog: pytest.LogCaptureFixture,
+    subtests: pytest.Subtests,
+):
+    value = "2021-08-25T20:05:28.000000+00:00"
+    record = {"created_at": value}
+    key_breadcrumb = ["created_at"]
+    datelike_typename = "datetime"
+    ex = ValueError("invalid timestamp")
+    logger = logging.getLogger("test-logger")
+
+    handle_val = partial(
+        handle_invalid_timestamp_in_record,
+        record=record,
+        key_breadcrumb=key_breadcrumb,
+        invalid_value=value,
+        datelike_typename=datelike_typename,
+        ex=ex,
+        logger=logger,
+    )
+
+    with (
+        subtests.test("default treatment"),
+        pytest.raises(ValueError, match=r"Could not parse value.*"),
+    ):
+        handle_val(treatment=None)
+
+    with (
+        subtests.test("error"),
+        pytest.raises(ValueError, match=r"Could not parse value.*"),
+    ):
+        handle_val(treatment=DatetimeErrorTreatmentEnum.ERROR)
+
+    with (
+        subtests.test("max (datetime)"),
+        caplog.at_level(logging.INFO, logger=logger.name),
+    ):
+        assert isinstance(handle_val(treatment=DatetimeErrorTreatmentEnum.MAX), str)
+
+    with (
+        subtests.test("max (time)"),
+        caplog.at_level(logging.INFO, logger=logger.name),
+    ):
+        assert isinstance(
+            handle_val(
+                treatment=DatetimeErrorTreatmentEnum.MAX,
+                datelike_typename="time",
+            ),
+            str,
+        )
+        assert "Replacing with MAX value." in caplog.text
+
+    with (
+        subtests.test("null"),
+        caplog.at_level(logging.INFO, logger=logger.name),
+    ):
+        assert handle_val(treatment=DatetimeErrorTreatmentEnum.NULL) is None
+        assert "Replacing with NULL." in caplog.text


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Expose datetime error handling and type conformance enums via a new public helpers module while keeping backward compatibility for existing imports.

Enhancements:
- Introduce a new public singer_sdk.helpers.conforming module that defines DatetimeErrorTreatmentEnum and TypeConformanceLevel for shared use.
- Update existing helper functions to reference the enums from the new conforming module instead of the private _typing module.
- Add a dynamic attribute accessor on singer_sdk.helpers._typing to preserve legacy imports with deprecation warnings.