### PR TITLE
refactor: Split type parameters for Singer reader and writer protocols

### DIFF
--- a/singer_sdk/contrib/msgspec.py
+++ b/singer_sdk/contrib/msgspec.py
@@ -48,7 +48,7 @@ decoder = msgspec.json.Decoder(dec_hook=dec_hook, float_hook=decimal.Decimal)
 _jsonl_msg_buffer = bytearray(64)
 
 
-def serialize_jsonl(obj: object, **kwargs: t.Any) -> bytes:  # noqa: ARG001
+def serialize_jsonl(obj: object, **kwargs: t.Any) -> bytearray:  # noqa: ARG001
     """Serialize a dictionary into a line of jsonl.
 
     Args:
@@ -60,7 +60,7 @@ def serialize_jsonl(obj: object, **kwargs: t.Any) -> bytes:  # noqa: ARG001
     """
     encoder.encode_into(obj, _jsonl_msg_buffer)
     _jsonl_msg_buffer.extend(b"\n")
-    return _jsonl_msg_buffer  # ty: ignore[invalid-return-type]
+    return _jsonl_msg_buffer
 
 
 class MsgSpecReader(GenericSingerReader[str]):
@@ -88,10 +88,10 @@ class MsgSpecReader(GenericSingerReader[str]):
             raise InvalidInputLine(msg) from exc
 
 
-class MsgSpecWriter(GenericSingerWriter[bytes, Message]):
+class MsgSpecWriter(GenericSingerWriter[bytearray, Message]):
     """Interface for all plugins writing Singer messages to stdout."""
 
-    def serialize_message(self, message: Message) -> bytes:  # noqa: PLR6301
+    def serialize_message(self, message: Message) -> bytearray:  # noqa: PLR6301
         """Serialize a dictionary into a line of json.
 
         Args:

--- a/singer_sdk/singerlib/encoding/base.py
+++ b/singer_sdk/singerlib/encoding/base.py
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)
 
 # TODO: Use to default to 'str' here
 # https://peps.python.org/pep-0696/
-T = t.TypeVar("T", str, bytes)
+_WT = t.TypeVar("_WT", str, bytes, bytearray)
+# IO[T] requires AnyStr (str | bytes); bytearray is only valid for writers
+_RT = t.TypeVar("_RT", str, bytes)
 M = t.TypeVar("M")
 
 
@@ -35,17 +37,17 @@ class SingerMessageType(str, enum.Enum):
     BATCH = "BATCH"
 
 
-class GenericSingerReader(abc.ABC, t.Generic[T]):
+class GenericSingerReader(abc.ABC, t.Generic[_RT]):
     """Interface for all plugins reading Singer messages as strings or bytes."""
 
     def __init__(self) -> None:
         """Initialize the reader."""
         super().__init__()
-        self._current_message: T | None = None
+        self._current_message: _RT | None = None
 
     def process_lines(
         self,
-        file_input: t.IO[T] | None,
+        file_input: t.IO[_RT] | None,
         callbacks: dict[str, t.Callable[[dict], None]],
     ) -> t.Counter[str]:
         """Internal method to process jsonl lines from a Singer tap.
@@ -77,7 +79,7 @@ class GenericSingerReader(abc.ABC, t.Generic[T]):
 
     @property
     @abc.abstractmethod
-    def default_input(self) -> t.IO[T]:
+    def default_input(self) -> t.IO[_RT]:
         """Default input stream for the reader."""
 
     @staticmethod
@@ -97,7 +99,7 @@ class GenericSingerReader(abc.ABC, t.Generic[T]):
             raise exceptions.InvalidInputLine(msg)
 
     @abc.abstractmethod
-    def deserialize_json(self, line: T) -> dict:
+    def deserialize_json(self, line: _RT) -> dict:
         """Deserialize a line of json."""
 
     def _process_unknown_message(self, message_dict: dict) -> None:  # noqa: PLR6301
@@ -114,10 +116,10 @@ class GenericSingerReader(abc.ABC, t.Generic[T]):
         raise ValueError(msg)
 
 
-class GenericSingerWriter(abc.ABC, t.Generic[T, M]):
+class GenericSingerWriter(abc.ABC, t.Generic[_WT, M]):
     """Interface for all plugins writing Singer messages as strings or bytes."""
 
-    def format_message(self, message: M) -> T:
+    def format_message(self, message: M) -> _WT:
         """Format a message as a JSON string.
 
         Args:
@@ -129,7 +131,7 @@ class GenericSingerWriter(abc.ABC, t.Generic[T, M]):
         return self.serialize_message(message)
 
     @abc.abstractmethod
-    def serialize_message(self, message: M) -> T:
+    def serialize_message(self, message: M) -> _WT:
         """Serialize a message into a line of json."""
 
     @abc.abstractmethod


### PR DESCRIPTION
## Summary by Sourcery

Refine the generic reader and writer protocols for Singer message encoding to use separate, more precise type parameters for input and output streams, and align the msgspec-based writer to use bytearray-based JSONL serialization.

Bug Fixes:
- Correct the msgspec JSONL serialization return type to match the actual bytearray buffer used for encoding, ensuring type safety for writer implementations.

Enhancements:
- Split the shared type parameter for Singer readers and writers into distinct reader and writer type variables, allowing writers to support bytearray while keeping readers constrained to str and bytes.
- Adjust the msgspec-based Singer writer to use bytearray as its message format type in line with the updated generic writer protocol.