### PR TITLE
ci: Switch to `griffecli`

### DIFF
--- a/.github/workflows/api-changes.yml
+++ b/.github/workflows/api-changes.yml
@@ -5,7 +5,9 @@ on:
     paths:
     - singer_sdk/**
     - .github/workflows/api-changes.yml
+    - .github/workflows/resources/requirements.txt
     - CHANGELOG.md
+    - noxfile.py
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/resources/requirements.txt
+++ b/.github/workflows/resources/requirements.txt
@@ -1,4 +1,4 @@
-griffe~=2.0
+griffecli~=2.0
 nox==2026.2.9
 prek==0.3.6
 twine==6.2.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -498,7 +498,6 @@ def api_changes(session: nox.Session) -> None:
     """Check for API changes."""
     args = [
         "check",
-        "--no-color",
         "singer_sdk",
     ]
 
@@ -508,7 +507,7 @@ def api_changes(session: nox.Session) -> None:
     if "GITHUB_ACTIONS" in os.environ:
         args.append("-f=github")
 
-    session.run("uvx", "griffe", *args, external=True)
+    session.run("uvx", "griffecli", *args, external=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Switch the CI and nox session tooling from griffe to griffecli for API change checks.

Build:
- Update workflow requirements to depend on griffecli instead of griffe.

CI:
- Update the api_changes nox session to invoke griffecli via uvx for API checks.