### PR TITLE
ci: Switch to CodSpeed `simulation` mode

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -63,4 +63,4 @@ jobs:
       with:
         token: ${{ secrets.CODSPEED_TOKEN }}
         run: pytest tests/ --codspeed
-        mode: instrumentation
+        mode: simulation


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update CodSpeed GitHub Actions workflow to run in simulation mode instead of instrumentation.