### PR TITLE
feat: Normalize individual members in `oneOf` members in OpenAPI specs

### DIFF
--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -374,10 +374,13 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
         if "allOf" in result:
             result = self.normalize_schema(self.handle_all_of(result["allOf"]))
 
-        if "oneOf" in result and len(result["oneOf"]) == 1:
-            (inner,) = result.pop("oneOf")
-            result.update(self.normalize_schema(inner))
-            schema_type = result.get("type", [])
+        if "oneOf" in result:
+            if len(result["oneOf"]) == 1:
+                (inner,) = result.pop("oneOf")
+                result.update(self.normalize_schema(inner))
+                schema_type = result.get("type", [])
+            else:
+                result["oneOf"] = [self.normalize_schema(s) for s in result["oneOf"]]
 
         types = [schema_type] if isinstance(schema_type, str) else schema_type
         if result.pop("nullable", False) and types and "null" not in types:

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -714,6 +714,13 @@ class TestOpenAPISchemaNormalization:
                             },
                         },
                     },
+                    "MultipleOneOf": {
+                        "oneOf": [
+                            {"type": "object", "properties": {"x": {"type": "string"}}},
+                            {"type": "object", "properties": {"y": {"type": "string"}}},
+                            {"type": "object", "properties": {"z": {"type": "string"}}},
+                        ],
+                    },
                     "AllOfNoElements": {
                         "allOf": [],
                     },
@@ -792,6 +799,14 @@ class TestOpenAPISchemaNormalization:
         normalized = source.preprocess_schema(schema)
         assert "oneOf" not in normalized["properties"]["value"]
         assert normalized["properties"]["value"]["type"] == ["integer", "null"]
+
+    def test_normalize_one_recursive(self, source: OpenAPISchema):
+        """Test that single-element oneOf constructs are unwrapped."""
+        schema = source.fetch_schema("MultipleOneOf")
+        assert all(elem["type"] == "object" for elem in schema["oneOf"])
+
+        normalized = source.preprocess_schema(schema)
+        assert all(elem["type"] == ["object", "null"] for elem in normalized["oneOf"])
 
     def test_normalize_all_of_no_elements(self, source: OpenAPISchema):
         """Test that an empty allOf is normalized to an empty schema."""


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Normalize all members of OpenAPI `oneOf` schemas during preprocessing while preserving existing single-element unwrapping behavior.

Enhancements:
- Normalize each branch of multi-element `oneOf` schemas when preprocessing OpenAPI schemas, in addition to unwrapping single-element `oneOf` cases.

Tests:
- Add fixture schema with multiple `oneOf` object variants and a test verifying that each branch is normalized consistently, including nullability handling.