### PR TITLE
refactor: Use `dict(...)` to copy the default functions supported in stream maps

### DIFF
--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -316,7 +316,7 @@ class CustomStreamMap(StreamMap):
         Returns:
             Functions which should be available for expression evaluation.
         """
-        funcs: dict[str, t.Any] = simpleeval.DEFAULT_FUNCTIONS.copy()
+        funcs: dict[str, t.Any] = dict(simpleeval.DEFAULT_FUNCTIONS)
         funcs["md5"] = md5
         funcs["sha256"] = sha256
         funcs["datetime"] = datetime


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Enhancements:
- Use a direct dict() construction instead of .copy() when cloning simpleeval's DEFAULT_FUNCTIONS in the stream mapper.