### PR TITLE
chore: Update templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
     types_or: [python, markdown]
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.11.8
+  rev: 0.11.13
   hooks:
   - id: uv-lock
   - id: uv-sync

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
+    - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
       id: baipp
 
   publish:

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/run-zizmor.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/run-zizmor.yml
@@ -28,4 +28,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
         id: baipp
 
   pytest:
@@ -57,7 +57,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup uv
-      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Run Tox
@@ -72,7 +72,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup uv
-      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Run Tox
       run: >
         uvx

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
+    - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
       id: baipp
 
   publish:

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/run-zizmor.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/run-zizmor.yml
@@ -28,4 +28,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
         id: baipp
 
   pytest:
@@ -57,7 +57,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup uv
-      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Run Tox
@@ -72,7 +72,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup uv
-      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Run Tox
       run: >
         uvx

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "singer-sdk~=0.53.7",
     {%- endif %}
     {%- if cookiecutter.stream_type in ["REST", "GraphQL"] %}
-    "requests~=2.33.0",
+    "requests~=2.34.0",
     {%- endif %}
     {%- if cookiecutter.stream_type == "SQL" %}
     "sqlalchemy~=2.0.36",
@@ -77,8 +77,6 @@ typing = [
     "ty>=0.0.18",
     {%- if cookiecutter.stream_type == "SQL" %}
     "sqlalchemy-stubs",
-    {%- else %}
-    "types-requests",
     {%- endif %}
 ]
 

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
+    - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
       id: baipp
 
   publish:

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/run-zizmor.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/run-zizmor.yml
@@ -28,4 +28,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
         id: baipp
 
   pytest:
@@ -57,7 +57,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup uv
-      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Run Tox
@@ -72,7 +72,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup uv
-      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Run Tox
       run: >
         uvx

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "sqlalchemy~=2.0",
     "typing-extensions>=4.5.0; python_version < '3.13'",
     {%- else %}
-    "requests~=2.33.0",
+    "requests~=2.34.0",
     {%- endif %}
 ]
 
@@ -72,8 +72,6 @@ typing = [
     "ty>=0.0.18",
     {%- if cookiecutter.serialization_method == "SQL" %}
     "sqlalchemy-stubs",
-    {%- else %}
-    "types-requests",
     {%- endif %}
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

Update cookiecutter tap/target/mapper templates and shared tooling to use newer versions of CI actions, dependencies, and pre-commit hooks.

Bug Fixes:
- Align tap and target templates to use requests~=2.34.0 and drop the types-requests typing dependency where not needed.

Enhancements:
- Bump hynek/build-and-inspect-python-package GitHub Action to v2.18.0 across mapper, tap, and target workflows.
- Upgrade astral-sh/setup-uv GitHub Action to v8.1.0 in test workflows for all templates.
- Update zizmorcore/zizmor-action GitHub Action to v0.5.3 in run-zizmor workflows for all templates.
- Increase uv-pre-commit hook version to 0.11.13 in the pre-commit configuration.