### PR TITLE
fix: Ensure parent stream records are emitted in auto-generated tap tests

### DIFF
--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -1369,7 +1369,13 @@ class Stream(abc.ABC):  # noqa: PLR0904
 
         for child_stream in self.child_streams:
             if child_stream.selected or child_stream.has_selected_descendents:
-                child_stream.sync(context=child_context)
+                try:
+                    child_stream.sync(context=child_context)
+                except (AbortedSyncFailedException, AbortedSyncPausedException):
+                    # Child stream reached its record limit (ABORT_AT_RECORD_COUNT).
+                    # Stop syncing remaining children for this context but allow the
+                    # parent stream to continue processing its own records.
+                    break
 
     # Overridable Methods
 

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -1373,9 +1373,10 @@ class Stream(abc.ABC):  # noqa: PLR0904
                     child_stream.sync(context=child_context)
                 except (AbortedSyncFailedException, AbortedSyncPausedException):
                     # Child stream reached its record limit (ABORT_AT_RECORD_COUNT).
-                    # Stop syncing remaining children for this context but allow the
-                    # parent stream to continue processing its own records.
-                    break
+                    # Continue with remaining child streams so each one can
+                    # independently emit up to max_records_limit records, and allow
+                    # the parent stream to continue processing its own records.
+                    continue
 
     # Overridable Methods
 

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -1372,10 +1372,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
                 try:
                     child_stream.sync(context=child_context)
                 except (AbortedSyncFailedException, AbortedSyncPausedException):
-                    # Child stream reached its record limit (ABORT_AT_RECORD_COUNT).
-                    # Continue with remaining child streams so each one can
-                    # independently emit up to max_records_limit records, and allow
-                    # the parent stream to continue processing its own records.
+                    # Child stream was interrupted, continue with remaining children
                     continue
 
     # Overridable Methods

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -281,9 +281,10 @@ class Tap(BaseSingerWriter, abc.ABC):  # noqa: PLR0904
             streams = self.streams.values()
 
         for stream in streams:
-            if not stream.child_streams:  # pragma: no branch
-                # Initialize streams' record limits before beginning the sync test.
-                stream.ABORT_AT_RECORD_COUNT = dry_run_record_limit
+            # Apply the record limit to every stream so that both parent and child
+            # streams are capped.  Child-stream aborts are caught in _sync_children
+            # so they do not prevent the parent from emitting its own records.
+            stream.ABORT_AT_RECORD_COUNT = dry_run_record_limit
 
             # Force selection of streams.
             stream.selected = True

--- a/tests/core/test_parent_child.py
+++ b/tests/core/test_parent_child.py
@@ -431,17 +431,32 @@ def test_parent_records_emitted_when_child_hits_record_limit():
         }
         parent_stream_type = ParentStream
 
-        def get_records(self, context: dict | None):
+        def get_records(self, context: dict | None):  # noqa: ARG002
             # More records than the dry-run limit (3 > 2)
-            yield {"id": 1, "pid": context["pid"]}
-            yield {"id": 2, "pid": context["pid"]}
-            yield {"id": 3, "pid": context["pid"]}
+            yield {"id": 1}
+            yield {"id": 2}
+            yield {"id": 3}
+
+    class SiblingStream(Stream):
+        name = "subling"
+        schema: t.ClassVar[dict] = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "pid": {"type": "integer"},
+            },
+        }
+        parent_stream_type = ParentStream
+
+        def get_records(self, context: dict | None):  # noqa: ARG002
+            for i in range(10):
+                yield {"id": i + 1}
 
     class TapLimited(Tap):
         name = "tap-limited"
 
         def discover_streams(self):
-            return [ParentStream(self), ChildStream(self)]
+            return [ParentStream(self), ChildStream(self), SiblingStream(self)]
 
     tap = TapLimited()
     buf = io.StringIO()
@@ -462,3 +477,6 @@ def test_parent_records_emitted_when_child_hits_record_limit():
 
     msg = "Only 2 (for each parent) child records should be emitted"
     assert tally["child_limited"] == 4, msg
+
+    msg = "Sibling records should also be emitted"
+    assert tally["subling"] == 4, msg

--- a/tests/core/test_parent_child.py
+++ b/tests/core/test_parent_child.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import io
+import json
 import logging
 import typing as t
 from contextlib import redirect_stdout
@@ -394,3 +395,66 @@ def test_preprocess_context_removes_large_payload(
 
     snapshot.assert_match(output, "singer.jsonl")
     snapshot.assert_match(caplog.text, "stderr.log")
+
+
+def test_parent_records_emitted_when_child_hits_record_limit():
+    """Parent records are written before child sync so they appear even if a child
+    stream aborts after reaching max_records_limit (dry-run record cap)."""
+
+    class ParentStream(Stream):
+        name = "parent_limited"
+        schema: t.ClassVar[dict] = {
+            "type": "object",
+            "properties": {"id": {"type": "integer"}},
+        }
+
+        def get_child_context(
+            self,
+            record: dict,
+            context: dict | None,  # noqa: ARG002
+        ) -> dict | None:
+            return {"pid": record["id"]}
+
+        def get_records(self, context: dict | None):  # noqa: ARG002
+            yield {"id": 1}
+            yield {"id": 2}
+
+    class ChildStream(Stream):
+        name = "child_limited"
+        schema: t.ClassVar[dict] = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "pid": {"type": "integer"},
+            },
+        }
+        parent_stream_type = ParentStream
+
+        def get_records(self, context: dict | None):  # noqa: ARG002
+            # More records than the dry-run limit (3 > 2)
+            yield {"id": 1}
+            yield {"id": 2}
+            yield {"id": 3}
+
+    class TapLimited(Tap):
+        name = "tap-limited"
+
+        def discover_streams(self):
+            return [ParentStream(self), ChildStream(self)]
+
+    tap = TapLimited()
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        # Limit child to 2 records; the 3rd would trigger AbortedSyncPausedException
+        tap.run_sync_dry_run(dry_run_record_limit=2)
+
+    buf.seek(0)
+    messages = [json.loads(line) for line in buf.read().splitlines() if line]
+
+    parent_records = [
+        m for m in messages if m["type"] == "RECORD" and m["stream"] == "parent_limited"
+    ]
+    assert len(parent_records) >= 1, (
+        "At least one parent record must be emitted even when the child stream "
+        "hits its dry-run record limit."
+    )

--- a/tests/core/test_parent_child.py
+++ b/tests/core/test_parent_child.py
@@ -5,6 +5,7 @@ import io
 import json
 import logging
 import typing as t
+from collections import defaultdict
 from contextlib import redirect_stdout
 
 import pytest
@@ -430,11 +431,11 @@ def test_parent_records_emitted_when_child_hits_record_limit():
         }
         parent_stream_type = ParentStream
 
-        def get_records(self, context: dict | None):  # noqa: ARG002
+        def get_records(self, context: dict | None):
             # More records than the dry-run limit (3 > 2)
-            yield {"id": 1}
-            yield {"id": 2}
-            yield {"id": 3}
+            yield {"id": 1, "pid": context["pid"]}
+            yield {"id": 2, "pid": context["pid"]}
+            yield {"id": 3, "pid": context["pid"]}
 
     class TapLimited(Tap):
         name = "tap-limited"
@@ -451,10 +452,13 @@ def test_parent_records_emitted_when_child_hits_record_limit():
     buf.seek(0)
     messages = [json.loads(line) for line in buf.read().splitlines() if line]
 
-    parent_records = [
-        m for m in messages if m["type"] == "RECORD" and m["stream"] == "parent_limited"
-    ]
-    assert len(parent_records) >= 1, (
-        "At least one parent record must be emitted even when the child stream "
-        "hits its dry-run record limit."
-    )
+    tally: dict[str, int] = defaultdict(int)
+    for m in messages:
+        if m["type"] == "RECORD":
+            tally[m["stream"]] += 1
+
+    msg = "At least one parent record must be emitted even when the child stream hits its dry-run record limit."  # noqa: E501
+    assert tally["parent_limited"] >= 1, msg
+
+    msg = "Only 2 (for each parent) child records should be emitted"
+    assert tally["child_limited"] == 4, msg


### PR DESCRIPTION
https://github.com/meltano/sdk/blob/4a5dd894d69cc068d140acea6e15fa4040831611/singer_sdk/tap_base.py#L284-L286

## Related

- https://github.com/meltano/sdk/issues/3029
- https://github.com/meltano/sdk/pull/3030
- https://github.com/meltano/sdk/pull/3037
- https://github.com/meltano/sdk/pull/3545

## Summary by Sourcery

Adjust tap dry-run behavior to cap record counts on all streams while ensuring parent streams continue emitting records when child streams hit their record limits.

Bug Fixes:
- Prevent auto-generated dry-run syncs from aborting parent streams when child streams reach their record limit by catching child abort exceptions and stopping only remaining child syncs.
- Apply the dry-run record limit consistently to both parent and child streams so all streams are subject to the same cap.

## Summary by Sourcery

Ensure dry-run syncs apply record limits consistently across parent and child streams without preventing parent records from being emitted when children hit their cap.

Bug Fixes:
- Apply the dry-run record limit to all streams, including parents and children, instead of only non-child streams.
- Prevent child stream aborts due to dry-run record limits from stopping sibling or parent stream processing by catching abort exceptions during child sync.

Tests:
- Add a regression test verifying that parent and sibling records are still emitted, and child records are correctly capped, when a child stream hits the dry-run record limit.