### PR TITLE
WIP: Test with upstream simpleeval PR for checking disallowed items at name-resolution boundary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -491,6 +491,7 @@ meltano-tap-sqlite = { workspace = true }
 meltano-target-csv = { workspace = true }
 meltano-target-parquet = { workspace = true }
 meltano-target-sqlite = { workspace = true }
+simpleeval = { git = "https://github.com/meltano/simpleeval.git", rev = "fix/check-at-names-boundary" }
 
 [tool.uv.workspace]
 members = [

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -14,7 +14,6 @@ import hashlib
 import importlib.util
 import json
 import logging
-import sys
 import typing as t
 
 import simpleeval
@@ -27,11 +26,6 @@ from singer_sdk.helpers._flattening import (
     flatten_schema,
     get_flattening_options,
 )
-
-if sys.version_info >= (3, 12):
-    from typing import override  # noqa: ICN003
-else:
-    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from faker import Faker
@@ -244,72 +238,6 @@ class SameRecordTransform(DefaultStreamMap):
         return True
 
 
-class _MapperEval(simpleeval.EvalWithCompoundTypes):
-    """Evaluator for stream map expressions.
-
-    Overrides ``_check_disallowed_items`` to skip the per-AST-node safety check
-    added in simpleeval 1.0.5 (CVE-2026-32640).  Safety is preserved by:
-
-    - all module objects in ``functions`` being wrapped in
-      ``simpleeval.ModuleWrapper`` before being passed here;
-    - ``_eval_attribute`` still raising ``FeatureNotAvailable`` when a bare
-      ``types.ModuleType`` leaks through an attribute chain; and
-    - ``_eval_call`` still rejecting ``DISALLOW_FUNCTIONS`` callables.
-
-    Singer records are JSON-serializable and cannot carry raw module objects
-    through the ``names`` dict, so the redundant container scan is safe to elide.
-    """
-
-    @override
-    def _check_disallowed_items(self, item: t.Any) -> None:
-        return
-
-    @override
-    def _eval(self, node: ast.AST) -> t.Any:
-        try:
-            handler = self.nodes[type(node)]  # ty:ignore[invalid-argument-type, not-subscriptable]
-        except KeyError:
-            msg = f"Sorry, {type(node).__name__} is not available in this evaluator"
-            raise simpleeval.FeatureNotAvailable(msg) from None
-
-        return handler(node)
-
-    @override
-    def _eval_name(self, node: ast.Name) -> t.Any:
-        try:
-            # This happens at least for slicing
-            # This is a safe thing to do because it is impossible
-            # that there is a true expression assigning to none
-            # (the compiler rejects it, so you can't even
-            # pass that to ast.parse)
-            val = self.names[node.id]
-            self._check_disallowed_items(val)
-        except (TypeError, KeyError):
-            pass
-        else:
-            return val
-
-        if callable(self.names):
-            try:
-                val = self.names(node)  # ty:ignore[call-top-callable]
-                self._check_disallowed_items(val)
-            except simpleeval.NameNotDefined:
-                pass
-            else:
-                return val
-
-        elif not hasattr(self.names, "__getitem__"):
-            msg = f'Trying to use name (variable) "{node.id}" when no "names" defined for evaluator'  # noqa: E501
-            raise simpleeval.InvalidExpression(msg)
-
-        if node.id in self.functions:
-            val = self.functions[node.id]
-            self._check_disallowed_items(val)
-            return val
-
-        raise simpleeval.NameNotDefined(node.id, self.expr)
-
-
 class CustomStreamMap(StreamMap):
     """Defines transformation logic for a singer stream map."""
 
@@ -355,9 +283,7 @@ class CustomStreamMap(StreamMap):
             self._transform_fn,
             self.transformed_schema,
         ) = self._init_functions_and_schema(stream_map=map_transform)
-        self.expr_evaluator: simpleeval.EvalWithCompoundTypes = _MapperEval(
-            functions=self.functions,
-        )
+        self.expr_evaluator = simpleeval.EvalWithCompoundTypes(functions=self.functions)
         self.fake = self._init_faker_instance()
 
     def transform(self, record: dict) -> dict | None:
@@ -939,7 +865,7 @@ class PluginMapper:
         result: str
 
         try:
-            expr_evaluator = _MapperEval(names=names)
+            expr_evaluator = simpleeval.EvalWithCompoundTypes(names=names)
             result = expr_evaluator.eval(expr)
         except simpleeval.NameNotDefined:
             logger.debug(

--- a/uv.lock
+++ b/uv.lock
@@ -2731,11 +2731,7 @@ wheels = [
 [[package]]
 name = "simpleeval"
 version = "1.0.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b4/9d/e7c9309940794dd3073cba2e5101df5874d84243595ce63b1e1c8f9b9c76/simpleeval-1.0.7.tar.gz", hash = "sha256:1e10e5f9fec597814444e20c0892ed15162fa214c8a88f434b5b077cf2fef85b", size = 30250, upload-time = "2026-03-16T10:53:03.464Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/2f/f32aa85591882378bb43caa09363f3ed97df399369a5144c7f19f2275bc0/simpleeval-1.0.7-py3-none-any.whl", hash = "sha256:97ac271bfd8f2af9e7b9a36ceea67617f26fa873f9d5ae1922f64d4c1442534b", size = 18792, upload-time = "2026-03-16T10:53:02.103Z" },
-]
+source = { git = "https://github.com/meltano/simpleeval.git?rev=fix%2Fcheck-at-names-boundary#ab5861a372bb88f36b581c532fff0a197d9d1998" }
 
 [[package]]
 name = "simplejson"
@@ -3014,7 +3010,7 @@ requires-dist = [
     { name = "referencing", specifier = ">=0.30.0" },
     { name = "requests", specifier = ">=2.25.1" },
     { name = "s3fs", marker = "extra == 's3'", specifier = ">=2024.9.0" },
-    { name = "simpleeval", specifier = "==1.0.7" },
+    { name = "simpleeval", git = "https://github.com/meltano/simpleeval.git?rev=fix%2Fcheck-at-names-boundary" },
     { name = "simplejson", specifier = ">=3.17.6" },
     { name = "sqlalchemy", specifier = ">=2" },
     { name = "sqlalchemy", marker = "extra == 'sql'", specifier = ">=2" },


### PR DESCRIPTION
## Related

- Upstream: https://github.com/danthedeckie/simpleeval/pull/181
- Closes https://github.com/meltano/sdk/issues/3561

## Summary by Sourcery

Wrap simpleeval datetime and json functions with module wrappers and pin simpleeval to a specific upstream Git revision for boundary checking behavior.

Enhancements:
- Expose datetime and json to the mapper expression evaluator via simpleeval.ModuleWrapper instead of raw modules.

Build:
- Depend on a specific upstream simpleeval Git revision with the fix/check-at-names-boundary branch.