### PR TITLE
fix: Emit a warning when running on a (near) EOL Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,7 @@ filterwarnings = [
     'ignore::ResourceWarning',
     # Our own warnings
     'once::singer_sdk.helpers._compat.SingerSDKDeprecationWarning',
+    'once::singer_sdk.helpers._compat.SingerSDKPythonEOLWarning',
 ]
 log_cli_level = "INFO"
 log_format = "%(levelname)s %(name)s %(message)s"

--- a/singer_sdk/helpers/_compat.py
+++ b/singer_sdk/helpers/_compat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import sys
+import warnings
 from functools import partial
 from importlib import resources as importlib_resources
 
@@ -39,8 +40,62 @@ class SingerSDKDeprecationWarning(DeprecationWarning):
 singer_sdk_deprecated = partial(deprecated, category=SingerSDKDeprecationWarning)
 
 
+class SingerSDKPythonEOLWarning(FutureWarning):
+    """Warning issued when the running Python is near or past its end of life."""
+
+
+# EOL dates from https://devguide.python.org/versions/
+_PYTHON_EOL_DATES: dict[tuple[int, int], datetime.date] = {
+    (3, 10): datetime.date(2026, 10, 4),
+    (3, 11): datetime.date(2027, 10, 24),
+    (3, 12): datetime.date(2028, 10, 2),
+    (3, 13): datetime.date(2029, 10, 7),
+    (3, 14): datetime.date(2030, 10, 7),
+}
+_PYTHON_EOL_WARNING_PERIOD = datetime.timedelta(days=365)  # warn 1 year before EOL
+
+
+def warn_python_eol(
+    _today: datetime.date | None = None,
+    _version: tuple[int, int] | None = None,
+) -> None:
+    """Issue a SingerSDKPythonEOLWarning if the running Python is near/past EOL.
+
+    Args:
+        _today: Override today's date (testing only).
+        _version: Override the Python version tuple (testing only).
+    """
+    version = _version or sys.version_info[:2]
+    eol = _PYTHON_EOL_DATES.get(version)
+    if eol is None:
+        return
+
+    today = _today or datetime.datetime.now(datetime.timezone.utc).date()
+    py_str = f"Python {version[0]}.{version[1]}"
+
+    if today >= eol:
+        warnings.warn(
+            f"{py_str} reached its end of life on {eol}. "
+            "The Singer SDK may drop support for it in an upcoming release. "
+            "Please upgrade to a supported Python version. "
+            "See https://devguide.python.org/versions/ for details.",
+            SingerSDKPythonEOLWarning,
+            stacklevel=2,
+        )
+    elif today >= eol - _PYTHON_EOL_WARNING_PERIOD:
+        warnings.warn(
+            f"{py_str} will reach its end of life on {eol}. "
+            "The Singer SDK will drop support for it in an upcoming release. "
+            "Please plan to upgrade to a supported Python version. "
+            "See https://devguide.python.org/versions/ for details.",
+            SingerSDKPythonEOLWarning,
+            stacklevel=2,
+        )
+
+
 __all__ = [
     "SingerSDKDeprecationWarning",
+    "SingerSDKPythonEOLWarning",
     "Traversable",
     "date_fromisoformat",
     "datetime_fromisoformat",
@@ -48,4 +103,5 @@ __all__ = [
     "entry_points",
     "importlib_resources",
     "time_fromisoformat",
+    "warn_python_eol",
 ]

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -27,7 +27,7 @@ from singer_sdk.configuration._dict_config import (
 )
 from singer_sdk.exceptions import ConfigValidationError, MapperNotInitialized
 from singer_sdk.helpers._classproperty import classproperty
-from singer_sdk.helpers._compat import SingerSDKDeprecationWarning
+from singer_sdk.helpers._compat import SingerSDKDeprecationWarning, warn_python_eol
 from singer_sdk.helpers._packaging import SDK_PACKAGE_NAME, get_package_version
 from singer_sdk.helpers._util import read_json_file
 from singer_sdk.helpers.capabilities import (
@@ -234,6 +234,7 @@ class PluginBase(abc.ABC):
         Raises:
             TypeError: If config is not a dict or path string.
         """
+        warn_python_eol()
         config = config or {}
         if isinstance(config, (str, PurePath)):
             config_dict = read_json_file(config)

--- a/tests/core/test_compat.py
+++ b/tests/core/test_compat.py
@@ -1,0 +1,63 @@
+"""Tests for singer_sdk/helpers/_compat.py."""
+
+from __future__ import annotations
+
+import datetime
+import warnings
+
+from singer_sdk.helpers._compat import (
+    SingerSDKPythonEOLWarning,
+    warn_python_eol,
+)
+
+# ---------------------------------------------------------------------------
+# warn_python_eol
+# ---------------------------------------------------------------------------
+
+
+def test_warn_python_eol_no_warning_far_from_eol() -> None:
+    """No warning when today is well before the 1-year EOL window."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warn_python_eol(
+            _today=datetime.date(2024, 1, 1),
+            _version=(3, 10),
+        )
+
+    assert not caught
+
+
+def test_warn_python_eol_approaching() -> None:
+    """A FutureWarning is issued when within the 1-year window before EOL."""
+    # 3.10 EOL is 2026-10-04; pick a date 6 months before
+    approaching = datetime.date(2026, 4, 4)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warn_python_eol(_today=approaching, _version=(3, 10))
+
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, SingerSDKPythonEOLWarning)
+    assert "will reach its end of life" in str(caught[0].message)
+
+
+def test_warn_python_eol_past_eol() -> None:
+    """A FutureWarning is issued when today is past the EOL date."""
+    past_eol = datetime.date(2027, 1, 1)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warn_python_eol(_today=past_eol, _version=(3, 10))
+
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, SingerSDKPythonEOLWarning)
+    assert "reached its end of life" in str(caught[0].message)
+
+
+def test_warn_python_eol_unknown_version() -> None:
+    """No warning is issued for a Python version not in the EOL table."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warn_python_eol(_today=datetime.date(2030, 1, 1), _version=(3, 99))
+
+    assert not caught


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Add runtime warnings for running the SDK on Python versions nearing or past end-of-life.

New Features:
- Introduce a Python EOL warning mechanism that alerts users when running on versions near or past their official end-of-life.

Enhancements:
- Emit a Python EOL warning during plugin initialization to encourage upgrades to supported Python versions.

Build:
- Configure pytest to treat the new Python EOL warning type as a once-per-run warning.

Tests:
- Add unit tests covering the Python EOL warning behavior for dates before, near, and after configured EOLs, as well as unknown versions.