### PR TITLE
ci: Use a cache suffix for setup-uv

### DIFF
--- a/.github/workflows/api-changes.yml
+++ b/.github/workflows/api-changes.yml
@@ -35,9 +35,6 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
 
-    - name: Setup Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         version: ${{ env.UV_VERSION }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,7 +47,7 @@ jobs:
         persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
-    - uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+    - uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
       with:
         config-file: .github/codeql-config.yml
         languages: ${{ matrix.language }}
@@ -61,7 +61,7 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+    - uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -73,4 +73,4 @@ jobs:
     #   echo "Run, Build Application using script"
     #   ./location_of_script_within_repo/buildscript.sh
 
-    - uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+    - uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -59,7 +59,7 @@ jobs:
         uv export --all-packages --no-editable --frozen --no-hashes --no-dev --all-extras --group benchmark --output-file requirements.codspeed.txt
         uv pip install --system -r requirements.codspeed.txt
 
-    - uses: CodSpeedHQ/action@658a901452bb54c799643e060733b7afe9121b8d # v4.14.0
+    - uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4.15.1
       with:
         token: ${{ secrets.CODSPEED_TOKEN }}
         run: pytest tests/ --codspeed

--- a/.github/workflows/cookiecutter-e2e.yml
+++ b/.github/workflows/cookiecutter-e2e.yml
@@ -46,8 +46,6 @@ jobs:
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         version: ${{ env.UV_VERSION }}
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-
     - name: Install Nox
       run: |
         uv tool install nox

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         if: ${{ github.event_name == 'pull_request' }}
         with:
           fail-on-severity: high

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
+    - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
       id: baipp
 
   provenance:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,14 +89,10 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
 
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
-
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         cache-suffix: ${{ matrix.session }}
+        python-version: ${{ matrix.python-version }}
         version: ${{ env.UV_VERSION }}
 
     - name: Install Nox
@@ -133,12 +129,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
+          python-version: ${{ matrix.python-version }}
           version: ${{ env.UV_VERSION }}
 
       - name: Install Nox
@@ -166,8 +159,6 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
@@ -202,7 +193,6 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,10 +77,10 @@ jobs:
         - { session: deps,          python-version: "3.14", os: "ubuntu-latest" }
         - { session: doctest,       python-version: "3.14", os: "ubuntu-latest" }
         - { session: deps,          python-version: "3.14", os: "ubuntu-latest" }
-        - { session: test-lowest,   python-version: "3.10",  os: "ubuntu-latest" }
-        - { session: test-contrib,  python-version: "3.10",  os: "ubuntu-latest" }
+        - { session: test-lowest,   python-version: "3.10", os: "ubuntu-latest" }
+        - { session: test-contrib,  python-version: "3.10", os: "ubuntu-latest" }
         - { session: test-contrib,  python-version: "3.14", os: "ubuntu-latest" }
-        - { session: test-packages, python-version: "3.10",  os: "ubuntu-latest" }
+        - { session: test-packages, python-version: "3.10", os: "ubuntu-latest" }
         - { session: test-packages, python-version: "3.14", os: "ubuntu-latest" }
 
     steps:
@@ -96,6 +96,7 @@ jobs:
 
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
+        cache-suffix: ${{ matrix.session }}
         version: ${{ env.UV_VERSION }}
 
     - name: Install Nox


### PR DESCRIPTION
SSIA

## Summary by Sourcery

CI:
- Add a cache suffix based on the Nox session name for the astral-sh/setup-uv action in the test workflow.