### PR TITLE
fix: Force streams with custom state partitioning keys to be non-resumable

### DIFF
--- a/singer_sdk/streams/_state.py
+++ b/singer_sdk/streams/_state.py
@@ -211,13 +211,9 @@ class StreamStateManager:
         # This also creates a state entry if one does not yet exist:
         state_dict = self.get_context_state(context)
 
-        treat_as_sorted = self._is_sorted
-
-        # TODO: This logic is a bit awkward. It essentially sets treat_as_sorted to
-        # False when it is already False
-        if not treat_as_sorted and self.state_partitioning_keys is not None:
-            # Streams with custom state partitioning are not resumable.
-            treat_as_sorted = False
+        # Treat as sorted only when the stream is sorted and there is no custom
+        # state partitioning configured (in which case the stream is not resumable)
+        treat_as_sorted = self._is_sorted and self.state_partitioning_keys is None
 
         # Advance state bookmark values
         increment_state(

--- a/tests/core/test_stream_state_manager.py
+++ b/tests/core/test_stream_state_manager.py
@@ -279,6 +279,22 @@ def test_increment_not_required(tap_state: types.TapState) -> None:
     )
 
 
+def test_increment_with_partitioning_keys(tap_state: types.TapState) -> None:
+    """Test that partitioning keys make streams non-resumable."""
+    state_manager = StreamStateManager(
+        stream_name="test_stream",
+        tap_state=tap_state,
+        is_sorted=True,
+        state_partitioning_keys=["tenant_id"],
+    )
+    state_manager.increment_state(
+        {"updated_at": "2021-05-17T20:41:16Z"},
+        replication_key="updated_at",
+    )
+    stream_state = tap_state["bookmarks"]["test_stream"]
+    assert "progress_markers" in stream_state
+
+
 def test_increment_invalid_sort(tap_state: types.TapState) -> None:
     """Test that increment_state does not compare when no old value."""
     state_manager = StreamStateManager(


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Ensure streams with custom state partitioning keys are treated as non-resumable and update related state handling logic.

Bug Fixes:
- Fix state increment logic so that streams with custom state partitioning keys are never treated as resumable/sorted.

Tests:
- Add a test verifying that streams with state partitioning keys use progress markers and are treated as non-resumable.