### PR TITLE
fix: Avoid logging full context dictionary

### DIFF
--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -1318,7 +1318,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
         log_args: list[t.Any] = [self.name, self.replication_method.lower()]
         if context:
             log_msg += " with context keys: %s"
-            log_args.append(tuple(context.keys()))
+            log_args.append(tuple(sorted(context.keys())))
 
         self.log(log_msg, *log_args)
 

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -1317,8 +1317,8 @@ class Stream(abc.ABC):  # noqa: PLR0904
         log_msg = "Beginning sync of '%s' in %s mode"
         log_args: list[t.Any] = [self.name, self.replication_method.lower()]
         if context:
-            log_msg += " with context: %s"
-            log_args.append(context)
+            log_msg += " with context keys: %s"
+            log_args.append(tuple(context.keys()))
 
         self.log(log_msg, *log_args)
 

--- a/tests/core/snapshots/test_parent_child/test_child_deselected_parent/stderr.log
+++ b/tests/core/snapshots/test_parent_child/test_child_deselected_parent/stderr.log
@@ -1,4 +1,4 @@
 INFO my-tap.parent Beginning sync of 'parent' in full_table mode
-INFO my-tap.child Beginning sync of 'child' in full_table mode with context: {'pid': 1}
-INFO my-tap.child Beginning sync of 'child' in full_table mode with context: {'pid': 2}
-INFO my-tap.child Beginning sync of 'child' in full_table mode with context: {'pid': 3}
+INFO my-tap.child Beginning sync of 'child' in full_table mode with context keys: ('pid',)
+INFO my-tap.child Beginning sync of 'child' in full_table mode with context keys: ('pid',)
+INFO my-tap.child Beginning sync of 'child' in full_table mode with context keys: ('pid',)

--- a/tests/core/snapshots/test_parent_child/test_one_parent_many_children/stderr.log
+++ b/tests/core/snapshots/test_parent_child/test_one_parent_many_children/stderr.log
@@ -1,7 +1,7 @@
 INFO my-tap-many Skipping parse of env var settings...
 INFO my-tap-many Added 'child_many' as child stream to 'parent_many'
 INFO my-tap-many.parent_many Beginning sync of 'parent_many' in full_table mode
-INFO my-tap-many.child_many Beginning sync of 'child_many' in full_table mode with context: {'child_id': 1, 'pid': '1'}
+INFO my-tap-many.child_many Beginning sync of 'child_many' in full_table mode with context keys: ('child_id', 'pid')
 WARNING my-tap-many.child_many Properties ('composite_id', 'child_id') were present in the 'child_many' stream but not found in catalog schema. Ignoring.
-INFO my-tap-many.child_many Beginning sync of 'child_many' in full_table mode with context: {'child_id': 2, 'pid': '1'}
-INFO my-tap-many.child_many Beginning sync of 'child_many' in full_table mode with context: {'child_id': 3, 'pid': '1'}
+INFO my-tap-many.child_many Beginning sync of 'child_many' in full_table mode with context keys: ('child_id', 'pid')
+INFO my-tap-many.child_many Beginning sync of 'child_many' in full_table mode with context keys: ('child_id', 'pid')

--- a/tests/core/snapshots/test_parent_child/test_parent_context_fields_in_child/stderr.log
+++ b/tests/core/snapshots/test_parent_child/test_parent_context_fields_in_child/stderr.log
@@ -1,4 +1,4 @@
 INFO my-tap.parent Beginning sync of 'parent' in full_table mode
-INFO my-tap.child Beginning sync of 'child' in full_table mode with context: {'pid': 1}
-INFO my-tap.child Beginning sync of 'child' in full_table mode with context: {'pid': 2}
-INFO my-tap.child Beginning sync of 'child' in full_table mode with context: {'pid': 3}
+INFO my-tap.child Beginning sync of 'child' in full_table mode with context keys: ('pid',)
+INFO my-tap.child Beginning sync of 'child' in full_table mode with context keys: ('pid',)
+INFO my-tap.child Beginning sync of 'child' in full_table mode with context keys: ('pid',)

--- a/tests/core/snapshots/test_parent_child/test_preprocess_context_removes_large_payload/stderr.log
+++ b/tests/core/snapshots/test_parent_child/test_preprocess_context_removes_large_payload/stderr.log
@@ -1,5 +1,5 @@
 INFO tap-preprocess Skipping parse of env var settings...
 INFO tap-preprocess Added 'child_preprocessed' as child stream to 'parent_large'
 INFO tap-preprocess.parent_large Beginning sync of 'parent_large' in full_table mode
-INFO tap-preprocess.child_preprocessed Beginning sync of 'child_preprocessed' in full_table mode with context: {'parent_id': 1, 'parent_name': 'Parent A'}
-INFO tap-preprocess.child_preprocessed Beginning sync of 'child_preprocessed' in full_table mode with context: {'parent_id': 2, 'parent_name': 'Parent B'}
+INFO tap-preprocess.child_preprocessed Beginning sync of 'child_preprocessed' in full_table mode with context keys: ('parent_id', 'parent_name')
+INFO tap-preprocess.child_preprocessed Beginning sync of 'child_preprocessed' in full_table mode with context keys: ('parent_id', 'parent_name')


### PR DESCRIPTION
And instead log only the context keys.

## Summary by Sourcery

Bug Fixes:
- Prevent potentially large or sensitive context payloads from being fully logged during stream sync.