### PR TITLE
fix(templates): Update SQL tap and target templates to reflect module reorganization

### DIFF
--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
@@ -9,9 +9,9 @@ import functools
 import sys
 from typing import TYPE_CHECKING, Any
 
-from singer_sdk import SQLConnector, SQLStream
-from singer_sdk.connectors.sql import SQLToJSONSchema
-from singer_sdk.helpers._typing import TypeConformanceLevel
+from singer_sdk.helpers.conform import TypeConformanceLevel
+from singer_sdk.sql import SQLConnector, SQLStream
+from singer_sdk.sql.connector import SQLToJSONSchema
 
 if sys.version_info >= (3, 12):
     from typing import override

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-tap.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-tap.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from singer_sdk import SQLTap
 from singer_sdk import typing as th  # JSON schema typing helpers
+from singer_sdk.sql import SQLTap
 
 from {{ cookiecutter.library_name }}.client import {{ cookiecutter.source_name }}Stream
 

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_sql.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_sql.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import sys
 from typing import TYPE_CHECKING, Any
 
-from singer_sdk.connectors import SQLConnector
-from singer_sdk.sinks import SQLSink
+from singer_sdk.sql import SQLConnector, SQLSink
 
 if sys.version_info >= (3, 12):
     from typing import override
@@ -16,7 +15,7 @@ else:
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from singer_sdk.connectors.sql import FullyQualifiedName
+    from singer_sdk.sql.connector import FullyQualifiedName
 
 
 class {{ cookiecutter.destination_name }}Connector(SQLConnector):


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Update SQL tap and target cookiecutter templates to use the new singer_sdk SQL and type conformance module locations after the SDK’s module reorganization.

Enhancements:
- Adjust SQL tap template imports to reference the relocated SQLConnector, SQLStream, SQLToJSONSchema, and TypeConformanceLevel modules.
- Align SQL target sink template imports with the new singer_sdk.sql and singer_sdk.sql.connector namespaces.