### PR TITLE
refactor: Improve type narrowing for null streamp map expressions

### DIFF
--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -689,7 +689,7 @@ class CustomStreamMap(StreamMap):
                         result[key_property] = record[key_property]
 
             for prop_key, prop_def, prop_def_parsed in stream_map_parsed:
-                if prop_def in {None, NULL_STRING}:
+                if prop_def is None or prop_def == NULL_STRING:
                     # Remove property from result
                     result.pop(prop_key, None)
                     continue
@@ -697,7 +697,7 @@ class CustomStreamMap(StreamMap):
                 if isinstance(prop_def_parsed, ast.Expr):
                     # Apply property transform
                     result[prop_key] = self._eval(
-                        expr=prop_def,  # type: ignore[arg-type]
+                        expr=prop_def,
                         expr_parsed=prop_def_parsed,
                         record=record,
                         property_name=prop_key,


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Refine handling of null-valued stream map expressions to improve type safety and clarity.

Bug Fixes:
- Correct null and NULL_STRING comparison logic when processing stream map definitions to avoid unintended behavior.

Enhancements:
- Remove an unnecessary type ignore by tightening the expression type used in stream map evaluation.