### PR TITLE
chore: Use the `uv-audit` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,8 @@ ci:
   autofix_commit_msg: "style: pre-commit fixes"
   autoupdate_schedule: monthly
   autoupdate_commit_msg: 'chore: pre-commit autoupdate'
+  skip:
+  - uv-audit
 
 default_language_version:
   python: python3.14
@@ -69,6 +71,7 @@ repos:
 - repo: https://github.com/astral-sh/uv-pre-commit
   rev: 0.11.14
   hooks:
+  - id: uv-audit
   - id: uv-lock
   - id: uv-sync
 

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
@@ -3,6 +3,8 @@ ci:
   autofix_commit_msg: "style: pre-commit fixes"
   autoupdate_schedule: monthly
   autoupdate_commit_msg: 'chore: pre-commit autoupdate'
+  skip:
+  - uv-audit
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -39,6 +41,7 @@ repos:
 - repo: https://github.com/astral-sh/uv-pre-commit
   rev: 0.11.14
   hooks:
+  - id: uv-audit
   - id: uv-lock
   - id: uv-sync
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
@@ -3,6 +3,8 @@ ci:
   autofix_commit_msg: "style: pre-commit fixes"
   autoupdate_schedule: monthly
   autoupdate_commit_msg: 'chore: pre-commit autoupdate'
+  skip:
+  - uv-audit
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -39,6 +41,7 @@ repos:
 - repo: https://github.com/astral-sh/uv-pre-commit
   rev: 0.11.14
   hooks:
+  - id: uv-audit
   - id: uv-lock
   - id: uv-sync
 

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
@@ -3,6 +3,8 @@ ci:
   autofix_commit_msg: "style: pre-commit fixes"
   autoupdate_schedule: monthly
   autoupdate_commit_msg: 'chore: pre-commit autoupdate'
+  skip:
+  - uv-audit
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -39,6 +41,7 @@ repos:
 - repo: https://github.com/astral-sh/uv-pre-commit
   rev: 0.11.14
   hooks:
+  - id: uv-audit
   - id: uv-lock
   - id: uv-sync
 


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Add uv-audit to pre-commit hook configurations while skipping it in CI-run pre-commit checks.

Enhancements:
- Enable the uv-audit hook from the uv-pre-commit repository in the main project and cookiecutter template pre-commit configurations.
- Configure CI pre-commit runs to skip the uv-audit hook across the main project and all cookiecutter templates.