### PR TITLE
refactor: Documented removals slated for v0.57

### DIFF
--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -27,6 +27,27 @@ from singer_sdk.helpers._batch import BaseBatchFileEncoding
 encoding = BaseBatchFileEncoding(format="jsonl")
 ```
 
+## v0.57
+
+### SQL module reorganization
+
+The `singer_sdk.connectors.sql`, `singer_sdk.sinks.sql`, `singer_sdk.streams.sql`, and
+top-level `singer_sdk` modules no longer export SQL classes directly. Import them from
+`singer_sdk.sql` instead. The shim modules will be removed in v0.57.
+
+```python
+# Old (deprecated)
+from singer_sdk import SQLConnector, SQLSink, SQLStream, SQLTap, SQLTarget
+from singer_sdk.connectors.sql import SQLConnector
+from singer_sdk.sinks.sql import SQLSink
+from singer_sdk.streams.sql import SQLStream
+
+# New
+from singer_sdk.sql import SQLConnector, SQLSink, SQLStream, SQLTap, SQLTarget
+```
+
+See the [migration guide](./guides/consolidate-sql-imports.md) for more information.
+
 ## 1.0
 
 - The `RESTStream.get_next_page_token` method will no longer be called

--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -32,7 +32,7 @@ encoding = BaseBatchFileEncoding(format="jsonl")
 ### SQL module reorganization
 
 The `singer_sdk.connectors.sql`, `singer_sdk.sinks.sql`, `singer_sdk.streams.sql`, and
-top-level `singer_sdk` modules no longer export SQL classes directly. Import them from
+top-level `singer_sdk` module no longer exports SQL classes directly. Import them from
 `singer_sdk.sql` instead. The shim modules will be removed in v0.57.
 
 ```python

--- a/docs/guides/consolidate-sql-imports.md
+++ b/docs/guides/consolidate-sql-imports.md
@@ -1,0 +1,136 @@
+# Consolidating SQL imports into `singer_sdk.sql`
+
+In v0.57, the deprecated SQL import shim modules will be removed. All SQL classes are
+now consolidated in the `singer_sdk.sql` package and its `connector` submodule. This guide covers
+every affected import path.
+
+## Module-level import paths
+
+The following modules are shims that re-export from `singer_sdk.sql`. They will be
+deleted in v0.57.
+
+| Deprecated import | Replacement |
+|---|---|
+| `from singer_sdk.connectors.sql import SQLConnector` | `from singer_sdk.sql import SQLConnector` |
+| `from singer_sdk.connectors.sql import FullyQualifiedName` | `from singer_sdk.sql.connector import FullyQualifiedName` |
+| `from singer_sdk.connectors.sql import JSONSchemaToSQL` | `from singer_sdk.sql.connector import JSONSchemaToSQL` |
+| `from singer_sdk.connectors.sql import JSONtoSQLHandler` | `from singer_sdk.sql.connector import JSONtoSQLHandler` |
+| `from singer_sdk.connectors.sql import SQLToJSONSchema` | `from singer_sdk.sql.connector import SQLToJSONSchema` |
+| `from singer_sdk.sinks.sql import SQLSink` | `from singer_sdk.sql import SQLSink` |
+| `from singer_sdk.streams.sql import SQLStream` | `from singer_sdk.sql import SQLStream` |
+
+## Top-level `singer_sdk` imports
+
+The top-level `singer_sdk` package no longer re-exports the SQL classes.
+
+| Deprecated import | Replacement |
+|---|---|
+| `from singer_sdk import SQLConnector` | `from singer_sdk.sql import SQLConnector` |
+| `from singer_sdk import SQLSink` | `from singer_sdk.sql import SQLSink` |
+| `from singer_sdk import SQLStream` | `from singer_sdk.sql import SQLStream` |
+| `from singer_sdk import SQLTap` | `from singer_sdk.sql import SQLTap` |
+| `from singer_sdk import SQLTarget` | `from singer_sdk.sql import SQLTarget` |
+
+## Typical tap migration
+
+```python
+# Old (deprecated)
+from singer_sdk import SQLConnector, SQLStream, SQLTap
+
+
+class MyConnector(SQLConnector): ...
+
+
+class MyStream(SQLStream): ...
+
+
+class MyTap(SQLTap): ...
+
+
+# New
+from singer_sdk.sql import SQLConnector, SQLStream, SQLTap
+
+
+class MyConnector(SQLConnector): ...
+
+
+class MyStream(SQLStream): ...
+
+
+class MyTap(SQLTap): ...
+```
+
+## Typical target migration
+
+```python
+# Old (deprecated)
+from singer_sdk import SQLConnector, SQLSink, SQLTarget
+
+
+class MyConnector(SQLConnector): ...
+
+
+class MySink(SQLSink): ...
+
+
+class MyTarget(SQLTarget): ...
+
+
+# New
+from singer_sdk.sql import SQLConnector, SQLSink, SQLTarget
+
+
+class MyConnector(SQLConnector): ...
+
+
+class MySink(SQLSink): ...
+
+
+class MyTarget(SQLTarget): ...
+```
+
+## Custom type converters
+
+`SQLToJSONSchema` and `JSONSchemaToSQL` moved to `singer_sdk.sql.connector`:
+
+```python
+# Old (deprecated)
+from singer_sdk.connectors.sql import SQLToJSONSchema, JSONSchemaToSQL
+
+
+class MyConverter(SQLToJSONSchema): ...
+
+
+# New
+from singer_sdk.sql.connector import SQLToJSONSchema, JSONSchemaToSQL
+
+
+class MyConverter(SQLToJSONSchema): ...
+```
+
+`FullyQualifiedName` follows the same pattern:
+
+```python
+# Old (deprecated)
+from singer_sdk.connectors.sql import FullyQualifiedName
+
+# New
+from singer_sdk.sql.connector import FullyQualifiedName
+```
+
+## Type annotations in `TYPE_CHECKING` blocks
+
+The pattern is the same — just update the import path:
+
+```python
+from __future__ import annotations
+
+import typing as t
+
+if t.TYPE_CHECKING:
+    # Old (deprecated)
+    from singer_sdk.connectors.sql import FullyQualifiedName
+
+    # New
+    from singer_sdk.sql.connector import FullyQualifiedName
+```

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -15,4 +15,5 @@ sql-tap
 sql-target
 
 migrate-to-uv
+consolidate-sql-imports
 ```

--- a/singer_sdk/__init__.py
+++ b/singer_sdk/__init__.py
@@ -62,8 +62,8 @@ def __getattr__(name: str) -> t.Any:  # noqa: ANN401
     """
     if name == "SQLConnector":
         warnings.warn(
-            f"Importing {name} from singer_sdk is deprecated. "
-            f"Please import from singer_sdk.sql instead: "
+            f"Importing {name} from singer_sdk is deprecated and will be removed "
+            f"in v0.57. Please import from singer_sdk.sql instead: "
             f"from singer_sdk.sql import {name}",
             SingerSDKDeprecationWarning,
             stacklevel=2,
@@ -73,8 +73,8 @@ def __getattr__(name: str) -> t.Any:  # noqa: ANN401
         return SQLConnector
     if name == "SQLSink":
         warnings.warn(
-            f"Importing {name} from singer_sdk is deprecated. "
-            f"Please import from singer_sdk.sql instead: "
+            f"Importing {name} from singer_sdk is deprecated and will be removed "
+            f"in v0.57. Please import from singer_sdk.sql instead: "
             f"from singer_sdk.sql import {name}",
             SingerSDKDeprecationWarning,
             stacklevel=2,
@@ -84,8 +84,8 @@ def __getattr__(name: str) -> t.Any:  # noqa: ANN401
         return SQLSink
     if name == "SQLStream":
         warnings.warn(
-            f"Importing {name} from singer_sdk is deprecated. "
-            f"Please import from singer_sdk.sql instead: "
+            f"Importing {name} from singer_sdk is deprecated and will be removed "
+            f"in v0.57. Please import from singer_sdk.sql instead: "
             f"from singer_sdk.sql import {name}",
             SingerSDKDeprecationWarning,
             stacklevel=2,
@@ -95,8 +95,8 @@ def __getattr__(name: str) -> t.Any:  # noqa: ANN401
         return SQLStream
     if name == "SQLTap":
         warnings.warn(
-            f"Importing {name} from singer_sdk is deprecated. "
-            f"Please import from singer_sdk.sql instead: "
+            f"Importing {name} from singer_sdk is deprecated and will be removed "
+            f"in v0.57. Please import from singer_sdk.sql instead: "
             f"from singer_sdk.sql import {name}",
             SingerSDKDeprecationWarning,
             stacklevel=2,
@@ -106,8 +106,8 @@ def __getattr__(name: str) -> t.Any:  # noqa: ANN401
         return SQLTap
     if name == "SQLTarget":
         warnings.warn(
-            f"Importing {name} from singer_sdk is deprecated. "
-            f"Please import from singer_sdk.sql instead: "
+            f"Importing {name} from singer_sdk is deprecated and will be removed "
+            f"in v0.57. Please import from singer_sdk.sql instead: "
             f"from singer_sdk.sql import {name}",
             SingerSDKDeprecationWarning,
             stacklevel=2,

--- a/singer_sdk/connectors/__init__.py
+++ b/singer_sdk/connectors/__init__.py
@@ -25,7 +25,8 @@ def __getattr__(name: str) -> t.Any:  # noqa: ANN401
     """
     if name == "SQLConnector":
         warnings.warn(
-            f"Importing {name} from singer_sdk.connectors is deprecated. "
+            f"Importing {name} from singer_sdk.connectors is deprecated and will be "
+            "removed in v0.57. "
             f"Please import from singer_sdk.sql instead: "
             f"from singer_sdk.sql import {name}",
             SingerSDKDeprecationWarning,

--- a/singer_sdk/connectors/sql.py
+++ b/singer_sdk/connectors/sql.py
@@ -1,6 +1,6 @@
 """Deprecated SQL connector module.
 
-.. deprecated:: Next Release
+.. deprecated:: v0.49
     Import from singer_sdk.sql instead.
 """
 
@@ -35,7 +35,7 @@ def __getattr__(name: str) -> t.Any:  # noqa: ANN401
     """
     msg_template = (
         "Importing {name} from singer_sdk.connectors.sql is deprecated and will be "  # noqa: RUF027
-        "removed in the next release. Please import from singer_sdk.sql instead."
+        "removed in v0.57. Please import from singer_sdk.sql instead."
     )
     if name == "FullyQualifiedName":
         msg = msg_template.format(name=name)

--- a/singer_sdk/sinks/sql.py
+++ b/singer_sdk/sinks/sql.py
@@ -1,6 +1,6 @@
 """Deprecated SQL sink module.
 
-.. deprecated:: Next Release
+.. deprecated:: v0.49
     Import from singer_sdk.sql instead.
 """
 
@@ -29,8 +29,8 @@ def __getattr__(name: str) -> t.Any:  # noqa: ANN401
     """
     if name == "SQLSink":
         warnings.warn(
-            f"Importing {name} from singer_sdk.sinks.sql is deprecated. "
-            f"Please import from singer_sdk.sql instead.",
+            f"Importing {name} from singer_sdk.sinks.sql is deprecated and will be "
+            f"removed in v0.57. Please import from singer_sdk.sql instead.",
             SingerSDKDeprecationWarning,
             stacklevel=2,
         )

--- a/singer_sdk/streams/sql.py
+++ b/singer_sdk/streams/sql.py
@@ -11,7 +11,7 @@ import warnings
 from singer_sdk.helpers._compat import SingerSDKDeprecationWarning
 
 warnings.warn(
-    "Importing from singer_sdk.streams.sql is deprecated. "
+    "Importing from singer_sdk.streams.sql is deprecated and will be removed in v0.57. "
     "Please import from singer_sdk.sql instead.",
     SingerSDKDeprecationWarning,
     stacklevel=2,

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -678,7 +678,8 @@ def __getattr__(name: str) -> t.Any:  # noqa: ANN401
     """
     if name == "SQLTap":
         warnings.warn(
-            f"Importing {name} from singer_sdk.tap_base is deprecated. "
+            f"Importing {name} from singer_sdk.tap_base is deprecated and will be "
+            "removed in v0.57. "
             f"Please import from singer_sdk.sql instead: "
             f"from singer_sdk.sql import {name}",
             SingerSDKDeprecationWarning,


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Clarify and document the planned removal of deprecated SQL shim imports for v0.57 and update deprecation messaging to reference the specific release.

Enhancements:
- Tighten deprecation warnings across SQL-related modules to specify removal in v0.57 and direct users to the consolidated singer_sdk.sql imports.

Documentation:
- Add deprecation section for v0.57 and a migration guide detailing how to consolidate SQL imports into singer_sdk.sql and singer_sdk.sql.connector.