### PR TITLE
docs: Documented removals slated for v0.58

### DIFF
--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -54,6 +54,17 @@ from singer_sdk.sql import SQLConnector, SQLSink, SQLStream, SQLTap, SQLTarget
 
 See the [migration guide](./guides/consolidate-sql-imports.md) for more information.
 
+## v0.58
+
+### Authenticator `stream` parameter and related properties
+
+The `stream` parameter on all authenticator constructors, the `tap_name` and `config`
+properties on `APIAuthenticatorBase`, and the `create_for_stream` class methods on
+`APIKeyAuthenticator`, `BearerTokenAuthenticator`, and `BasicAuthenticator` are
+deprecated and will be removed in v0.58.
+
+See the [migration guide](./guides/decouple-authenticators.md) for more information.
+
 ## 1.0
 
 - The `RESTStream.get_next_page_token` method will no longer be called

--- a/docs/guides/decouple-authenticators.md
+++ b/docs/guides/decouple-authenticators.md
@@ -1,0 +1,194 @@
+# Decoupling authenticators from streams
+
+In v0.58, the `stream` constructor parameter and all related shim API on authenticator
+classes will be removed. Authenticators are now constructed directly with explicit
+parameters, making them easier to test in isolation without a stream instance.
+This guide walks through each affected class and shows the new construction pattern.
+
+## Background
+
+The old pattern passed a stream instance directly to the authenticator constructor so
+it could read `stream.config` and `stream.tap_name` internally:
+
+```python
+# Old (deprecated)
+class MyStream(RESTStream):
+    @cached_property
+    def authenticator(self):
+        return APIKeyAuthenticator(
+            stream=self,
+            key="x-api-key",
+            value=self.config["api_key"],
+        )
+```
+
+Authenticators no longer hold a reference to the stream. Config values are passed
+explicitly at construction time, which makes authenticators easier to test in isolation
+and removes a hidden dependency on the stream lifecycle.
+
+## What's removed
+
+| Deprecated | Replacement |
+| ---------------------------------------------------------- | --------------------------------------------- |
+| `stream` constructor parameter (all authenticator classes) | Construct directly with explicit kwargs |
+| `APIKeyAuthenticator.create_for_stream()` | Construct `APIKeyAuthenticator` directly |
+| `BearerTokenAuthenticator.create_for_stream()` | Construct `BearerTokenAuthenticator` directly |
+| `BasicAuthenticator.create_for_stream()` | Construct `BasicAuthenticator` directly |
+| `APIAuthenticatorBase.tap_name` property | Access via your tap/stream directly |
+| `APIAuthenticatorBase.config` property | Access via your tap/stream directly |
+
+## Simple authenticators
+
+`APIKeyAuthenticator`, `BearerTokenAuthenticator`, and `BasicAuthenticator` are the
+easiest to migrate — drop `stream=` and the `create_for_stream` factory:
+
+```python
+# Old (deprecated)
+APIKeyAuthenticator(stream=self, key="x-api-key", value="secret")
+APIKeyAuthenticator.create_for_stream(stream=self, key="x-api-key", value="secret")
+
+BearerTokenAuthenticator(stream=self, token="my-token")
+BearerTokenAuthenticator.create_for_stream(stream=self, token="my-token")
+
+BasicAuthenticator(stream=self, username="user", password="pass")
+BasicAuthenticator.create_for_stream(stream=self, username="user", password="pass")
+
+# New
+APIKeyAuthenticator(key="x-api-key", value="secret")
+BearerTokenAuthenticator(token="my-token")
+BasicAuthenticator(username="user", password="pass")
+```
+
+In your stream's `authenticator` property, read config values directly from `self.config`:
+
+```python
+@cached_property
+def authenticator(self) -> APIKeyAuthenticator:
+    return APIKeyAuthenticator(key="x-api-key", value=self.config["api_key"])
+```
+
+## OAuth authenticators
+
+`OAuthAuthenticator` and `OAuthJWTAuthenticator` require a few more steps because the
+old `stream=` path read `client_id`, `client_secret` (and `private_key` for JWT) from
+`stream.config` automatically. These must now be passed explicitly.
+
+### `OAuthAuthenticator`
+
+```python
+# Old (deprecated)
+class MyAuthenticator(OAuthAuthenticator):
+    @classmethod
+    def create_for_stream(cls, stream):
+        return cls(
+            stream=stream,
+            auth_endpoint="https://api.example.com/oauth/token",
+        )
+
+    @property
+    def oauth_request_body(self) -> dict:
+        return {
+            "client_id": self.client_id,  # populated from stream.config
+            "client_secret": self.client_secret,  # populated from stream.config
+            "grant_type": "client_credentials",
+        }
+
+
+# In your stream:
+@cached_property
+def authenticator(self):
+    return MyAuthenticator.create_for_stream(self)
+
+
+# New — remove create_for_stream; pass config values from the stream
+class MyAuthenticator(OAuthAuthenticator):
+    @property
+    def oauth_request_body(self) -> dict:
+        return {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "grant_type": "client_credentials",
+        }
+
+
+# In your stream:
+@cached_property
+def authenticator(self):
+    return MyAuthenticator(
+        auth_endpoint="https://api.example.com/oauth/token",
+        client_id=self.config["client_id"],
+        client_secret=self.config["client_secret"],
+    )
+```
+
+### `OAuthJWTAuthenticator`
+
+The same pattern applies; pass `private_key` and `private_key_passphrase` explicitly:
+
+```python
+# Old (deprecated)
+class MyJWTAuthenticator(OAuthJWTAuthenticator):
+    @classmethod
+    def create_for_stream(cls, stream):
+        return cls(stream=stream, auth_endpoint="https://api.example.com/oauth/token")
+
+
+# In your stream:
+@cached_property
+def authenticator(self):
+    return MyJWTAuthenticator.create_for_stream(self)
+
+
+# New
+# In your stream:
+@cached_property
+def authenticator(self):
+    return MyJWTAuthenticator(
+        auth_endpoint="https://api.example.com/oauth/token",
+        client_id=self.config["client_id"],
+        client_secret=self.config["client_secret"],
+        private_key=self.config["private_key"],
+        private_key_passphrase=self.config.get("private_key_passphrase"),
+    )
+```
+
+## Subclasses that access `self.config` or `self.tap_name`
+
+If your authenticator subclass reads `self.config` or `self.tap_name` in methods like
+`oauth_request_body`, store those values in `__init__` instead:
+
+```python
+# Old (deprecated) — reads self.config inside the authenticator
+class MyAuthenticator(OAuthAuthenticator):
+    @property
+    def oauth_request_body(self) -> dict:
+        return {
+            "audience": self.config["audience"],  # will no longer work
+            "grant_type": "client_credentials",
+        }
+
+
+# New — receive the value at construction time
+class MyAuthenticator(OAuthAuthenticator):
+    def __init__(self, *, audience: str, **kwargs: t.Any) -> None:
+        super().__init__(**kwargs)
+        self._audience = audience
+
+    @property
+    def oauth_request_body(self) -> dict:
+        return {
+            "audience": self._audience,
+            "grant_type": "client_credentials",
+        }
+
+
+# In your stream:
+@cached_property
+def authenticator(self):
+    return MyAuthenticator(
+        auth_endpoint="https://api.example.com/oauth/token",
+        client_id=self.config["client_id"],
+        client_secret=self.config["client_secret"],
+        audience=self.config["audience"],
+    )
+```

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -16,4 +16,5 @@ sql-target
 
 migrate-to-uv
 consolidate-sql-imports
+decouple-authenticators
 ```

--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -100,10 +100,7 @@ def _get_stream_param(*args: t.Any, **kwargs: t.Any) -> _HTTPStream | None:
 
 def _warn_stream_param_deprecation() -> None:
     warnings.warn(
-        (
-            "The `stream` parameter is deprecated and will be removed in a "
-            "future version"
-        ),
+        "The `stream` parameter will be removed in v0.58.",
         SingerSDKDeprecationWarning,
         stacklevel=2,
     )
@@ -141,10 +138,7 @@ class APIAuthenticatorBase:
 
     @property
     @deprecated(
-        (
-            "The `tap_name` property is deprecated and will be removed in a "
-            "future version"
-        ),
+        "The `tap_name` property will be removed in v0.58.",
         category=SingerSDKDeprecationWarning,
     )
     def tap_name(self) -> str:
@@ -158,7 +152,7 @@ class APIAuthenticatorBase:
 
     @property
     @deprecated(
-        "The `config` property is deprecated and will be removed in a future version",
+        "The `config` property will be removed in v0.58. Use existing authenticator properties or override the `__init__` method.",  # noqa: E501
         category=SingerSDKDeprecationWarning,
     )
     def config(self) -> t.Mapping[str, t.Any]:
@@ -232,7 +226,7 @@ class SimpleAuthenticator(APIAuthenticatorBase):
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore",
-                    message=r"The `stream` parameter is deprecated.*",
+                    message=r"The `stream` parameter will be removed.*",
                     category=SingerSDKDeprecationWarning,
                 )
                 super().__init__(stream=stream)
@@ -279,7 +273,7 @@ class APIKeyAuthenticator(APIAuthenticatorBase):
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore",
-                    message=r"The `stream` parameter is deprecated.*",
+                    message=r"The `stream` parameter will be removed.*",
                     category=SingerSDKDeprecationWarning,
                 )
                 super().__init__(stream=stream)
@@ -303,10 +297,7 @@ class APIKeyAuthenticator(APIAuthenticatorBase):
 
     @classmethod
     @deprecated(
-        (
-            "The `create_for_stream` method is deprecated and will be removed in a "
-            "future version"
-        ),
+        "The `create_for_stream` method will be removed in v0.58. Instantiate the authenticator directly instead.",  # noqa: E501
         category=SingerSDKDeprecationWarning,
     )
     def create_for_stream(
@@ -352,7 +343,7 @@ class BearerTokenAuthenticator(APIAuthenticatorBase):
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore",
-                    message=r"The `stream` parameter is deprecated.*",
+                    message=r"The `stream` parameter will be removed.*",
                     category=SingerSDKDeprecationWarning,
                 )
                 super().__init__(stream=stream)
@@ -367,10 +358,7 @@ class BearerTokenAuthenticator(APIAuthenticatorBase):
 
     @classmethod
     @deprecated(
-        (
-            "The `create_for_stream` method is deprecated and will be removed in a "
-            "future version"
-        ),
+        "The `create_for_stream` method will be removed in v0.58. Instantiate the authenticator directly instead.",  # noqa: E501
         category=SingerSDKDeprecationWarning,
     )
     def create_for_stream(
@@ -419,7 +407,7 @@ class BasicAuthenticator(APIAuthenticatorBase):
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore",
-                    message=r"The `stream` parameter is deprecated.*",
+                    message=r"The `stream` parameter will be removed.*",
                     category=SingerSDKDeprecationWarning,
                 )
                 super().__init__(stream=stream)
@@ -436,10 +424,7 @@ class BasicAuthenticator(APIAuthenticatorBase):
 
     @classmethod
     @deprecated(
-        (
-            "The `create_for_stream` method is deprecated and will be removed in a "
-            "future version"
-        ),
+        "The `create_for_stream` method will be removed in v0.58. Instantiate the authenticator directly instead.",  # noqa: E501
         category=SingerSDKDeprecationWarning,
     )
     def create_for_stream(
@@ -494,7 +479,7 @@ class OAuthAuthenticator(APIAuthenticatorBase):
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore",
-                    message=r"The `stream` parameter is deprecated.*",
+                    message=r"The `stream` parameter will be removed.*",
                     category=SingerSDKDeprecationWarning,
                 )
                 super().__init__(stream=stream)
@@ -705,7 +690,7 @@ class OAuthJWTAuthenticator(OAuthAuthenticator):
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore",
-                    message=r"The `stream` parameter is deprecated.*",
+                    message=r"The `stream` parameter will be removed.*",
                     category=SingerSDKDeprecationWarning,
                 )
                 super().__init__(stream=stream)

--- a/tests/core/rest/test_authenticators.py
+++ b/tests/core/rest/test_authenticators.py
@@ -384,7 +384,7 @@ def assert_stream_param_deprecation_warning(warning: warnings.WarningMessage):
     assert isinstance(warning.message, SingerSDKDeprecationWarning)
     message = warning.message.args[0]
     assert isinstance(message, str)
-    assert message.startswith("The `stream` parameter is deprecated")
+    assert "The `stream` parameter will be removed" in message
     assert warning.filename.endswith(f"{os.path.sep}authenticators.py")
 
 
@@ -392,7 +392,7 @@ def assert_create_for_stream_deprecation_warning(warning: warnings.WarningMessag
     assert isinstance(warning.message, SingerSDKDeprecationWarning)
     message = warning.message.args[0]
     assert isinstance(message, str)
-    assert message.startswith("The `create_for_stream` method is deprecated")
+    assert "The `create_for_stream` method will be removed" in message
     assert warning.filename.endswith(f"{os.path.sep}test_authenticators.py")
 
 
@@ -400,7 +400,7 @@ def assert_config_property_deprecation_warning(warning: warnings.WarningMessage)
     assert isinstance(warning.message, SingerSDKDeprecationWarning)
     message = warning.message.args[0]
     assert isinstance(message, str)
-    assert message.startswith("The `config` property is deprecated")
+    assert "The `config` property will be removed" in message
     assert warning.filename.endswith(f"{os.path.sep}authenticators.py")
 
 


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Clarify authenticator deprecation messaging and document the upcoming v0.58 removal of stream-coupled authenticator APIs.

Enhancements:
- Update deprecation warnings for authenticator stream-related APIs to reference the concrete v0.58 removal version and migration guidance.

Documentation:
- Add deprecation and migration guide documentation describing removal of stream-coupled authenticator parameters and helpers in v0.58, including examples of the new construction patterns.
- Link the new authenticator decoupling guide from the guides index for easier discoverability.

Tests:
- Adjust authenticator deprecation tests to assert on the updated deprecation messages tied to v0.58 removals.