### PR TITLE
refactor: Import `DatetimeErrorTreatmentEnum` from `singer_sdk.helpers.conform`

### DIFF
--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -28,10 +28,10 @@ from singer_sdk.helpers._compat import (
     time_fromisoformat,
 )
 from singer_sdk.helpers._typing import (
-    DatetimeErrorTreatmentEnum,
     get_datelike_property_type,
     handle_invalid_timestamp_in_record,
 )
+from singer_sdk.helpers.conform import DatetimeErrorTreatmentEnum
 from singer_sdk.singerlib.json import deserialize_json
 from singer_sdk.typing import DEFAULT_JSONSCHEMA_VALIDATOR
 


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Enhancements:
- Consolidate DatetimeErrorTreatmentEnum usage in sink core to import from the common singer_sdk.helpers.conform module for consistency.