### PR TITLE
refactor!: Removed the `PluginBase.config_from_cli_args` method, which has not been used for a while

### DIFF
--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -13,7 +13,7 @@ import time
 import typing as t
 import warnings
 from importlib import metadata
-from pathlib import Path, PurePath
+from pathlib import PurePath
 from types import MappingProxyType
 
 import click
@@ -27,7 +27,7 @@ from singer_sdk.configuration._dict_config import (
 )
 from singer_sdk.exceptions import ConfigValidationError, MapperNotInitialized
 from singer_sdk.helpers._classproperty import classproperty
-from singer_sdk.helpers._compat import SingerSDKDeprecationWarning, deprecated
+from singer_sdk.helpers._compat import SingerSDKDeprecationWarning
 from singer_sdk.helpers._packaging import SDK_PACKAGE_NAME, get_package_version
 from singer_sdk.helpers._util import read_json_file
 from singer_sdk.helpers.capabilities import (
@@ -181,7 +181,7 @@ def _plugin_log_level(*, plugin_name: str) -> str:
     return level.upper() if level is not None else DEFAULT_LOG_LEVEL
 
 
-class PluginBase(abc.ABC):  # noqa: PLR0904
+class PluginBase(abc.ABC):
     """Abstract base class for taps."""
 
     #: The executable name of the tap or target plugin. e.g. tap-foo
@@ -566,46 +566,6 @@ class PluginBase(abc.ABC):  # noqa: PLR0904
         info = cls._get_about_info()
         formatter = about.AboutFormatter.get_formatter(output_format or "text")
         print(formatter.format_about(info))  # noqa: T201
-
-    @staticmethod
-    @deprecated(
-        "config_from_cli_args is deprecated and will be removed by 2026-01-01.",
-        category=SingerSDKDeprecationWarning,
-        stacklevel=2,
-    )
-    def config_from_cli_args(*args: str) -> tuple[list[Path], bool]:  # pragma: no cover
-        """Parse CLI arguments into a config dictionary.
-
-        Args:
-            args: CLI arguments.
-
-        Returns:
-            A tuple containing the config dictionary and a boolean indicating whether
-            the config file was found.
-
-        Raises:
-            FileNotFoundError: If the config file does not exist.
-        """
-        config_files = []
-        parse_env_config = False
-
-        for config_path in args:
-            if config_path == "ENV":
-                # Allow parse from env vars:
-                parse_env_config = True
-                continue
-
-            # Validate config file paths before adding to list
-            if not Path(config_path).is_file():
-                msg = (
-                    f"Could not locate config file at '{config_path}'. Please check "
-                    "that the file exists."
-                )
-                raise FileNotFoundError(msg)
-
-            config_files.append(Path(config_path))
-
-        return config_files, parse_env_config
 
     @classmethod
     def invoke(


### PR DESCRIPTION
Deprecated since v0.48.0 and not used anymore.

## Summary by Sourcery

Remove the long-deprecated PluginBase.config_from_cli_args helper and clean up an obsolete lint suppression on PluginBase.

Enhancements:
- Remove the deprecated PluginBase.config_from_cli_args method that is no longer used.
- Drop an unnecessary lint suppression comment from the PluginBase class definition.