### PR TITLE
feat(taps): Normalize two-element `oneOf` schema members where one of them is the null type, into a single nullable schema

### DIFF
--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -313,6 +313,38 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
         schema.pop("pattern", None)
         return schema
 
+    def handle_one_of(self, schema: Schema) -> Schema:
+        """Handle oneOf constructs in a JSON schema.
+
+        - Single element: unwrap.
+        - Two elements where one is ``{"type": "null"}``: extract the non-null schema,
+          normalize it, and add ``"null"`` to its type (nullable shorthand pattern).
+        - Otherwise: normalize each subschema in place.
+
+        Args:
+            schema: A JSON schema containing a ``oneOf`` keyword.
+
+        Returns:
+            The processed schema.
+        """
+        subschemas = schema["oneOf"]
+        rest = {k: v for k, v in schema.items() if k != "oneOf"}
+
+        if len(subschemas) == 1:
+            (inner,) = subschemas
+            return rest | self.normalize_schema(inner)
+
+        if len(subschemas) == 2 and {"type": "null"} in subschemas:  # noqa: PLR2004
+            non_null = next(s for s in subschemas if s != {"type": "null"})
+            inner = self.normalize_schema(non_null)
+            types_raw = inner.get("type", [])
+            types = [types_raw] if isinstance(types_raw, str) else list(types_raw)
+            if "null" not in types:
+                inner["type"] = [*types, "null"]
+            return rest | inner
+
+        return {**rest, "oneOf": [self.normalize_schema(s) for s in subschemas]}
+
     def handle_all_of(self, subschemas: list[Schema]) -> Schema:  # noqa: PLR6301
         """Handle allOf constructs in a JSON schema.
 
@@ -367,25 +399,18 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
 
         if "object" in schema_type:
             result = self.handle_object(result, key_properties=key_properties)
-
         elif "array" in schema_type and (items := result.get("items")):
             result["items"] = self.handle_array_items(items)
 
         if "allOf" in result:
             result = self.normalize_schema(self.handle_all_of(result["allOf"]))
-
         if "oneOf" in result:
-            if len(result["oneOf"]) == 1:
-                (inner,) = result.pop("oneOf")
-                result.update(self.normalize_schema(inner))
-                schema_type = result.get("type", [])
-            else:
-                result["oneOf"] = [self.normalize_schema(s) for s in result["oneOf"]]
-
+            result = self.handle_one_of(result)
         if "anyOf" in result:
             result["anyOf"] = [self.normalize_schema(s) for s in result["anyOf"]]
 
-        types = [schema_type] if isinstance(schema_type, str) else schema_type
+        types_raw = result.get("type", [])
+        types = [types_raw] if isinstance(types_raw, str) else types_raw
         if result.pop("nullable", False) and types and "null" not in types:
             result["type"] = [*types, "null"]
 

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -714,6 +714,27 @@ class TestOpenAPISchemaNormalization:
                             },
                         },
                     },
+                    "NullableOneOf": {
+                        "oneOf": [
+                            {"type": "string", "format": "date-time"},
+                            {"type": "null"},
+                        ],
+                    },
+                    "NullableOneOfNullFirst": {
+                        "oneOf": [
+                            {"type": "null"},
+                            {"type": "integer"},
+                        ],
+                    },
+                    "NullableOneOfObject": {
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "properties": {"id": {"type": "string"}},
+                            },
+                            {"type": "null"},
+                        ],
+                    },
                     "MultipleOneOf": {
                         "oneOf": [
                             {"type": "object", "properties": {"x": {"type": "string"}}},
@@ -806,6 +827,41 @@ class TestOpenAPISchemaNormalization:
         normalized = source.preprocess_schema(schema)
         assert "oneOf" not in normalized["properties"]["value"]
         assert normalized["properties"]["value"]["type"] == ["integer", "null"]
+
+    @pytest.mark.parametrize(
+        "schema_name, expected",
+        [
+            pytest.param(
+                "NullableOneOf",
+                {"type": ["string", "null"], "format": "date-time"},
+                id="rich-schema-then-null",
+            ),
+            pytest.param(
+                "NullableOneOfNullFirst",
+                {"type": ["integer", "null"]},
+                id="null-then-rich-schema",
+            ),
+            pytest.param(
+                "NullableOneOfObject",
+                {
+                    "type": ["object", "null"],
+                    "properties": {"id": {"type": ["string", "null"]}},
+                },
+                id="object-schema-then-null",
+            ),
+        ],
+    )
+    def test_normalize_two_element_one_of_with_null(
+        self,
+        source: OpenAPISchema,
+        schema_name: str,
+        expected: dict[str, t.Any],
+    ):
+        """Test that oneOf [<schema>, {"type": "null"}] is unwrapped and made nullable."""  # noqa: E501
+        schema = source.get_schema(schema_name)
+        normalized = source.preprocess_schema(schema)
+        assert "oneOf" not in normalized
+        assert normalized == expected
 
     def test_normalize_one_of_recursive(self, source: OpenAPISchema):
         """Test that oneOf are recursively normalized to nullable object members."""


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Normalize JSON schemas that use two-element oneOf with a null branch into a single nullable schema representation and centralize oneOf handling logic.

New Features:
- Support normalization of two-element oneOf schemas where one branch is the null type into compact nullable type schemas, including nested object properties.

Enhancements:
- Refactor oneOf processing into a dedicated handler used by normalize_schema to simplify and unify oneOf normalization behavior.

Tests:
- Add parametrized tests covering normalization of nullable oneOf schemas for primitives and objects, ensuring oneOf removal and correct nullable type shaping.