### PR TITLE
docs: Avoid documenting deprecated authenticator method `create_for_stream`

### DIFF
--- a/docs/_templates/authenticator.rst
+++ b/docs/_templates/authenticator.rst
@@ -1,0 +1,9 @@
+{{ fullname }}
+{{ "=" * fullname|length }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ name }}
+    :members:
+    :special-members: __init__, __call__
+    :exclude-members: create_for_stream

--- a/docs/classes/singer_sdk.authenticators.APIAuthenticatorBase.rst
+++ b/docs/classes/singer_sdk.authenticators.APIAuthenticatorBase.rst
@@ -6,3 +6,4 @@
 .. autoclass:: APIAuthenticatorBase
     :members:
     :special-members: __init__, __call__
+    :exclude-members: create_for_stream

--- a/docs/classes/singer_sdk.authenticators.APIKeyAuthenticator.rst
+++ b/docs/classes/singer_sdk.authenticators.APIKeyAuthenticator.rst
@@ -6,3 +6,4 @@
 .. autoclass:: APIKeyAuthenticator
     :members:
     :special-members: __init__, __call__
+    :exclude-members: create_for_stream

--- a/docs/classes/singer_sdk.authenticators.BasicAuthenticator.rst
+++ b/docs/classes/singer_sdk.authenticators.BasicAuthenticator.rst
@@ -6,3 +6,4 @@
 .. autoclass:: BasicAuthenticator
     :members:
     :special-members: __init__, __call__
+    :exclude-members: create_for_stream

--- a/docs/classes/singer_sdk.authenticators.BearerTokenAuthenticator.rst
+++ b/docs/classes/singer_sdk.authenticators.BearerTokenAuthenticator.rst
@@ -6,3 +6,4 @@
 .. autoclass:: BearerTokenAuthenticator
     :members:
     :special-members: __init__, __call__
+    :exclude-members: create_for_stream

--- a/docs/classes/singer_sdk.authenticators.OAuthAuthenticator.rst
+++ b/docs/classes/singer_sdk.authenticators.OAuthAuthenticator.rst
@@ -6,3 +6,4 @@
 .. autoclass:: OAuthAuthenticator
     :members:
     :special-members: __init__, __call__
+    :exclude-members: create_for_stream

--- a/docs/classes/singer_sdk.authenticators.OAuthJWTAuthenticator.rst
+++ b/docs/classes/singer_sdk.authenticators.OAuthJWTAuthenticator.rst
@@ -6,3 +6,4 @@
 .. autoclass:: OAuthJWTAuthenticator
     :members:
     :special-members: __init__, __call__
+    :exclude-members: create_for_stream

--- a/docs/classes/singer_sdk.authenticators.SimpleAuthenticator.rst
+++ b/docs/classes/singer_sdk.authenticators.SimpleAuthenticator.rst
@@ -6,3 +6,4 @@
 .. autoclass:: SimpleAuthenticator
     :members:
     :special-members: __init__, __call__
+    :exclude-members: create_for_stream

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -54,7 +54,7 @@ Authenticator Classes
 
 .. autosummary::
     :toctree: classes
-    :template: class.rst
+    :template: authenticator.rst
 
     authenticators.APIAuthenticatorBase
     authenticators.APIKeyAuthenticator


### PR DESCRIPTION
Deprecated back in v0.49.0 via https://github.com/meltano/sdk/commit/2351c346ed4a18d6cc45971246fb561ad3108700.

## Summary by Sourcery

Update authenticator documentation to stop referencing the deprecated create_for_stream method and centralize shared authenticator docs in a new template.

Documentation:
- Remove references to the deprecated create_for_stream method from authenticator class documentation.
- Introduce a shared authenticator documentation template and update reference docs to use it.