### PR TITLE
perf(mappers): Pre-build static names dict at init time

### DIFF
--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -39,6 +39,8 @@ if t.TYPE_CHECKING:
     from singer_sdk.helpers._flattening import FlatteningOptions
     from singer_sdk.singerlib.catalog import Catalog
 
+FunctionsDict: t.TypeAlias = dict[str, t.Callable | simpleeval.ModuleWrapper]
+
 
 MAPPER_ELSE_OPTION = "__else__"
 MAPPER_FILTER_OPTION = "__filter__"
@@ -348,6 +350,20 @@ class CustomStreamMap(StreamMap):
         self.faker_config = faker_config
         self.stream_name = stream_name
 
+        self.expr_evaluator = _MapperEval(functions=self.functions)
+        self.fake = self._init_faker_instance()
+
+        # Pre-build the static portion of the names dict (entries that never change
+        # across records).  Record-specific entries (_/record/self) are merged in at
+        # eval time.
+        self._static_eval_names: dict[str, t.Any] = {
+            "config": self.map_config,
+            "__stream_name__": self.stream_alias,
+            "__original_stream_name__": self.stream_name,
+        }
+        if self.fake:
+            self._static_eval_names["fake"] = self.fake
+
         self._transform_fn: t.Callable[[dict], dict | None]
         self._filter_fn: t.Callable[[dict], bool]
         (
@@ -355,9 +371,6 @@ class CustomStreamMap(StreamMap):
             self._transform_fn,
             self.transformed_schema,
         ) = self._init_functions_and_schema(stream_map=map_transform)
-        self.expr_evaluator: simpleeval.EvalWithCompoundTypes = _MapperEval(
-            functions=self.functions,
-        )
         self.fake = self._init_faker_instance()
 
     def transform(self, record: dict) -> dict | None:
@@ -384,7 +397,7 @@ class CustomStreamMap(StreamMap):
         return self._filter_fn(record)
 
     @property
-    def functions(self) -> dict[str, t.Callable]:
+    def functions(self) -> FunctionsDict:
         """Get available transformation functions.
 
         Returns:
@@ -397,6 +410,25 @@ class CustomStreamMap(StreamMap):
         funcs["bool"] = bool
         funcs["json"] = simpleeval.ModuleWrapper(json)
         return funcs
+
+    def _build_eval_names(self, record: dict) -> dict:
+        """Build the simpleeval names dict for a single record.
+
+        Merges the pre-built static names (config, stream name, faker) with the
+        record fields.  Callers can then set ``names["self"]`` for per-property
+        access before each ``_eval`` call.
+
+        Args:
+            record: The current stream record.
+
+        Returns:
+            Names dict ready to pass to the expression evaluator.
+        """
+        names = dict(self._static_eval_names)
+        names.update(record)
+        names["_"] = record
+        names["record"] = record
+        return names
 
     def _eval(
         self,
@@ -419,17 +451,7 @@ class CustomStreamMap(StreamMap):
         Raises:
             MapExpressionError: If the mapping expression failed to evaluate.
         """
-        names = record.copy()  # Start with names from record properties
-        names["_"] = record  # Add a shorthand alias in case of reserved words in names
-        names["record"] = record  # ...and a longhand alias
-        names["config"] = self.map_config  # Allow map config access within transform
-        names["__stream_name__"] = self.stream_alias  # Access stream name in transform
-
-        # Stream name (prior to aliasing, if applicable)
-        names["__original_stream_name__"] = self.stream_name
-
-        if self.fake:
-            names["fake"] = self.fake
+        names = self._build_eval_names(record)
 
         if property_name and property_name in record:
             # Allow access to original property value if applicable


### PR DESCRIPTION
The names dict passed to simpleeval contains several entries that never
change across records: config, __stream_name__, __original_stream_name__,
and (optionally) fake.  Previously these were assembled from scratch
inside _eval on every single property of every record.

This commit builds those entries once in __init__ into
_static_eval_names and introduces _build_eval_names(record), which
copies that base dict and merges only the record-level fields.  _eval
now calls _build_eval_names instead of performing the inline assembly.

The evaluator and faker are also moved before _init_functions_and_schema
so _static_eval_names can be fully populated before any transform closure
is created.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Optimize mapper expression evaluation by reusing a pre-built static names dictionary for each record instead of rebuilding it per property.

Enhancements:
- Pre-compute a static simpleeval names dictionary at mapper initialization and reuse it when evaluating expressions for each record.
- Introduce a helper to construct per-record evaluation contexts, separating static and record-specific entries.
- Adjust mapper initialization order and type aliases to better support the shared evaluator and names dictionary.