### PR TITLE
feat: Normalize individual members in `anyOf` members in OpenAPI specs

### DIFF
--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -382,6 +382,9 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
             else:
                 result["oneOf"] = [self.normalize_schema(s) for s in result["oneOf"]]
 
+        if "anyOf" in result:
+            result["anyOf"] = [self.normalize_schema(s) for s in result["anyOf"]]
+
         types = [schema_type] if isinstance(schema_type, str) else schema_type
         if result.pop("nullable", False) and types and "null" not in types:
             result["type"] = [*types, "null"]

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -808,7 +808,7 @@ class TestOpenAPISchemaNormalization:
         assert normalized["properties"]["value"]["type"] == ["integer", "null"]
 
     def test_normalize_one_of_recursive(self, source: OpenAPISchema):
-        """Test that single-element oneOf constructs are unwrapped."""
+        """Test that oneOf are recursively normalized to nullable object members."""
         schema = source.fetch_schema("MultipleOneOf")
         assert all(elem["type"] == "object" for elem in schema["oneOf"])
 
@@ -816,7 +816,7 @@ class TestOpenAPISchemaNormalization:
         assert all(elem["type"] == ["object", "null"] for elem in normalized["oneOf"])
 
     def test_normalize_any_of_recursive(self, source: OpenAPISchema):
-        """Test that anyOf constructs are recursively normalized to nullable object members."""
+        """Test that anyOf are recursively normalized to nullable object members."""
         schema = source.fetch_schema("MultipleAnyOf")
         assert all(elem["type"] == "object" for elem in schema["anyOf"])
 

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -816,7 +816,7 @@ class TestOpenAPISchemaNormalization:
         assert all(elem["type"] == ["object", "null"] for elem in normalized["oneOf"])
 
     def test_normalize_any_of_recursive(self, source: OpenAPISchema):
-        """Test that single-element oneOf constructs are unwrapped."""
+        """Test that anyOf constructs are recursively normalized to nullable object members."""
         schema = source.fetch_schema("MultipleAnyOf")
         assert all(elem["type"] == "object" for elem in schema["anyOf"])
 

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -721,6 +721,13 @@ class TestOpenAPISchemaNormalization:
                             {"type": "object", "properties": {"z": {"type": "string"}}},
                         ],
                     },
+                    "MultipleAnyOf": {
+                        "anyOf": [
+                            {"type": "object", "properties": {"x": {"type": "string"}}},
+                            {"type": "object", "properties": {"y": {"type": "string"}}},
+                            {"type": "object", "properties": {"z": {"type": "string"}}},
+                        ],
+                    },
                     "AllOfNoElements": {
                         "allOf": [],
                     },
@@ -800,13 +807,21 @@ class TestOpenAPISchemaNormalization:
         assert "oneOf" not in normalized["properties"]["value"]
         assert normalized["properties"]["value"]["type"] == ["integer", "null"]
 
-    def test_normalize_one_recursive(self, source: OpenAPISchema):
+    def test_normalize_one_of_recursive(self, source: OpenAPISchema):
         """Test that single-element oneOf constructs are unwrapped."""
         schema = source.fetch_schema("MultipleOneOf")
         assert all(elem["type"] == "object" for elem in schema["oneOf"])
 
         normalized = source.preprocess_schema(schema)
         assert all(elem["type"] == ["object", "null"] for elem in normalized["oneOf"])
+
+    def test_normalize_any_of_recursive(self, source: OpenAPISchema):
+        """Test that single-element oneOf constructs are unwrapped."""
+        schema = source.fetch_schema("MultipleAnyOf")
+        assert all(elem["type"] == "object" for elem in schema["anyOf"])
+
+        normalized = source.preprocess_schema(schema)
+        assert all(elem["type"] == ["object", "null"] for elem in normalized["anyOf"])
 
     def test_normalize_all_of_no_elements(self, source: OpenAPISchema):
         """Test that an empty allOf is normalized to an empty schema."""


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Tests:
- Add fixtures and tests covering recursive normalization of `anyOf` and `oneOf` member schemas in OpenAPI definitions.