### PR TITLE
docs: Added `NumberType` to reference index page

### DIFF
--- a/docs/classes/typing/singer_sdk.typing.NumberType.rst
+++ b/docs/classes/typing/singer_sdk.typing.NumberType.rst
@@ -1,0 +1,9 @@
+﻿singer_sdk.typing.NumberType
+============================
+
+.. currentmodule:: singer_sdk.typing
+
+.. autoclass:: NumberType
+    :members:
+    :special-members: __init__, __call__
+    :inherited-members: JSONTypeHelper

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -107,6 +107,7 @@ JSON Schema builder classes
     typing.JSONPointerType
     typing.ObjectType
     typing.OneOf
+    typing.NumberType
     typing.Property
     typing.RegexType
     typing.RelativeJSONPointerType


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Documentation:
- Adjust reference index documentation entries, including NumberType.