### PR TITLE
refactor: Use the `@warnings.deprecated` decorator directly

### DIFF
--- a/singer_sdk/helpers/_batch.py
+++ b/singer_sdk/helpers/_batch.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 
 from upath import UPath
 
-from singer_sdk.helpers._compat import singer_sdk_deprecated
+from singer_sdk.helpers._compat import SingerSDKDeprecationWarning, deprecated
 from singer_sdk.singerlib.messages import Message, SingerMessageType
 
 if t.TYPE_CHECKING:
@@ -47,9 +47,9 @@ class BaseBatchFileEncoding:
         return cls(**data)
 
 
-@singer_sdk_deprecated(
-    "JSONLinesEncoding is deprecated and will be removed in v0.56. "
-    "Use BaseBatchFileEncoding with format='jsonl' instead."
+@deprecated(
+    "Use BaseBatchFileEncoding with format='jsonl' instead. JSONLinesEncoding will be removed in v0.56.",  # noqa: E501
+    category=SingerSDKDeprecationWarning,
 )
 @dataclass(slots=True)
 class JSONLinesEncoding(BaseBatchFileEncoding):
@@ -58,9 +58,9 @@ class JSONLinesEncoding(BaseBatchFileEncoding):
     format: t.Literal["jsonl"] = "jsonl"
 
 
-@singer_sdk_deprecated(
-    "ParquetEncoding is deprecated and will be removed in v0.56. "
-    "Use BaseBatchFileEncoding with format='parquet' instead."
+@deprecated(
+    "Use BaseBatchFileEncoding with format='parquet' instead. ParquetEncoding will be removed in v0.56.",  # noqa: E501
+    category=SingerSDKDeprecationWarning,
 )
 @dataclass(slots=True)
 class ParquetEncoding(BaseBatchFileEncoding):

--- a/singer_sdk/helpers/_compat.py
+++ b/singer_sdk/helpers/_compat.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import datetime
 import sys
 import warnings
-from functools import partial
 from importlib import resources as importlib_resources
 
 if sys.version_info >= (3, 13):
@@ -35,9 +34,6 @@ time_fromisoformat = datetime.time.fromisoformat
 
 class SingerSDKDeprecationWarning(DeprecationWarning):
     """Custom deprecation warning for the Singer SDK."""
-
-
-singer_sdk_deprecated = partial(deprecated, category=SingerSDKDeprecationWarning)
 
 
 class SingerSDKPythonEOLWarning(FutureWarning):

--- a/singer_sdk/pagination.py
+++ b/singer_sdk/pagination.py
@@ -7,7 +7,7 @@ import typing as t
 from abc import ABC, abstractmethod
 from urllib.parse import ParseResult, urlparse
 
-from singer_sdk.helpers._compat import singer_sdk_deprecated
+from singer_sdk.helpers._compat import SingerSDKDeprecationWarning, deprecated
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 
 if sys.version_info >= (3, 12):
@@ -372,9 +372,10 @@ class PageNumberPaginator(BaseAPIPaginator[int]):
         return self._value + 1
 
 
-@singer_sdk_deprecated(
+@deprecated(
     "BasePageNumberPaginator is deprecated and will be removed in a future version. "
-    "Use PageNumberPaginator instead."
+    "Use PageNumberPaginator instead.",
+    category=SingerSDKDeprecationWarning,
 )
 class BasePageNumberPaginator(PageNumberPaginator):
     """DEPRECATED.
@@ -422,9 +423,10 @@ class OffsetPaginator(BaseAPIPaginator[int], ABC):
         return self._value + self._page_size
 
 
-@singer_sdk_deprecated(
+@deprecated(
     "BaseOffsetPaginator is deprecated and will be removed in a future version. "
-    "Use OffsetPaginator instead."
+    "Use OffsetPaginator instead.",
+    category=SingerSDKDeprecationWarning,
 )
 class BaseOffsetPaginator(OffsetPaginator):
     """DEPRECATED.


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Replace the internal Singer SDK deprecation helper with the shared @deprecated decorator and explicit SingerSDKDeprecationWarning usage.

Enhancements:
- Update deprecated paginator and batch encoding classes to use the shared @deprecated decorator with the SingerSDKDeprecationWarning category.
- Remove the singer_sdk_deprecated partial helper in favor of direct decorator usage.