### PR TITLE
refactor: Handle state increment logic for state partitioning keys in state manager helper

### DIFF
--- a/singer_sdk/streams/_state.py
+++ b/singer_sdk/streams/_state.py
@@ -38,9 +38,11 @@ class StreamStateManager:
     def __init__(
         self,
         *,
-        tap_name: str,
         stream_name: str,
         tap_state: types.TapState,
+        is_sorted: bool = False,
+        check_sorted: bool = True,
+        tap_name: str | None = None,
         state_partitioning_keys: t.Sequence[str] | None = None,
     ) -> None:
         """Initialize the StreamStateManager.
@@ -50,12 +52,16 @@ class StreamStateManager:
             stream_name: Name of the stream.
             tap_state: Shared tap-level state dictionary.
             state_partitioning_keys: Keys used for state partitioning.
+            is_sorted: Whether the stream is expected to be sorted.
+            check_sorted: Whether to check for sort violations.
         """
         self.tap_name = tap_name
         self.stream_name = stream_name
         self.tap_state = tap_state
         self.state_partitioning_keys = state_partitioning_keys
         self.is_flushed = True
+        self._is_sorted = is_sorted
+        self._check_sorted = check_sorted
         self._logger = logging.getLogger(tap_name).getChild(stream_name)
 
     @property
@@ -186,8 +192,6 @@ class StreamStateManager:
         *,
         context: types.Context | None = None,
         replication_key: str,
-        is_sorted: bool,
-        check_sorted: bool,
     ) -> None:
         """Update state of stream or partition with data from the provided record.
 
@@ -198,19 +202,25 @@ class StreamStateManager:
             latest_record: The latest record to update state with.
             context: Stream partition or context dictionary.
             replication_key: The replication key field name.
-            is_sorted: Whether the stream is expected to be sorted.
-            check_sorted: Whether to check for sort violations.
         """
         # This also creates a state entry if one does not yet exist:
         state_dict = self.get_context_state(context)
+
+        treat_as_sorted = self._is_sorted
+
+        # TODO: This logic is a bit awkward. It essentially sets treat_as_sorted to
+        # False when it is already False
+        if not treat_as_sorted and self.state_partitioning_keys is not None:
+            # Streams with custom state partitioning are not resumable.
+            treat_as_sorted = False
 
         # Advance state bookmark values
         increment_state(
             state_dict,
             replication_key=replication_key,
             latest_record=latest_record,
-            is_sorted=is_sorted,
-            check_sorted=check_sorted,
+            is_sorted=treat_as_sorted,
+            check_sorted=self._check_sorted,
         )
 
     def finalize_state(self, state: dict | None = None) -> None:

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -151,15 +151,8 @@ class Stream(abc.ABC):  # noqa: PLR0904
         self._mask: singer.SelectionMask | None = None
         self._schema: dict | None = None
         self._sync_costs: dict[str, int] = {}
+        self._state_manager: StreamStateManager | None = None
         self.child_streams: list[Stream] = []
-
-        # Initialize state manager
-        self._state_manager = StreamStateManager(
-            tap_name=tap.name,
-            stream_name=self.name,
-            tap_state=self._tap_state,
-            state_partitioning_keys=self._state_partitioning_keys,
-        )
 
         if schema:
             if isinstance(schema, (PathLike, str)):
@@ -195,6 +188,20 @@ class Stream(abc.ABC):  # noqa: PLR0904
     def logger(self) -> logging.Logger:
         """Get stream logger."""
         return self._logger
+
+    @property
+    def state_manager(self) -> StreamStateManager:
+        """Get stream state manager."""
+        if self._state_manager is None:
+            self._state_manager = StreamStateManager(
+                tap_name=self.tap_name,
+                stream_name=self.name,
+                tap_state=self._tap_state,
+                state_partitioning_keys=self._state_partitioning_keys,
+                is_sorted=self.is_sorted,
+                check_sorted=self.check_sorted,
+            )
+        return self._state_manager
 
     def log(
         self,
@@ -296,7 +303,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
            This method requires :attr:`~singer_sdk.Stream.replication_key` to be set
            to a non-null value, indicating the stream should be synced incrementally.
         """
-        return self._state_manager.get_starting_replication_value(
+        return self.state_manager.get_starting_replication_value(
             context,
             self.replication_method,
         )
@@ -412,7 +419,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
             context: Stream partition or context dictionary.
             value: TODO
         """
-        self._state_manager.write_replication_key_signpost(value, context=context)
+        self.state_manager.write_replication_key_signpost(value, context=context)
 
     def _parse_datetime(self, value: str) -> datetime.datetime:  # noqa: PLR6301
         """Parse a datetime string.
@@ -460,7 +467,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
         Args:
             context: Stream partition or context dictionary.
         """
-        self._state_manager.write_starting_replication_value(
+        self.state_manager.write_starting_replication_value(
             context=context,
             replication_method=self.replication_method,
             replication_key=self.replication_key,
@@ -759,7 +766,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
             A partitioned context state if applicable; else returns stream state.
             A blank state will be created in none exists.
         """
-        return self._state_manager.get_context_state(context)
+        return self.state_manager.get_context_state(context)
 
     @property
     def stream_state(self) -> dict:
@@ -778,7 +785,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
         Returns:
             A writable state dict for this stream.
         """
-        return self._state_manager.stream_state
+        return self.state_manager.stream_state
 
     # Partitions
 
@@ -796,7 +803,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
         """
         result: list[dict] = [
             partition_state["context"]
-            for partition_state in (self._state_manager.get_state_partitions() or [])
+            for partition_state in (self.state_manager.get_state_partitions() or [])
         ]
         return result or None
 
@@ -831,27 +838,22 @@ class Stream(abc.ABC):  # noqa: PLR0904
                     f"stream(replication method={self.replication_method})"
                 )
                 raise ValueError(msg)
-            treat_as_sorted = self.is_sorted
-            if not treat_as_sorted and self.state_partitioning_keys is not None:
-                # Streams with custom state partitioning are not resumable.
-                treat_as_sorted = False
-            self._state_manager.increment_state(
+
+            self.state_manager.increment_state(
                 latest_record,
                 context=context,
                 replication_key=self.replication_key,
-                is_sorted=treat_as_sorted,
-                check_sorted=self.check_sorted,
             )
 
     # Private message authoring methods:
 
     def _write_state_message(self) -> None:
         """Write out a STATE message with the latest state."""
-        if not self._state_manager.is_flushed:
+        if not self.state_manager.is_flushed:
             # Ensure stream state entry exists before writing
             _ = self.stream_state
             self._tap.state_writer.write_state(self.tap_state)
-            self._state_manager.is_flushed = True
+            self.state_manager.is_flushed = True
 
     def _write_activate_version_message(self, full_table_version: int) -> None:
         """Write out an ACTIVATE_VERSION message."""
@@ -962,7 +964,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
         for record_message in self._generate_record_messages(record):
             self._tap.write_message(record_message)
 
-        self._state_manager.is_flushed = False
+        self.state_manager.is_flushed = False
 
     def _write_batch_message(
         self,
@@ -978,7 +980,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
         for batch_message in self._generate_batch_messages(encoding, manifest):
             self._tap.write_message(batch_message)
 
-        self._state_manager.is_flushed = False
+        self.state_manager.is_flushed = False
 
     def _log_metric(self, point: metrics.Point) -> None:
         """Log a single measurement.
@@ -1099,7 +1101,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
             msg = "Sync operation aborted for stream in 'FULL_TABLE' replication mode."
             raise AbortedSyncFailedException(msg) from abort_reason
 
-        if self._state_manager.is_state_non_resumable():
+        if self.state_manager.is_state_non_resumable():
             msg = "Sync operation aborted and state is not in a resumable state."
             raise AbortedSyncFailedException(msg) from abort_reason
 
@@ -1113,7 +1115,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
         Args:
             state: State object to promote progress markers with.
         """
-        self._state_manager.finalize_state(state)
+        self.state_manager.finalize_state(state)
 
     def finalize_state_progress_markers(self, state: dict | None = None) -> None:
         """Reset progress markers and emit state message if necessary.
@@ -1131,7 +1133,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
             if not self.selected:
                 return
 
-            self._state_manager.finalize_progress_markers(
+            self.state_manager.finalize_progress_markers(
                 state=state,
                 partitions=self.partitions,
             )
@@ -1244,7 +1246,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
                             partition_context=state_partition_context,
                         )
                     except InvalidStreamSortException as ex:  # pragma: no cover
-                        self._state_manager.log_sort_error(
+                        self.state_manager.log_sort_error(
                             ex=ex,
                             record_count=record_index + 1,
                             partition_record_count=idx + 1,
@@ -1419,7 +1421,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
         Returns:
             TODO
         """
-        return self._state_manager.get_state_partition_context(context)
+        return self.state_manager.get_state_partition_context(context)
 
     def get_child_context(
         self,

--- a/tests/core/test_stream_state_manager.py
+++ b/tests/core/test_stream_state_manager.py
@@ -6,6 +6,7 @@ import typing as t
 
 import pytest
 
+from singer_sdk.exceptions import InvalidStreamSortException
 from singer_sdk.singerlib.catalog import REPLICATION_FULL_TABLE, REPLICATION_INCREMENTAL
 from singer_sdk.streams._state import StreamStateManager
 
@@ -22,11 +23,7 @@ def tap_state() -> types.TapState:
 @pytest.fixture
 def state_manager(tap_state: types.TapState) -> StreamStateManager:
     """Return a StreamStateManager instance."""
-    return StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    return StreamStateManager(stream_name="test_stream", tap_state=tap_state)
 
 
 # Tests for StreamStateManager initialization
@@ -35,12 +32,10 @@ def state_manager(tap_state: types.TapState) -> StreamStateManager:
 def test_init_sets_attributes(tap_state: types.TapState) -> None:
     """Test that init sets all attributes correctly."""
     manager = StreamStateManager(
-        tap_name="my-tap",
         stream_name="my_stream",
         tap_state=tap_state,
         state_partitioning_keys=["tenant_id"],
     )
-    assert manager.tap_name == "my-tap"
     assert manager.stream_name == "my_stream"
     assert manager.tap_state is tap_state
     assert manager.state_partitioning_keys == ["tenant_id"]
@@ -49,11 +44,7 @@ def test_init_sets_attributes(tap_state: types.TapState) -> None:
 
 def test_init_default_partitioning_keys(tap_state: types.TapState) -> None:
     """Test that state_partitioning_keys defaults to None."""
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
     assert manager.state_partitioning_keys is None
 
 
@@ -73,11 +64,7 @@ def test_stream_state_creates_bookmark(
 def test_stream_state_returns_existing(tap_state: types.TapState) -> None:
     """Test that stream_state returns existing bookmark."""
     tap_state["bookmarks"] = {"test_stream": {"replication_key_value": "2021-01-01"}}
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
     state = manager.stream_state
     assert state == {"replication_key_value": "2021-01-01"}
 
@@ -122,11 +109,7 @@ def test_get_context_state_returns_existing_partition(
             ]
         }
     }
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
     context = {"tenant_id": "abc123"}
     state = manager.get_context_state(context)
     assert state["replication_key_value"] == "2021-01-01"
@@ -149,7 +132,6 @@ def test_get_context_state_with_state_partitioning_keys(
         },
     }
     manager = StreamStateManager(
-        tap_name="test-tap",
         stream_name="test_stream",
         tap_state=tap_state,
         state_partitioning_keys=["tenant_id"],
@@ -185,7 +167,6 @@ def test_get_state_partition_context_filters_by_keys(
 ) -> None:
     """Test that context is filtered by partitioning keys."""
     manager = StreamStateManager(
-        tap_name="test-tap",
         stream_name="test_stream",
         tap_state=tap_state,
         state_partitioning_keys=["tenant_id"],
@@ -214,16 +195,17 @@ def test_is_flushed_after_finalize_state(
 # Tests for increment_state method
 
 
-def test_increment_state_updates_bookmark(
-    state_manager: StreamStateManager,
-    tap_state: types.TapState,
-) -> None:
+def test_increment_state_updates_bookmark(tap_state: types.TapState) -> None:
     """Test that increment_state updates replication key value."""
+    state_manager = StreamStateManager(
+        stream_name="test_stream",
+        tap_state=tap_state,
+        is_sorted=True,
+        check_sorted=False,
+    )
     state_manager.increment_state(
         {"updated_at": "2021-05-17T20:41:16Z"},
         replication_key="updated_at",
-        is_sorted=True,
-        check_sorted=False,
     )
     stream_state = tap_state["bookmarks"]["test_stream"]
     assert stream_state["replication_key"] == "updated_at"
@@ -233,17 +215,16 @@ def test_increment_state_updates_bookmark(
 def test_increment_state_with_context(tap_state: types.TapState) -> None:
     """Test increment_state with partition context."""
     manager = StreamStateManager(
-        tap_name="test-tap",
         stream_name="test_stream",
         tap_state=tap_state,
+        is_sorted=True,
+        check_sorted=False,
     )
     context = {"tenant_id": "abc123"}
     manager.increment_state(
         {"updated_at": "2021-05-17T20:41:16Z"},
         context=context,
         replication_key="updated_at",
-        is_sorted=True,
-        check_sorted=False,
     )
     partitions = tap_state["bookmarks"]["test_stream"]["partitions"]
     assert len(partitions) == 1
@@ -252,19 +233,72 @@ def test_increment_state_with_context(tap_state: types.TapState) -> None:
 
 
 def test_increment_state_unsorted_creates_progress_markers(
-    state_manager: StreamStateManager,
     tap_state: types.TapState,
 ) -> None:
     """Test that unsorted streams create progress markers."""
+    state_manager = StreamStateManager(
+        stream_name="test_stream",
+        tap_state=tap_state,
+        is_sorted=False,
+        check_sorted=False,
+    )
     state_manager.increment_state(
         {"updated_at": "2021-05-17T20:41:16Z"},
         replication_key="updated_at",
-        is_sorted=False,
-        check_sorted=False,
     )
     stream_state = tap_state["bookmarks"]["test_stream"]
     assert "progress_markers" in stream_state
     assert stream_state["progress_markers"]["replication_key"] == "updated_at"
+
+
+def test_increment_not_required(tap_state: types.TapState) -> None:
+    """Test that increment_state does not compare when no old value."""
+    state_manager = StreamStateManager(
+        stream_name="test_stream",
+        tap_state=tap_state,
+        is_sorted=False,
+    )
+    state_manager.increment_state(
+        {"updated_at": "2021-05-17T20:41:16Z"},
+        replication_key="updated_at",
+    )
+    stream_state = tap_state["bookmarks"]["test_stream"]
+    assert (
+        stream_state["progress_markers"]["replication_key_value"]
+        == "2021-05-17T20:41:16Z"
+    )
+
+    state_manager.increment_state(
+        {"updated_at": "2021-05-05T20:41:16Z"},
+        replication_key="updated_at",
+    )
+    stream_state = tap_state["bookmarks"]["test_stream"]
+    assert (
+        stream_state["progress_markers"]["replication_key_value"]
+        == "2021-05-17T20:41:16Z"
+    )
+
+
+def test_increment_invalid_sort(tap_state: types.TapState) -> None:
+    """Test that increment_state does not compare when no old value."""
+    state_manager = StreamStateManager(
+        stream_name="test_stream",
+        tap_state=tap_state,
+        is_sorted=True,
+    )
+    state_manager.increment_state(
+        {"updated_at": "2021-05-17T20:41:16Z"},
+        replication_key="updated_at",
+    )
+
+    with pytest.raises(
+        InvalidStreamSortException,
+        match="Unsorted data detected in stream",
+    ):
+        state_manager.increment_state(
+            {"updated_at": "2021-05-05T20:41:16Z"},
+            replication_key="updated_at",
+        )
 
 
 # Tests for finalize_state method
@@ -282,11 +316,7 @@ def test_finalize_state_promotes_progress_markers(
             }
         }
     }
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
     state = manager.stream_state
     manager.finalize_state(state)
 
@@ -311,11 +341,7 @@ def test_finalize_progress_markers_no_state_uses_stream_state(
 
 def test_finalize_progress_markers_with_partitions(tap_state: types.TapState) -> None:
     """Test finalize_progress_markers with partitions."""
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
     partitions = [{"tenant_id": "a"}, {"tenant_id": "b"}]
     manager.finalize_progress_markers(partitions=partitions)
 
@@ -349,15 +375,14 @@ def test_finalize_progress_markers_beyond_signpost() -> None:
 
     tap_state: types.TapState = {}
     manager = StreamStateManager(
-        tap_name="test-tap",
         stream_name="test_stream",
         tap_state=tap_state,
+        is_sorted=False,
+        check_sorted=False,
     )
     manager.increment_state(
         latest_record={"updated_at": replication_key_value},
         replication_key="updated_at",
-        is_sorted=False,
-        check_sorted=False,
     )
     manager.write_replication_key_signpost(signpost_value)
     manager.finalize_progress_markers()
@@ -392,11 +417,7 @@ def test_get_state_partitions_returns_existing(tap_state: types.TapState) -> Non
             ]
         }
     }
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
     partitions = manager.get_state_partitions()
     assert partitions is not None
     assert len(partitions) == 2
@@ -410,11 +431,7 @@ def test_get_starting_replication_value_full_table_returns_none(
 ) -> None:
     """Test that FULL_TABLE replication returns None."""
     tap_state["bookmarks"] = {"test_stream": {"replication_key_value": "2021-01-01"}}
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
     result = manager.get_starting_replication_value(None, REPLICATION_FULL_TABLE)
     assert result is None
 
@@ -429,11 +446,7 @@ def test_get_starting_replication_value_incremental_returns_value(
             "starting_replication_value": "2021-05-17T20:41:16Z",
         }
     }
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
     result = manager.get_starting_replication_value(None, REPLICATION_INCREMENTAL)
     assert result == "2021-05-17T20:41:16Z"
 
@@ -467,11 +480,7 @@ def test_get_starting_replication_value_multiple_partitions(
             ]
         }
     }
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
 
     result = manager.get_starting_replication_value(
         {"tenant_id": "a"},
@@ -514,11 +523,7 @@ def test_is_state_non_resumable_with_progress_markers(
             }
         }
     }
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
     assert manager.is_state_non_resumable() is True
 
 
@@ -550,11 +555,7 @@ def test_write_starting_replication_value_incremental_writes_value(
             "replication_key_value": "2021-05-17T20:41:16Z",
         }
     }
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
     manager.write_starting_replication_value(
         context=None,
         replication_method=REPLICATION_INCREMENTAL,
@@ -589,11 +590,7 @@ def test_write_starting_replication_value_compare_fn_used(
             "replication_key_value": "2021-05-17",
         }
     }
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
 
     # This function always returns the second argument
     def compare_fn(a: str, b: str) -> str:  # noqa: ARG001
@@ -621,11 +618,7 @@ def test_write_starting_replication_value_no_compare_fn(
             "replication_key_value": "2021-05-17",
         }
     }
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
 
     manager.write_starting_replication_value(
         context=None,
@@ -661,11 +654,7 @@ def test_write_starting_replication_value_replication_key_changed() -> None:
             }
         }
     }
-    manager = StreamStateManager(
-        tap_name="test-tap",
-        stream_name="test_stream",
-        tap_state=tap_state,
-    )
+    manager = StreamStateManager(stream_name="test_stream", tap_state=tap_state)
     manager.write_starting_replication_value(
         context=None,
         replication_method=REPLICATION_INCREMENTAL,


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Refactor stream state management to encapsulate sort handling inside StreamStateManager and lazy‑initialize it from Stream, while updating tests to cover the new behavior.

Enhancements:
- Make StreamStateManager lazily initialized via a Stream.state_manager property and wire all stream state operations through it.
- Extend StreamStateManager to accept is_sorted and check_sorted flags and internally determine how to handle incremental state updates, including for partitioned state.
- Simplify StreamStateManager construction by making tap_name optional and removing the requirement to pass sort flags to increment_state.

Tests:
- Update existing stream state manager tests to reflect the new constructor and usage pattern.
- Add tests that verify increment_state behavior for unsorted streams, non-comparable updates, and invalid sort order raising InvalidStreamSortException.