### PR TITLE
chore: Merge branch 'v0.53'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Singer SDK Version
       description: Version of the library you are using
-      placeholder: "0.53.5"
+      placeholder: "0.53.6"
     validations:
       required: true
   - type: checkboxes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v0.53.6 (2026-03-13)
 
-## v0.53.6 (2026-03-13)
-
 ### 🐛 Fixes
 
 - [#3562](https://github.com/meltano/sdk/issues/3562) Constrain `simpleeval` dependency to prevent issues with using `json` in stream maps expressions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixes
 
-- [#3562](https://github.com/meltano/sdk/issues/3562) Constrain `simpleeval` dependency to prevent issues with using `json` in stream maps expressions
+- [#3562](https://github.com/meltano/sdk/issues/3562) Constrain `simpleeval` dependency to prevent issues when using `json` in stream maps expressions
 
 ## v0.53.5 (2026-01-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.53.6 (2026-03-13)
+
+## v0.53.6 (2026-03-13)
+
+### 🐛 Fixes
+
+- [#3562](https://github.com/meltano/sdk/issues/3562) Constrain `simpleeval` dependency to prevent issues with using `json` in stream maps expressions
+
 ## v0.53.5 (2026-01-06)
 
 ### 🐛 Fixes

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -32,9 +32,9 @@ license-files = [ "LICENSE" ]
 requires-python = ">=3.10"
 dependencies = [
     {%- if cookiecutter.faker_extra %}
-    "singer-sdk[faker]~=0.53.5",
+    "singer-sdk[faker]~=0.53.6",
     {%- else %}
-    "singer-sdk~=0.53.5",
+    "singer-sdk~=0.53.6",
     {%- endif %}
     "typing-extensions>=4.5.0; python_version < '3.13'",
 ]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -35,9 +35,9 @@ license-files = [ "LICENSE" ]
 requires-python = ">=3.10"
 dependencies = [
     {%- if extras %}
-    "singer-sdk[{{ extras|join(',') }}]~=0.53.5",
+    "singer-sdk[{{ extras|join(',') }}]~=0.53.6",
     {%- else %}
-    "singer-sdk~=0.53.5",
+    "singer-sdk~=0.53.6",
     {%- endif %}
     {%- if cookiecutter.stream_type in ["REST", "GraphQL"] %}
     "requests~=2.32.3",

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -31,9 +31,9 @@ license-files = [ "LICENSE" ]
 requires-python = ">=3.10"
 dependencies = [
     {%- if cookiecutter.faker_extra %}
-    "singer-sdk[faker]~=0.53.5",
+    "singer-sdk[faker]~=0.53.6",
     {%- else %}
-    "singer-sdk~=0.53.5",
+    "singer-sdk~=0.53.6",
     {%- endif %}
     {%- if cookiecutter.serialization_method == "SQL" %}
     "sqlalchemy~=2.0",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ copyright = f"{datetime.now().year}, Arch Data, Inc and Contributors"  # noqa: A
 author = "Meltano Core Team and Contributors"
 
 # The full version, including alpha/beta/rc tags
-release = "0.53.5"
+release = "0.53.6"
 
 
 # -- General configuration -------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,7 +218,7 @@ xfail_strict = false
 
 [tool.commitizen]
 name = "cz_version_bump"
-version = "0.53.5"
+version = "0.53.6"
 changelog_merge_prerelease = true
 prerelease_offset = 1
 tag_format = "v$major.$minor.$patch$prerelease"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "PyYAML>=6.0",
     "referencing>=0.30.0",
     "requests>=2.25.1",
-    "simpleeval>=0.9.13,!=1.0.1",
+    "simpleeval>=0.9.13,!=1.0.1,<1.0.5",
     "simplejson>=3.17.6",
     "sqlalchemy>=2",
     "typing-extensions>=4.5.0; python_version < '3.13'",

--- a/uv.lock
+++ b/uv.lock
@@ -904,7 +904,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2923,7 +2923,7 @@ requires-dist = [
     { name = "referencing", specifier = ">=0.30.0" },
     { name = "requests", specifier = ">=2.25.1" },
     { name = "s3fs", marker = "extra == 's3'", specifier = ">=2024.9.0" },
-    { name = "simpleeval", specifier = ">=0.9.13,!=1.0.1" },
+    { name = "simpleeval", specifier = ">=0.9.13,!=1.0.1,<1.0.5" },
     { name = "simplejson", specifier = ">=3.17.6" },
     { name = "sqlalchemy", specifier = ">=2" },
     { name = "sqlalchemy", marker = "extra == 'sql'", specifier = ">=2" },


### PR DESCRIPTION
## Summary by Sourcery

Release version 0.53.6 across the project and templates, documenting the change and aligning configuration and tooling references.

Bug Fixes:
- Document the constraint on the simpleeval dependency to avoid issues when using json in stream map expressions.

Enhancements:
- Update all cookiecutter templates to depend on singer-sdk version 0.53.6.
- Align documentation, issue templates, and versioning config with the 0.53.6 release.