### PR TITLE
fix(mappers): Remove extremely noisy debug logging from expression evaluation

### DIFF
--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -444,8 +444,6 @@ class CustomStreamMap(StreamMap):
             msg = f"Failed to evaluate simpleeval expressions {expr}."
             raise MapExpressionError(msg) from ex
 
-        logger.debug("Eval result: %s = %s", expr, result)
-
         return result
 
     def _eval_type(  # noqa: PLR0911


### PR DESCRIPTION
`logger.debug("Eval result: …")` was called for every evaluated
property even when DEBUG logging was inactive, causing unnecessary
string-formatting work in the hot path.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Bug Fixes:
- Eliminate unconditional formatting work for debug log messages when DEBUG logging is disabled.