### PR TITLE
chore: Added some needed `ty: ignore` comments

### DIFF
--- a/singer_sdk/helpers/capabilities.py
+++ b/singer_sdk/helpers/capabilities.py
@@ -328,7 +328,7 @@ TARGET_LOAD_METHOD_CONFIG = PropertiesList(
             TargetLoadMethods.APPEND_ONLY,
             TargetLoadMethods.UPSERT,
             TargetLoadMethods.OVERWRITE,
-        ],
+        ],  # ty:ignore[invalid-argument-type]
         default=TargetLoadMethods.APPEND_ONLY,
     ),
 ).to_dict()


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Bug Fixes:
- Silence a static type-checking error on the target load methods configuration by adding an appropriate ignore annotation.