### PR TITLE
feat(taps): Allow customization of replication value comparisons for advancing state bookmark beyond the default "greater than or equal" check

### DIFF
--- a/docs/classes/singer_sdk.AscendingComparator.rst
+++ b/docs/classes/singer_sdk.AscendingComparator.rst
@@ -1,0 +1,8 @@
+﻿singer_sdk.AscendingComparator
+==============================
+
+.. currentmodule:: singer_sdk
+
+.. autoclass:: AscendingComparator
+    :members:
+    :special-members: __init__, __call__

--- a/docs/classes/singer_sdk.StateComparator.rst
+++ b/docs/classes/singer_sdk.StateComparator.rst
@@ -1,0 +1,8 @@
+﻿singer_sdk.StateComparator
+==========================
+
+.. currentmodule:: singer_sdk
+
+.. autoclass:: StateComparator
+    :members:
+    :special-members: __init__, __call__

--- a/docs/classes/singer_sdk.StrictAscendingComparator.rst
+++ b/docs/classes/singer_sdk.StrictAscendingComparator.rst
@@ -1,0 +1,8 @@
+﻿singer_sdk.StrictAscendingComparator
+====================================
+
+.. currentmodule:: singer_sdk
+
+.. autoclass:: StrictAscendingComparator
+    :members:
+    :special-members: __init__, __call__

--- a/docs/incremental_replication.md
+++ b/docs/incremental_replication.md
@@ -49,6 +49,50 @@ class CommentsStream(RESTStream):
 - In incremental replication, it is OK and usually recommended to resend rows where the replication key is equal to previous highest key. Targets are expected to update rows that are re-synced.
 ```
 
+## Customizing state comparison
+
+By default the SDK uses `>=` when deciding whether to advance the state bookmark — a record whose replication key equals the current bookmark is re-emitted on the next sync run. This is the Singer-recommended default ("at-least-once" semantics) because it avoids silently skipping records that arrive with a timestamp equal to the bookmark.
+
+If your use case requires stricter semantics, set the `state_comparator` class attribute on your stream:
+
+```python
+from singer_sdk import RESTStream, StrictAscendingComparator
+
+
+class MyStream(RESTStream):
+    replication_key = "id"
+    state_comparator = StrictAscendingComparator()
+```
+
+{py:class}`StrictAscendingComparator <singer_sdk.StrictAscendingComparator>` uses `>` instead of `>=`, so a record whose replication key equals the bookmark is **not** re-emitted. This is suitable when:
+
+- The target cannot tolerate duplicate records (e.g. reverse-ETL destinations that post to external services).
+- The replication key is guaranteed unique (e.g. an auto-incrementing integer primary key).
+
+```{warning}
+With `StrictAscendingComparator`, if multiple records share the same replication key value and a sync is interrupted mid-batch, those records may be silently skipped on resume. Only use it when you are certain ties cannot occur, or when missing a duplicate is preferable to sending one.
+```
+
+For fully custom ordering or pre-processing logic, subclass {py:class}`StateComparator <singer_sdk.StateComparator>`:
+
+```python
+from singer_sdk import RESTStream, StateComparator
+
+
+class MyComparator(StateComparator):
+    def preprocess(self, value):
+        # Convert to a comparable form before is_advance is called
+        return parse_my_custom_format(value)
+
+    def is_advance(self, new_value, old_value):
+        return new_value >= old_value
+
+
+class MyStream(RESTStream):
+    replication_key = "cursor"
+    state_comparator = MyComparator()
+```
+
 ## Manually testing incremental import during development
 
 To test the tap in standalone mode, manually create a state file and run the tap:

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -147,6 +147,17 @@ Batch
     batch.BaseBatcher
     batch.JSONLinesBatcher
 
+State Comparators
+-----------------
+
+.. autosummary::
+    :toctree: classes
+    :template: class.rst
+
+    StateComparator
+    AscendingComparator
+    StrictAscendingComparator
+
 Other
 -----
 

--- a/singer_sdk/__init__.py
+++ b/singer_sdk/__init__.py
@@ -16,6 +16,11 @@ from singer_sdk.schema.source import (
     StreamSchema,
 )
 from singer_sdk.sinks import BatchSink, RecordSink, Sink
+from singer_sdk.state_comparators import (
+    AscendingComparator,
+    StateComparator,
+    StrictAscendingComparator,
+)
 from singer_sdk.streams import GraphQLStream, RESTStream, Stream
 from singer_sdk.tap_base import Tap
 from singer_sdk.target_base import Target
@@ -30,6 +35,7 @@ if t.TYPE_CHECKING:
     )
 
 __all__ = [
+    "AscendingComparator",
     "BatchSink",
     "GraphQLStream",
     "InlineMapper",
@@ -40,8 +46,10 @@ __all__ = [
     "SchemaDirectory",
     "SchemaSource",
     "Sink",
+    "StateComparator",
     "Stream",
     "StreamSchema",
+    "StrictAscendingComparator",
     "Tap",
     "Target",
     "streams",

--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -9,12 +9,14 @@ import typing as t
 from singer_sdk.exceptions import InvalidStreamSortException
 from singer_sdk.helpers._typing import to_json_compatible
 from singer_sdk.singerlib.encoding.simple import StateMessage
+from singer_sdk.state_comparators import AscendingComparator
 
 if t.TYPE_CHECKING:
     import datetime
 
     from singer_sdk.helpers import types
     from singer_sdk.singerlib.encoding.base import GenericSingerWriter
+    from singer_sdk.state_comparators import StateComparator
 
     _T = t.TypeVar("_T", datetime.datetime, str, int, float)
 
@@ -202,6 +204,7 @@ def increment_state(
     replication_key: str,
     is_sorted: bool,
     check_sorted: bool,
+    comparator: StateComparator = AscendingComparator(),  # noqa: B008
 ) -> None:
     """Update the state using data from the latest record.
 
@@ -220,20 +223,20 @@ def increment_state(
                 extra={"replication_key": replication_key},
             )
         progress_dict = stream_or_partition_state[PROGRESS_MARKERS]
-    # TODO: Instead of forcing all values to be JSON-compatible strings and hope
-    # we catch all cases, we should allow the stream to define how to
-    # the values from the state and the record should be pre-processed.
-    # https://github.com/meltano/sdk/issues/2753
-    old_rk_value = to_json_compatible(progress_dict.get("replication_key_value"))
-    new_rk_value = to_json_compatible(latest_record[replication_key])
+    old_rk_value = progress_dict.get("replication_key_value")
+    new_rk_value = latest_record[replication_key]
 
     if new_rk_value is None:
         logger.warning("New replication value is null")
         return
 
-    if old_rk_value is None or not check_sorted or new_rk_value >= old_rk_value:
+    if (
+        old_rk_value is None
+        or not check_sorted
+        or comparator(new_rk_value, old_rk_value)
+    ):
         progress_dict["replication_key"] = replication_key
-        progress_dict["replication_key_value"] = new_rk_value
+        progress_dict["replication_key_value"] = to_json_compatible(new_rk_value)
         return
 
     if is_sorted:

--- a/singer_sdk/state_comparators.py
+++ b/singer_sdk/state_comparators.py
@@ -1,0 +1,132 @@
+"""State comparators for replication key advancement logic."""
+
+from __future__ import annotations
+
+import sys
+import typing as t
+from abc import ABC, abstractmethod
+
+from singer_sdk.helpers._typing import to_json_compatible
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
+
+class StateComparator(ABC):
+    """Abstract base for replication key state comparison.
+
+    Subclass to customize how the SDK determines whether a new replication
+    key value represents a state advancement over the previously bookmarked value.
+
+    Two responsibilities are intentionally separated:
+
+    - :meth:`preprocess`: normalize/deserialize raw values before comparison
+    - :meth:`is_advance`: define the ordering semantics
+
+    Example::
+
+        class MyComparator(StateComparator):
+            def preprocess(self, value):
+                return parse_my_date(value)
+
+            def is_advance(self, new_value, old_value):
+                return new_value >= old_value
+    """
+
+    def preprocess(self, value: t.Any) -> t.Any:  # noqa: ANN401, PLR6301
+        """Prepare a raw value for comparison.
+
+        Args:
+            value: Raw replication key value from a record or the state.
+
+        Returns:
+            A JSON-compatible form of the value, suitable for ordering.
+        """
+        return to_json_compatible(value)
+
+    @abstractmethod
+    def is_advance(self, new_value: t.Any, old_value: t.Any) -> bool:  # noqa: ANN401
+        """Return True if new_value represents a state advancement over old_value.
+
+        Both arguments have already been passed through :meth:`preprocess`.
+
+        Args:
+            new_value: Preprocessed replication key value from the latest record.
+            old_value: Preprocessed replication key value stored in the current state.
+
+        Returns:
+            True if the state bookmark should be updated to new_value.
+        """
+        ...
+
+    def __call__(self, new_value: t.Any, old_value: t.Any) -> bool:  # noqa: ANN401
+        """Preprocess then compare two replication key values.
+
+        Args:
+            new_value: Raw replication key value from the latest record.
+            old_value: Raw replication key value stored in the current state.
+
+        Returns:
+            True if the state bookmark should be updated to new_value.
+        """
+        return self.is_advance(self.preprocess(new_value), self.preprocess(old_value))
+
+
+class AscendingComparator(StateComparator):
+    """Default comparator: advances state when new value >= old value.
+
+    Implements *at-least-once* delivery semantics. Records whose replication key
+    equals the current bookmark are re-emitted on the next sync run, so targets
+    must be able to handle duplicate rows (upsert / dedup).
+
+    This is the Singer-recommended default because it avoids silently skipping
+    records that arrive with a timestamp equal to the bookmark (e.g. multiple
+    writes within the same second).
+    """
+
+    @override
+    def is_advance(self, new_value: t.Any, old_value: t.Any) -> bool:
+        """Return True when new_value >= old_value.
+
+        Args:
+            new_value: Preprocessed replication key value from the latest record.
+            old_value: Preprocessed replication key value stored in the current state.
+
+        Returns:
+            True if new_value is greater than or equal to old_value.
+        """
+        return new_value >= old_value  # type: ignore[no-any-return]
+
+
+class StrictAscendingComparator(StateComparator):
+    """Comparator that advances state only when new value > old value.
+
+    Implements *exactly-once* delivery semantics. Records whose replication key
+    equals the current bookmark are **not** re-emitted on the next sync run.
+
+    Use this when:
+
+    - The target cannot tolerate duplicate records (e.g. reverse-ETL destinations).
+    - The replication key is guaranteed unique (e.g. an auto-incrementing integer PK).
+
+    .. warning::
+        If multiple records share the same replication key value and a sync is
+        interrupted mid-batch, those records may be silently skipped on resume.
+        Only use this comparator when you are certain ties cannot occur or are
+        acceptable to miss.
+    """
+
+    @override
+    def is_advance(self, new_value: t.Any, old_value: t.Any) -> bool:
+        """Return True when new_value > old_value.
+
+        Args:
+            new_value: Preprocessed replication key value from the latest record.
+            old_value: Preprocessed replication key value stored in the current state.
+
+        Returns:
+            True if new_value is strictly greater than old_value.
+        """
+        return new_value > old_value  # type: ignore[no-any-return]

--- a/singer_sdk/streams/_state.py
+++ b/singer_sdk/streams/_state.py
@@ -16,11 +16,13 @@ from singer_sdk.helpers._state import (
     write_starting_replication_value,
 )
 from singer_sdk.singerlib.catalog import REPLICATION_FULL_TABLE
+from singer_sdk.state_comparators import AscendingComparator
 
 if t.TYPE_CHECKING:
     import datetime
 
     from singer_sdk.helpers import types
+    from singer_sdk.state_comparators import StateComparator
 
 
 class StreamStateManager:
@@ -43,6 +45,7 @@ class StreamStateManager:
         is_sorted: bool = False,
         check_sorted: bool = True,
         tap_name: str | None = None,
+        comparator: StateComparator = AscendingComparator(),  # noqa: B008
         state_partitioning_keys: t.Sequence[str] | None = None,
     ) -> None:
         """Initialize the StreamStateManager.
@@ -51,6 +54,7 @@ class StreamStateManager:
             tap_name: Name of the tap.
             stream_name: Name of the stream.
             tap_state: Shared tap-level state dictionary.
+            comparator: Comparator that determines replication key advancement.
             state_partitioning_keys: Keys used for state partitioning.
             is_sorted: Whether the stream is expected to be sorted.
             check_sorted: Whether to check for sort violations.
@@ -62,6 +66,7 @@ class StreamStateManager:
         self.is_flushed = True
         self._is_sorted = is_sorted
         self._check_sorted = check_sorted
+        self._comparator = comparator
         self._logger = logging.getLogger(tap_name).getChild(stream_name)
 
     @property
@@ -221,6 +226,7 @@ class StreamStateManager:
             latest_record=latest_record,
             is_sorted=treat_as_sorted,
             check_sorted=self._check_sorted,
+            comparator=self._comparator,
         )
 
     def finalize_state(self, state: dict | None = None) -> None:

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -40,6 +40,7 @@ from singer_sdk.singerlib.catalog import (
     REPLICATION_INCREMENTAL,
     REPLICATION_LOG_BASED,  # noqa: F401
 )
+from singer_sdk.state_comparators import AscendingComparator
 from singer_sdk.streams._state import StreamStateManager
 
 if t.TYPE_CHECKING:
@@ -48,6 +49,7 @@ if t.TYPE_CHECKING:
     from singer_sdk.helpers._compat import Traversable
     from singer_sdk.mapper import StreamMap
     from singer_sdk.singerlib.catalog import StreamMetadata
+    from singer_sdk.state_comparators import StateComparator
     from singer_sdk.tap_base import Tap
 
 
@@ -101,6 +103,21 @@ class Stream(abc.ABC):  # noqa: PLR0904
 
     selected_by_default: bool = True
     """Whether this stream is selected by default in the catalog."""
+
+    state_comparator: StateComparator = AscendingComparator()
+    """Comparator used to determine replication key state advancement.
+
+    Defaults to :class:`~singer_sdk.AscendingComparator` (``>=``), which implements
+    *at-least-once* semantics: records whose replication key equals the current bookmark
+    are re-emitted on the next sync run.
+
+    Override at the class level to change ordering semantics::
+
+        from singer_sdk import RESTStream, StrictAscendingComparator
+
+        class MyStream(RESTStream):
+            state_comparator = StrictAscendingComparator()
+    """
 
     def __init__(
         self,
@@ -200,6 +217,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
                 state_partitioning_keys=self._state_partitioning_keys,
                 is_sorted=self.is_sorted,
                 check_sorted=self.check_sorted,
+                comparator=self.state_comparator,
             )
         return self._state_manager
 

--- a/tests/core/test_state_comparators.py
+++ b/tests/core/test_state_comparators.py
@@ -1,0 +1,152 @@
+"""Tests for StateComparator classes."""
+
+from __future__ import annotations
+
+import datetime
+import typing as t
+
+import pytest
+
+from singer_sdk.state_comparators import (
+    AscendingComparator,
+    StateComparator,
+    StrictAscendingComparator,
+)
+from singer_sdk.streams._state import StreamStateManager
+
+if t.TYPE_CHECKING:
+    from singer_sdk.helpers import types
+
+
+class TestAscendingComparator:
+    @pytest.fixture
+    def comparator(self) -> AscendingComparator:
+        return AscendingComparator()
+
+    def test_advance_when_greater(self, comparator: AscendingComparator) -> None:
+        assert comparator("2024-02-01", "2024-01-01") is True
+
+    def test_advance_when_equal(self, comparator: AscendingComparator) -> None:
+        assert comparator("2024-01-01", "2024-01-01") is True
+
+    def test_no_advance_when_less(self, comparator: AscendingComparator) -> None:
+        assert comparator("2024-01-01", "2024-02-01") is False
+
+    def test_advance_with_integers(self, comparator: AscendingComparator) -> None:
+        assert comparator(42, 41) is True
+        assert comparator(41, 41) is True
+        assert comparator(40, 41) is False
+
+    def test_preprocess_converts_datetime(
+        self,
+        comparator: AscendingComparator,
+    ) -> None:
+        dt = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+        result = comparator.preprocess(dt)
+        assert isinstance(result, str)
+
+    def test_advance_with_raw_datetime_vs_stored_string(
+        self,
+        comparator: AscendingComparator,
+    ) -> None:
+        """New value from record (datetime) vs stored value (ISO string) should work."""
+        dt_new = datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc)
+        stored = "2024-01-01T00:00:00+00:00"
+        assert comparator(dt_new, stored) is True
+
+
+class TestStrictAscendingComparator:
+    @pytest.fixture
+    def comparator(self) -> StrictAscendingComparator:
+        return StrictAscendingComparator()
+
+    def test_advance_when_greater(self, comparator: StrictAscendingComparator) -> None:
+        assert comparator("2024-02-01", "2024-01-01") is True
+
+    def test_no_advance_when_equal(self, comparator: StrictAscendingComparator) -> None:
+        """Key difference from AscendingComparator: equal values do NOT advance."""
+        assert comparator("2024-01-01", "2024-01-01") is False
+
+    def test_no_advance_when_less(self, comparator: StrictAscendingComparator) -> None:
+        assert comparator("2024-01-01", "2024-02-01") is False
+
+    def test_advance_with_integers(self, comparator: StrictAscendingComparator) -> None:
+        assert comparator(42, 41) is True
+        assert comparator(41, 41) is False
+        assert comparator(40, 41) is False
+
+
+class TestCustomSubclass:
+    def test_custom_comparator_is_callable(self) -> None:
+        class MyComparator(StateComparator):
+            def is_advance(self, new_value: object, old_value: object) -> bool:
+                return new_value != old_value
+
+        c = MyComparator()
+        assert c("a", "b") is True
+        assert c("a", "a") is False
+
+    def test_custom_preprocess(self) -> None:
+        class LowerCaseComparator(StateComparator):
+            def preprocess(self, value: object) -> str:
+                return str(value).lower()
+
+            def is_advance(self, new_value: object, old_value: object) -> bool:
+                return new_value >= old_value  # type: ignore[operator]
+
+        c = LowerCaseComparator()
+        assert c("B", "a") is True
+        assert c("A", "b") is False
+
+
+def test_increment_state_ascending_allows_equal_value() -> None:
+    """AscendingComparator updates state when new == old (at-least-once)."""
+    tap_state: types.TapState = {
+        "bookmarks": {
+            "test_stream": {"replication_key": "id", "replication_key_value": "5"},
+        },
+    }
+    manager = StreamStateManager(
+        stream_name="test_stream",
+        tap_state=tap_state,
+        is_sorted=True,
+        check_sorted=True,
+        comparator=AscendingComparator(),
+    )
+    manager.increment_state({"id": "5"}, replication_key="id")
+    assert tap_state["bookmarks"]["test_stream"]["replication_key_value"] == "5"
+
+
+def test_increment_state_strict_skips_equal_value() -> None:
+    """StrictAscendingComparator does NOT update state when new == old."""
+    tap_state: types.TapState = {
+        "bookmarks": {
+            "test_stream": {"replication_key": "id", "replication_key_value": "5"},
+        },
+    }
+    manager = StreamStateManager(
+        stream_name="test_stream",
+        tap_state=tap_state,
+        is_sorted=True,
+        check_sorted=False,
+        comparator=StrictAscendingComparator(),
+    )
+    manager.increment_state({"id": "5"}, replication_key="id")
+    assert tap_state["bookmarks"]["test_stream"]["replication_key_value"] == "5"
+
+
+def test_increment_state_strict_advances_when_greater() -> None:
+    tap_state: types.TapState = {
+        "bookmarks": {
+            "test_stream": {"replication_key": "id", "replication_key_value": "5"},
+        },
+    }
+    manager = StreamStateManager(
+        stream_name="test_stream",
+        tap_state=tap_state,
+        is_sorted=True,
+        check_sorted=True,
+        comparator=StrictAscendingComparator(),
+    )
+    manager.increment_state({"id": "6"}, replication_key="id")
+    assert tap_state["bookmarks"]["test_stream"]["replication_key_value"] == "6"


### PR DESCRIPTION
This PR adds support for custom state comparators, allowing users to choose replication key advancement logic other than the default "greater than or equal to" behavior. 

This is useful for cases where

- the target cannot tolerate duplicate records (e.g. reverse-ETL destinations that post to external services), or
- the source system frequently updates a large number of records so they end up sharing replication key values (e.g. a `last_updated` timestamp). This can lead to large batches of records being re-emitted on every sync without any new data being replicated.

## Links

- Closes https://github.com/meltano/sdk/issues/1200
- Closes https://github.com/meltano/sdk/issues/2154

## Summary by Sourcery

Introduce configurable replication key state comparison via pluggable comparator classes and wire this into stream state management.

New Features:
- Add pluggable StateComparator base class and default AscendingComparator and StrictAscendingComparator implementations for replication key advancement semantics.
- Allow streams to configure a state_comparator attribute that controls bookmark advancement logic instead of always using a >= check.

Enhancements:
- Refactor state increment logic to delegate replication key comparison to a configurable comparator while preserving JSON-compatible storage of bookmark values.

Documentation:
- Document how to customize state comparison, including using StrictAscendingComparator and authoring custom StateComparator subclasses, and add API reference stubs for the new comparator classes.

Tests:
- Add unit tests covering AscendingComparator, StrictAscendingComparator, custom StateComparator subclasses, and integration of comparators with StreamStateManager bookmark updates.