### PR TITLE
fix(taps): Honor `state_partitioning_keys` declared as class attributes

### DIFF
--- a/singer_sdk/streams/_state.py
+++ b/singer_sdk/streams/_state.py
@@ -98,6 +98,12 @@ class StreamStateManager:
             )
         return self.stream_state
 
+    @t.overload
+    def get_state_partition_context(self, context: None) -> None: ...
+
+    @t.overload
+    def get_state_partition_context(self, context: types.Context) -> types.Context: ...
+
     def get_state_partition_context(
         self,
         context: types.Context | None,

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -197,7 +197,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
                 tap_name=self.tap_name,
                 stream_name=self.name,
                 tap_state=self._tap_state,
-                state_partitioning_keys=self._state_partitioning_keys,
+                state_partitioning_keys=self.state_partitioning_keys,
                 is_sorted=self.is_sorted,
                 check_sorted=self.check_sorted,
             )

--- a/tests/core/test_streams.py
+++ b/tests/core/test_streams.py
@@ -776,3 +776,59 @@ def test_post_process_transforms_record(tap: Tap):
     stream = TransformsRecord(tap)
     records = stream._sync_records(None, write_messages=False)
     assert all(record["extra"] == "transformed" for record in records)
+
+
+@pytest.mark.parametrize(
+    "keys,expected_context",
+    [
+        pytest.param(
+            ["parent_id"],
+            {"parent_id": 123},
+            id="single_key",
+        ),
+        pytest.param(
+            ["parent_id", "other_key"],
+            {"parent_id": 123, "other_key": "abc"},
+            id="multiple_keys",
+        ),
+        pytest.param(
+            (),
+            {},
+            id="empty_tuple",
+        ),
+        pytest.param(
+            [],
+            {},
+            id="empty_list",
+        ),
+        pytest.param(
+            None,
+            {"parent_id": 123, "other_key": "abc"},
+            id="none",
+        ),
+    ],
+)
+def test_state_partitioning_keys_class_variable(
+    tap: Tap,
+    keys: t.Sequence[str] | None,
+    expected_context: Context | None,
+):
+    """Regression test: class-level state_partitioning_keys=[] is respected.
+
+    When a stream sets state_partitioning_keys=... as a class variable, the
+    state_manager must receive the right value (not the default None,
+    None). Bug: state_manager was initialised with self._state_partitioning_keys
+    (always None from __init__) rather than self.state_partitioning_keys (which
+    resolves the class attribute). See https://github.com/meltano/sdk/issues/3631.
+    """
+
+    class NoPartitionStream(SimpleTestStream):
+        name = "no_partition"
+        state_partitioning_keys = keys
+
+    stream = NoPartitionStream(tap)
+    original_context = {"parent_id": 123, "other_key": "abc"}
+    assert (
+        stream.state_manager.get_state_partition_context(original_context)
+        == expected_context
+    )

--- a/tests/core/test_streams.py
+++ b/tests/core/test_streams.py
@@ -792,6 +792,11 @@ def test_post_process_transforms_record(tap: Tap):
             id="multiple_keys",
         ),
         pytest.param(
+            ["parent_id", "missing_key"],
+            {"parent_id": 123},
+            id="missing_keys",
+        ),
+        pytest.param(
             (),
             {},
             id="empty_tuple",


### PR DESCRIPTION
Closes

- https://github.com/meltano/sdk/issues/3631

## Summary by Sourcery

Ensure stream state partitioning respects class-level configuration and improve state management typing.

Bug Fixes:
- Fix state manager initialization so streams that define state_partitioning_keys as a class attribute correctly pass those keys to the state manager.

Enhancements:
- Add precise overload typing for get_state_partition_context to clarify its behavior with None and non-None contexts.

Tests:
- Add a regression test suite verifying that class-level state_partitioning_keys values, including empty and None cases, are correctly honored when computing the state partition context.