### PR TITLE
fix: Constrain `simpleeval` dependency to prevent issues with using `json` in stream maps expressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "PyYAML>=6.0",
     "referencing>=0.30.0",
     "requests>=2.25.1",
-    "simpleeval>=0.9.13,!=1.0.1",
+    "simpleeval>=0.9.13,!=1.0.1,<1.0.5",
     "simplejson>=3.17.6",
     "sqlalchemy>=2",
     "typing-extensions>=4.5.0; python_version < '3.13'",

--- a/uv.lock
+++ b/uv.lock
@@ -904,7 +904,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2923,7 +2923,7 @@ requires-dist = [
     { name = "referencing", specifier = ">=0.30.0" },
     { name = "requests", specifier = ">=2.25.1" },
     { name = "s3fs", marker = "extra == 's3'", specifier = ">=2024.9.0" },
-    { name = "simpleeval", specifier = ">=0.9.13,!=1.0.1" },
+    { name = "simpleeval", specifier = ">=0.9.13,!=1.0.1,<1.0.5" },
     { name = "simplejson", specifier = ">=3.17.6" },
     { name = "sqlalchemy", specifier = ">=2" },
     { name = "sqlalchemy", marker = "extra == 'sql'", specifier = ">=2" },


### PR DESCRIPTION
Backport of 

- https://github.com/meltano/sdk/pull/3560

## Summary by Sourcery

Constrain the simpleeval dependency version to avoid a breaking change in recent releases.

Bug Fixes:
- Pin simpleeval to versions below 1.0.5 to prevent regressions affecting stream maps expressions referencing modules.

Build:
- Adjust project dependency specification to restrict simpleeval to <1.0.5.