### PR TITLE
feat: Automatically quote fully-qualified table names based on the corresponding database dialect

### DIFF
--- a/singer_sdk/sql/connector.py
+++ b/singer_sdk/sql/connector.py
@@ -69,6 +69,7 @@ class FullyQualifiedName(UserString):
         schema: str | None = None,
         database: str | None = None,
         delimiter: str = ".",
+        dialect: Dialect | None = None,
     ) -> None:
         """Initialize the fully qualified table name.
 
@@ -77,6 +78,7 @@ class FullyQualifiedName(UserString):
             schema: The name of the schema. Defaults to None.
             database: The name of the database. Defaults to None.
             delimiter: The delimiter to use between parts. Defaults to '.'.
+            dialect: Optional SQLAlchemy Dialect for dialect-specific formatting.
 
         Raises:
             ValueError: If the fully qualified name could not be generated.
@@ -85,6 +87,7 @@ class FullyQualifiedName(UserString):
         self.schema = schema
         self.database = database
         self.delimiter = delimiter
+        self.dialect = dialect
 
         parts = []
         if self.database:
@@ -108,7 +111,7 @@ class FullyQualifiedName(UserString):
 
         super().__init__(self.delimiter.join(parts))
 
-    def prepare_part(self, part: str) -> str:  # noqa: PLR6301
+    def prepare_part(self, part: str) -> str:
         """Prepare a part of the fully qualified name.
 
         Args:
@@ -117,7 +120,7 @@ class FullyQualifiedName(UserString):
         Returns:
             The prepared part.
         """
-        return part
+        return self.dialect.identifier_preparer.quote(part) if self.dialect else part
 
 
 class SQLToJSONSchema:
@@ -837,9 +840,9 @@ class SQLConnector:  # noqa: PLR0904
         """
         return self.jsonschema_to_sql.to_sql_type(jsonschema_type)
 
-    @staticmethod
     def get_fully_qualified_name(
-        table_name: str | None = None,
+        self,
+        table_name: str = "",
         schema_name: str | None = None,
         db_name: str | None = None,
         delimiter: str = ".",
@@ -859,10 +862,11 @@ class SQLConnector:  # noqa: PLR0904
            A ``FullyQualifiedName`` object is now returned.
         """
         return FullyQualifiedName(
-            table=table_name,  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+            table=table_name,
             schema=schema_name,
             database=db_name,
             delimiter=delimiter,
+            dialect=self._dialect,
         )
 
     @property

--- a/tests/sql/test_connector.py
+++ b/tests/sql/test_connector.py
@@ -8,7 +8,6 @@ from unittest import mock
 
 import pytest
 import sqlalchemy
-import sqlalchemy.engine
 import sqlalchemy.exc
 import sqlalchemy.schema
 import sqlalchemy.types
@@ -641,18 +640,14 @@ def test_fully_qualified_name():
 
 
 def test_fully_qualified_name_with_quoting():
-    class QuotedFullyQualifiedName(FullyQualifiedName):
-        def __init__(self, *, dialect: sqlalchemy.engine.Dialect, **kwargs: t.Any):
-            self.dialect = dialect
-            super().__init__(**kwargs)
-
-        def prepare_part(self, part: str) -> str:
-            return self.dialect.identifier_preparer.quote(part)
-
     dialect = DefaultDialect()
-
-    fqn = QuotedFullyQualifiedName(table="order", schema="public", dialect=dialect)
+    fqn = FullyQualifiedName(table="order", schema="public", dialect=dialect)
     assert fqn == 'public."order"'
+
+
+def test_fully_qualified_name_without_quoting():
+    fqn = FullyQualifiedName(table="order", schema="public", dialect=None)
+    assert fqn == "public.order"
 
 
 def test_fully_qualified_name_empty_error():


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Automatically apply dialect-specific quoting to fully-qualified SQL table names and expose dialect-aware name generation from the SQL connector.

New Features:
- Support passing an optional SQLAlchemy dialect into FullyQualifiedName to enable dialect-aware formatting and quoting of table identifiers.

Enhancements:
- Update FullyQualifiedName to quote identifier parts when a dialect is provided while preserving unquoted behavior when no dialect is set.
- Make SQLToJSONSchema.get_fully_qualified_name an instance method that uses the connector's configured dialect when constructing fully-qualified table names.

Tests:
- Extend fully-qualified name tests to cover both quoted and unquoted behaviors depending on whether a dialect is supplied.