### PR TITLE
refactor: Update types to match new inline type annotations in Requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,6 @@ typing = [
     "ty==0.0.29",
     "types-jsonschema>=4.17.0.6",
     "types-pytz>=2022.7.1.2",
-    "types-requests>=2.28.11",
     "types-simplejson>=3.18.0",
     "types-PyYAML>=6.0.12",
 ]

--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -673,7 +673,7 @@ class OAuthAuthenticator(APIAuthenticatorBase):
         limit = 1000
         snippet = f"{content[:limit]}..." if len(content) > limit else content
         self.logger.error(
-            "Failed OAuth login with status code %d, response was '%s'",
+            "Failed OAuth login with status code %s, response was '%s'",
             status_code or "Unknown",
             snippet,
         )

--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -637,11 +637,16 @@ class OAuthAuthenticator(APIAuthenticatorBase):
         try:
             token_response.raise_for_status()
         except requests.HTTPError as ex:
-            self.handle_error(
-                content=ex.response.text,
-                status_code=ex.response.status_code,
+            text, status_code = (
+                (ex.response.text, ex.response.status_code)
+                if ex.response is not None
+                else ("Error", None)
             )
-            msg = f"Failed to update access token (status={ex.response.status_code})"
+            self.handle_error(
+                content=text,
+                status_code=status_code,
+            )
+            msg = f"Failed to update access token (status={status_code or 'Unknown'})"
             raise RuntimeError(msg) from ex
 
         self.logger.debug("OAuth authorization attempt was successful")
@@ -658,7 +663,7 @@ class OAuthAuthenticator(APIAuthenticatorBase):
             )
         self.last_refreshed = request_time
 
-    def handle_error(self, *, content: str, status_code: int) -> None:
+    def handle_error(self, *, content: str, status_code: int | None) -> None:
         """Handle an OAuth error.
 
         Args:
@@ -669,7 +674,7 @@ class OAuthAuthenticator(APIAuthenticatorBase):
         snippet = f"{content[:limit]}..." if len(content) > limit else content
         self.logger.error(
             "Failed OAuth login with status code %d, response was '%s'",
-            status_code,
+            status_code or "Unknown",
             snippet,
         )
 

--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -493,7 +493,7 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
             A :class:`requests.PreparedRequest` object.
         """
         request = requests.Request(*args, **kwargs)
-        request.headers.setdefault("User-Agent", self.user_agent)
+        request.headers.setdefault("User-Agent", self.user_agent)  # type: ignore[union-attr] # ty: ignore[unresolved-attribute]
         self.requests_session.auth = self.authenticator
         return self.requests_session.prepare_request(request)
 

--- a/uv.lock
+++ b/uv.lock
@@ -946,7 +946,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2501,7 +2501,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.33.1"
+version = "2.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -2509,9 +2509,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/b8/7a707d60fea4c49094e40262cc0e2ca6c768cca21587e34d3f705afec47e/requests-2.34.0.tar.gz", hash = "sha256:7d62fe92f50eb82c529b0916bb445afa1531a566fc8f35ffdc64446e771b856a", size = 142436, upload-time = "2026-05-11T19:29:51.717Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e6/e300fce5fe83c30520607a015dabd985df3251e188d234bfe9492e17a389/requests-2.34.0-py3-none-any.whl", hash = "sha256:917520a21b767485ce7c588f4ebb917c436b24a31231b44228715eaeb5a52c60", size = 73021, upload-time = "2026-05-11T19:29:49.923Z" },
 ]
 
 [[package]]
@@ -2935,7 +2935,6 @@ dev = [
     { name = "types-jsonschema" },
     { name = "types-pytz" },
     { name = "types-pyyaml" },
-    { name = "types-requests" },
     { name = "types-simplejson" },
     { name = "xdoctest", extra = ["colors"] },
 ]
@@ -3011,7 +3010,6 @@ typing = [
     { name = "types-jsonschema" },
     { name = "types-pytz" },
     { name = "types-pyyaml" },
-    { name = "types-requests" },
     { name = "types-simplejson" },
     { name = "xdoctest", extra = ["colors"] },
 ]
@@ -3104,7 +3102,6 @@ dev = [
     { name = "types-jsonschema", specifier = ">=4.17.0.6" },
     { name = "types-pytz", specifier = ">=2022.7.1.2" },
     { name = "types-pyyaml", specifier = ">=6.0.12" },
-    { name = "types-requests", specifier = ">=2.28.11" },
     { name = "types-simplejson", specifier = ">=3.18.0" },
     { name = "xdoctest", extras = ["colors"], specifier = ">=1.1.1" },
 ]
@@ -3176,7 +3173,6 @@ typing = [
     { name = "types-jsonschema", specifier = ">=4.17.0.6" },
     { name = "types-pytz", specifier = ">=2022.7.1.2" },
     { name = "types-pyyaml", specifier = ">=6.0.12" },
-    { name = "types-requests", specifier = ">=2.28.11" },
     { name = "types-simplejson", specifier = ">=3.18.0" },
     { name = "xdoctest", extras = ["colors"], specifier = ">=1.1.1" },
 ]
@@ -3725,18 +3721,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/36/85/0d9fafce21be112e977a89677f1ce9d1aef921d745b17c758c93e861c11f/types_pyyaml-6.0.12.20260510.tar.gz", hash = "sha256:09c1f1cb65a6eebea1e2e51ccf4918b8288e152909609a35cdb0d805efd125ad", size = 17831, upload-time = "2026-05-10T05:26:28.136Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/ad/fd618a218925daada7b8a5e7326e662599fa5fdff4a4c44ab2795bd2d9ca/types_pyyaml-6.0.12.20260510-py3-none-any.whl", hash = "sha256:3492eb9ba4d9d833473214c4d5736cccf5f37d93f5854059721e1c84f785309d", size = 20304, upload-time = "2026-05-10T05:26:26.981Z" },
-]
-
-[[package]]
-name = "types-requests"
-version = "2.33.0.20260508"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/6b/eb226bdd61a982c9a03e02c657fb4ab001733506e6423906ac142331f2e3/types_requests-2.33.0.20260508.tar.gz", hash = "sha256:81b2ae5f0d20967714a6aa5ef9284c05570d7cb06b7de8f2a77b918b63ddd411", size = 23991, upload-time = "2026-05-08T04:50:56.818Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/96/080db0afdf2c5cc5fe512b41354e8d114fe8f65e9510c56ff8dfd40216ce/types_requests-2.33.0.20260508-py3-none-any.whl", hash = "sha256:fa01459cca184229713df03709db46a905325906d27e042cd4fd7ea3d15d3400", size = 20722, upload-time = "2026-05-08T04:50:55.548Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Handle missing HTTP response objects when refreshing OAuth access tokens and align type hints and tooling with updated Requests type annotations.

Bug Fixes:
- Prevent crashes when OAuth token refresh errors lack an HTTP response by safely handling missing response attributes.

Enhancements:
- Allow OAuth error handler to accept optional HTTP status codes and log a fallback when the status is unknown.
- Relax type checking around setting the User-Agent header on prepared requests to accommodate updated Requests types.

Build:
- Remove the types-requests dependency from the typing extras in project configuration.