### PR TITLE
test: Run pytest in strict mode and fix duplicate parametrization IDs

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -157,7 +157,7 @@ def tests(session: nox.Session) -> None:
     )
 
 
-@nox.session(name="test-external", python=main_python, tags=["test"], default=False)
+@nox.session(name="test-external", python=main_python, tags=["test"])
 def test_external(session: nox.Session) -> None:
     """Execute pytest tests and compute coverage."""
     session.run_install(
@@ -181,7 +181,6 @@ def test_external(session: nox.Session) -> None:
     name="test-contrib",
     python=[python_versions[0], main_python],
     tags=["test"],
-    default=False,
 )
 def test_contrib(session: nox.Session) -> None:
     """Execute pytest tests and compute coverage."""
@@ -209,7 +208,6 @@ def test_contrib(session: nox.Session) -> None:
     name="test-packages",
     python=[python_versions[0], main_python],
     tags=["test"],
-    default=False,
 )
 def test_packages(session: nox.Session) -> None:
     """Execute pytest tests and compute coverage."""
@@ -238,7 +236,6 @@ def test_packages(session: nox.Session) -> None:
     name="test-lowest",
     python=python_versions[0],
     tags=["test"],
-    default=False,
 )
 def test_lowest_requirements(session: nox.Session) -> None:
     """Test the package with the lowest dependency versions."""
@@ -344,7 +341,7 @@ def dependencies(session: nox.Session) -> None:
     session.run("deptry", "singer_sdk", *session.posargs)
 
 
-@nox.session(name="snap", default=False)
+@nox.session(name="snap")
 def update_snapshots(session: nox.Session) -> None:
     """Update pytest snapshots."""
     session.run_install(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,9 +218,9 @@ markers = [
     "snapshot: Tests that use pytest-snapshot",
 ]
 minversion = "9"
-testpaths = ["tests"]
 norecursedirs = ["cookiecutter"]
-strict = false
+strict = true
+testpaths = ["tests"]
 
 [tool.commitizen]
 name = "cz_version_bump"

--- a/tests/core/rest/test_failure.py
+++ b/tests/core/rest/test_failure.py
@@ -132,8 +132,8 @@ def custom_validation_stream(rest_tap):
     ],
     ids=[
         "client-error",
-        "server-error",
-        "server-error",
+        "server-error-503",
+        "server-error-521",
         "rate-limited",
         "forbidden-with-content",
         "forbidden-empty-content",


### PR DESCRIPTION
Docs: https://docs.pytest.org/en/stable/explanation/goodpractices.html#using-pytest-s-strict-mode

## Summary by Sourcery

Enable stricter pytest configuration and adjust test sessions to run by default.

Enhancements:
- Make several nox test sessions (external, contrib, packages, lowest, and snapshot updates) enabled by default.

Tests:
- Enable pytest strict mode and keep tests discovery limited to the tests directory.
- Fix duplicate parameter IDs in REST failure tests to avoid conflicts under strict mode.