### PR TITLE
chore: Removed some unused `ty: ignore` comments

### DIFF
--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -443,11 +443,11 @@ class BasicAuthenticator(APIAuthenticatorBase):
         category=SingerSDKDeprecationWarning,
     )
     def create_for_stream(
-        cls: type[BasicAuthenticator],  # ty: ignore[deprecated]
+        cls: type[BasicAuthenticator],
         stream: _HTTPStream,
         username: str,
         password: str,
-    ) -> BasicAuthenticator:  # ty: ignore[deprecated]
+    ) -> BasicAuthenticator:
         """Create an Authenticator object specific to the Stream class.
 
         Args:


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Enhancements:
- Clean up type hints by removing unnecessary deprecated ignore comments from BasicAuthenticator.create_for_stream.