### PR TITLE
refactor: Rename `IgnorableSyncError` -> `SkippableSyncError`

### DIFF
--- a/singer_sdk/exceptions.py
+++ b/singer_sdk/exceptions.py
@@ -44,8 +44,8 @@ __all__ = [  # noqa: RUF022
     "RetriableSyncError",
     "RetriableAPIError",
     # Sync — ignorable
-    "IgnorableSyncError",
-    "IgnorableAPIError",
+    "SkippableSyncError",
+    "SkippableAPIError",
     "InvalidRecord",
     # Sync — data quality
     "DataError",
@@ -245,15 +245,15 @@ class RetriableAPIError(RetriableSyncError):
 # ---------------------------------------------------------------------------
 
 
-class IgnorableSyncError(SyncError):
+class SkippableSyncError(SyncError):
     """Raised when an error can be logged, skipped, and the sync continued."""
 
 
-class IgnorableAPIError(IgnorableSyncError):
+class SkippableAPIError(SkippableSyncError):
     """Raised when a failed API request can be safely ignored and the sync continued."""
 
 
-class InvalidRecord(IgnorableSyncError):
+class InvalidRecord(SkippableSyncError):
     """Raised when a stream record is invalid according to its declared schema."""
 
     def __init__(self, error_message: str, record: dict) -> None:


### PR DESCRIPTION
## Summary by Sourcery

Rename ignorable sync/API error types to skippable variants and adjust dependent exception classes accordingly.

Enhancements:
- Rename IgnorableSyncError to SkippableSyncError and IgnorableAPIError to SkippableAPIError for clearer semantics.
- Update InvalidRecord to inherit from the new SkippableSyncError base class.