### PR TITLE
fix: The `BasicAuthenticator` class is no longer deprecated

### DIFF
--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -391,16 +391,8 @@ class BearerTokenAuthenticator(APIAuthenticatorBase):
         return cls(stream=stream, token=token)
 
 
-@deprecated(
-    "BasicAuthenticator is deprecated and will be removed by 2026-01-01. "
-    "Use `requests.auth.HTTPBasicAuth` instead.",
-    category=SingerSDKDeprecationWarning,
-)
 class BasicAuthenticator(APIAuthenticatorBase):
     """Implements basic authentication for REST Streams.
-
-    .. deprecated:: 0.36.0
-       Use :class:`requests.auth.HTTPBasicAuth` instead.
 
     This Authenticator implements basic authentication by concatenating a
     username and password then base64 encoding the string. The resulting

--- a/tests/core/rest/test_authenticators.py
+++ b/tests/core/rest/test_authenticators.py
@@ -380,18 +380,6 @@ def _get_args_kwargs(
     return ((stream,), {}) if stream_param == "positional" else ((), {"stream": stream})
 
 
-def assert_basic_auth_deprecation_warning(
-    warning: warnings.WarningMessage,
-    *,
-    location: str = "authenticators.py",
-):
-    assert isinstance(warning.message, SingerSDKDeprecationWarning)
-    message = warning.message.args[0]
-    assert isinstance(message, str)
-    assert message.startswith("BasicAuthenticator is deprecated")
-    assert warning.filename.endswith(f"{os.path.sep}{location}")
-
-
 def assert_stream_param_deprecation_warning(warning: warnings.WarningMessage):
     assert isinstance(warning.message, SingerSDKDeprecationWarning)
     message = warning.message.args[0]
@@ -426,12 +414,8 @@ def test_basic_auth_deprecation_warning(
     with pytest.deprecated_call() as recorder:
         BasicAuthenticator(*args, username="username", password="password", **kwargs)  # noqa: S106
 
-    assert len(recorder.list) == 2
-    assert_basic_auth_deprecation_warning(
-        recorder.list[0],
-        location="test_authenticators.py",
-    )
-    assert_stream_param_deprecation_warning(recorder.list[1])
+    assert len(recorder.list) == 1
+    assert_stream_param_deprecation_warning(recorder.list[0])
 
 
 @pytest.mark.parametrize("stream_param", ["positional", "keyword"])
@@ -587,10 +571,9 @@ def test_basic_authenticator_create_for_stream_deprecation_warning(rest_tap: Tap
         )
 
     # create_for_stream, BasicAuthenticator, and stream param warnings
-    assert len(recorder.list) == 3
+    assert len(recorder.list) == 2
     assert_create_for_stream_deprecation_warning(recorder.list[0])
-    assert_basic_auth_deprecation_warning(recorder.list[1])
-    assert_stream_param_deprecation_warning(recorder.list[2])
+    assert_stream_param_deprecation_warning(recorder.list[1])
 
 
 def test_authenticator_invoked_on_each_retry(

--- a/tests/core/rest/test_authenticators.py
+++ b/tests/core/rest/test_authenticators.py
@@ -405,7 +405,7 @@ def assert_config_property_deprecation_warning(warning: warnings.WarningMessage)
 
 
 @pytest.mark.parametrize("stream_param", ["positional", "keyword"])
-def test_basic_auth_deprecation_warning(
+def test_basic_auth_stream_param_deprecation_warning(
     rest_tap: Tap, stream_param: t.Literal["positional", "keyword"]
 ):
     """Validate that a warning is emitted when using BasicAuthenticator."""


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Adjust deprecation warning expectations in tests now that BasicAuthenticator is no longer deprecated.

## Summary by Sourcery

Bug Fixes:
- Update deprecation warning expectations in authenticator tests now that BasicAuthenticator is no longer deprecated.