### PR TITLE
fix(mappers): Support `simpleeval` 1.0.5+ by subclassing `simpleeval.EvalWithCompoundTypes`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "PyYAML>=6.0",
     "referencing>=0.30.0",
     "requests>=2.25.1",
-    "simpleeval>=0.9.13,!=1.0.1,<1.0.5",
+    "simpleeval==1.0.7",
     "simplejson>=3.17.6",
     "sqlalchemy>=2",
     "typing-extensions>=4.5.0; python_version < '3.13'",

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -14,6 +14,7 @@ import hashlib
 import importlib.util
 import json
 import logging
+import sys
 import typing as t
 
 import simpleeval  # type: ignore[import-untyped]
@@ -26,6 +27,11 @@ from singer_sdk.helpers._flattening import (
     flatten_schema,
     get_flattening_options,
 )
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from faker import Faker
@@ -238,6 +244,72 @@ class SameRecordTransform(DefaultStreamMap):
         return True
 
 
+class _MapperEval(simpleeval.EvalWithCompoundTypes):
+    """Evaluator for stream map expressions.
+
+    Overrides ``_check_disallowed_items`` to skip the per-AST-node safety check
+    added in simpleeval 1.0.5 (CVE-2026-32640).  Safety is preserved by:
+
+    - all module objects in ``functions`` being wrapped in
+      ``simpleeval.ModuleWrapper`` before being passed here;
+    - ``_eval_attribute`` still raising ``FeatureNotAvailable`` when a bare
+      ``types.ModuleType`` leaks through an attribute chain; and
+    - ``_eval_call`` still rejecting ``DISALLOW_FUNCTIONS`` callables.
+
+    Singer records are JSON-serializable and cannot carry raw module objects
+    through the ``names`` dict, so the redundant container scan is safe to elide.
+    """
+
+    @override
+    def _check_disallowed_items(self, item: t.Any) -> None:
+        return
+
+    @override
+    def _eval(self, node: ast.AST) -> t.Any:
+        try:
+            handler = self.nodes[type(node)]  # ty:ignore[invalid-argument-type, not-subscriptable]
+        except KeyError:
+            msg = f"Sorry, {type(node).__name__} is not available in this evaluator"
+            raise simpleeval.FeatureNotAvailable(msg) from None
+
+        return handler(node)
+
+    @override
+    def _eval_name(self, node: ast.Name) -> t.Any:
+        try:
+            # This happens at least for slicing
+            # This is a safe thing to do because it is impossible
+            # that there is a true expression assigning to none
+            # (the compiler rejects it, so you can't even
+            # pass that to ast.parse)
+            val = self.names[node.id]
+            self._check_disallowed_items(val)
+        except (TypeError, KeyError):
+            pass
+        else:
+            return val
+
+        if callable(self.names):
+            try:
+                val = self.names(node)  # ty:ignore[call-top-callable]
+                self._check_disallowed_items(val)
+            except simpleeval.NameNotDefined:
+                pass
+            else:
+                return val
+
+        elif not hasattr(self.names, "__getitem__"):
+            msg = f'Trying to use name (variable) "{node.id}" when no "names" defined for evaluator'  # noqa: E501
+            raise simpleeval.InvalidExpression(msg)
+
+        if node.id in self.functions:
+            val = self.functions[node.id]
+            self._check_disallowed_items(val)
+            return val
+
+        raise simpleeval.NameNotDefined(node.id, self.expr)
+
+
 class CustomStreamMap(StreamMap):
     """Defines transformation logic for a singer stream map."""
 
@@ -283,7 +355,9 @@ class CustomStreamMap(StreamMap):
             self._transform_fn,
             self.transformed_schema,
         ) = self._init_functions_and_schema(stream_map=map_transform)
-        self.expr_evaluator = simpleeval.EvalWithCompoundTypes(functions=self.functions)
+        self.expr_evaluator: simpleeval.EvalWithCompoundTypes = _MapperEval(
+            functions=self.functions,
+        )
         self.fake = self._init_faker_instance()
 
     def transform(self, record: dict) -> dict | None:
@@ -319,9 +393,9 @@ class CustomStreamMap(StreamMap):
         funcs: dict[str, t.Any] = simpleeval.DEFAULT_FUNCTIONS.copy()
         funcs["md5"] = md5
         funcs["sha256"] = sha256
-        funcs["datetime"] = datetime
+        funcs["datetime"] = simpleeval.ModuleWrapper(datetime)
         funcs["bool"] = bool
-        funcs["json"] = json
+        funcs["json"] = simpleeval.ModuleWrapper(json)
         return funcs
 
     def _eval(
@@ -865,7 +939,7 @@ class PluginMapper:
         result: str
 
         try:
-            expr_evaluator = simpleeval.EvalWithCompoundTypes(names=names)
+            expr_evaluator = _MapperEval(names=names)
             result = expr_evaluator.eval(expr)
         except simpleeval.NameNotDefined:
             logger.debug(

--- a/uv.lock
+++ b/uv.lock
@@ -2745,11 +2745,11 @@ wheels = [
 
 [[package]]
 name = "simpleeval"
-version = "1.0.4"
+version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fd/d6/c25276f8aafd69172852a0f3564cf71b4339bae88d2609ee0843fb1eb6f7/simpleeval-1.0.4.tar.gz", hash = "sha256:32df6dfd5ca09212a7d8b45625b7a2b6aba697ad061a7b0f30938d7d158227fe", size = 37046, upload-time = "2026-03-11T07:40:38.666Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/9d/e7c9309940794dd3073cba2e5101df5874d84243595ce63b1e1c8f9b9c76/simpleeval-1.0.7.tar.gz", hash = "sha256:1e10e5f9fec597814444e20c0892ed15162fa214c8a88f434b5b077cf2fef85b", size = 30250, upload-time = "2026-03-16T10:53:03.464Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/bf/3b1df358e83606ab12fae5861e759ae18084599cfaa9c828b6f8c7cbef03/simpleeval-1.0.4-py3-none-any.whl", hash = "sha256:380318357214f4abb98a0527bd598417707e5416ea13d4b67debf3f67c506c22", size = 17249, upload-time = "2026-03-11T07:40:36.543Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2f/f32aa85591882378bb43caa09363f3ed97df399369a5144c7f19f2275bc0/simpleeval-1.0.7-py3-none-any.whl", hash = "sha256:97ac271bfd8f2af9e7b9a36ceea67617f26fa873f9d5ae1922f64d4c1442534b", size = 18792, upload-time = "2026-03-16T10:53:02.103Z" },
 ]
 
 [[package]]
@@ -3012,7 +3012,7 @@ requires-dist = [
     { name = "referencing", specifier = ">=0.30.0" },
     { name = "requests", specifier = ">=2.25.1" },
     { name = "s3fs", marker = "extra == 's3'", specifier = ">=2024.9.0" },
-    { name = "simpleeval", specifier = ">=0.9.13,!=1.0.1,<1.0.5" },
+    { name = "simpleeval", specifier = "==1.0.7" },
     { name = "simplejson", specifier = ">=3.17.6" },
     { name = "sqlalchemy", specifier = ">=2" },
     { name = "sqlalchemy", marker = "extra == 'sql'", specifier = ">=2" },


### PR DESCRIPTION
## Related

- https://github.com/meltano/sdk/issues/3561
- https://github.com/meltano/sdk/issues/3595
- Re-implements upstream https://github.com/danthedeckie/simpleeval/pull/181

## Summary by Sourcery

Update stream mapper expression evaluation to be compatible with simpleeval 1.0.5+ while preserving the mapper’s existing safety guarantees.

New Features:
- Introduce a dedicated mapper expression evaluator subclass to control how AST nodes, names, and disallowed items are handled during evaluation.

Bug Fixes:
- Fix incompatibility with simpleeval 1.0.5+ by bypassing its new redundant container safety scan in a controlled way.

Enhancements:
- Wrap datetime and json modules with simpleeval.ModuleWrapper when exposing them as mapper functions to align with simpleeval’s safety model.

Build:
- Pin simpleeval to version 1.0.7 in project dependencies.