### PR TITLE
refactor: Documented removals slated for v0.56 and updated warning messages

### DIFF
--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -4,6 +4,23 @@ This page outlines when various features of the Singer SDK will be removed or ch
 incompatible way, following their deprecation, as indicated in the
 [deprecation policy](./release_process.md#deprecation-policy).
 
+## v0.56
+
+### Batch file encoding
+
+`JSONLinesEncoding` and `ParquetEncoding` are thin wrappers over `BaseBatchFileEncoding`
+that add no behaviour. They will be removed in v0.56.
+
+```python
+# Old (deprecated)
+from singer_sdk.helpers._batch import JSONLinesEncoding, ParquetEncoding
+
+# New
+from singer_sdk.helpers._batch import BaseBatchFileEncoding
+
+encoding = BaseBatchFileEncoding(format="jsonl")
+```
+
 ## 1.0
 
 - The `RESTStream.get_next_page_token` method will no longer be called

--- a/singer_sdk/helpers/_batch.py
+++ b/singer_sdk/helpers/_batch.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 
 from upath import UPath
 
-from singer_sdk.helpers._compat import deprecated
+from singer_sdk.helpers._compat import singer_sdk_deprecated
 from singer_sdk.singerlib.messages import Message, SingerMessageType
 
 if t.TYPE_CHECKING:
@@ -47,7 +47,10 @@ class BaseBatchFileEncoding:
         return cls(**data)
 
 
-@deprecated("Use BaseBatchFileEncoding with format='jsonl' instead")
+@singer_sdk_deprecated(
+    "JSONLinesEncoding is deprecated and will be removed in v0.56. "
+    "Use BaseBatchFileEncoding with format='jsonl' instead."
+)
 @dataclass(slots=True)
 class JSONLinesEncoding(BaseBatchFileEncoding):
     """JSON Lines encoding for batch files."""
@@ -55,7 +58,10 @@ class JSONLinesEncoding(BaseBatchFileEncoding):
     format: t.Literal["jsonl"] = "jsonl"
 
 
-@deprecated("Use BaseBatchFileEncoding with format='parquet' instead")
+@singer_sdk_deprecated(
+    "ParquetEncoding is deprecated and will be removed in v0.56. "
+    "Use BaseBatchFileEncoding with format='parquet' instead."
+)
 @dataclass(slots=True)
 class ParquetEncoding(BaseBatchFileEncoding):
     """Parquet encoding for batch files."""


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Document deprecations and planned removals for batch file encodings in v0.56 and update deprecation warnings accordingly.

Enhancements:
- Update JSONLinesEncoding and ParquetEncoding decorators to use the Singer SDK deprecation helper with clearer messages including the v0.56 removal timeline.

Documentation:
- Add v0.56 deprecation notes documenting planned removal of JSONLinesEncoding and ParquetEncoding in favor of BaseBatchFileEncoding.