### PR TITLE
revert: Update `RESTStream.get_url_params` return type annotation to also support returning a string (revert of #3502)

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -352,7 +352,7 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
         self,
         context: Context | None,  # noqa: ARG002
         next_page_token: _TToken | None,  # noqa: ARG002
-    ) -> dict[str, t.Any]:
+    ) -> dict[str, t.Any] | str:
         """Return a dictionary or string of URL query parameters.
 
         If paging is supported, developers may override with specific paging logic.
@@ -377,7 +377,8 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
                 next page of data.
 
         Returns:
-            Dictionary with URL query parameters to use in the request.
+            Dictionary or encoded string with URL query parameters to use in the
+                request.
         """
         return {}
 


### PR DESCRIPTION
#3502

## Summary by Sourcery

Enhancements:
- Allow RESTStream.get_url_params to return either a dictionary of parameters or an encoded query string, and update its docstring accordingly.