### PR TITLE
fix(templates): Bump minimal required Tox to 4.53 and update configuration in templates

### DIFF
--- a/.github/workflows/resources/requirements.txt
+++ b/.github/workflows/resources/requirements.txt
@@ -1,4 +1,4 @@
 griffecli~=2.0
 nox==2026.4.10
-prek==0.3.13
+prek==0.4.1
 twine==6.2.0

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -132,14 +132,12 @@ convention = "google"
 # This configuration can be used to customize tox environments
 [tool.tox]
 requires = [
-    "tox>=4.43",
-    "tox-uv",
+    "tox>=4.53",
+    "tox-uv>=1.35",
 ]
 env_list = [
     "typing",
-    { product = [
-        { prefix = "3.", start = 10 },
-    ] },
+    { prefix = "3.", start = 10 },
 ]
 
 [tool.tox.env_run_base]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -146,14 +146,12 @@ convention = "google"
 # This configuration can be used to customize tox environments
 [tool.tox]
 requires = [
-    "tox>=4.43",
-    "tox-uv",
+    "tox>=4.53",
+    "tox-uv>=1.35",
 ]
 env_list = [
     "typing",
-    { product = [
-        { prefix = "3.", start = 10 },
-    ] },
+    { prefix = "3.", start = 10 },
 ]
 
 [tool.tox.env_run_base]

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -139,14 +139,12 @@ convention = "google"
 # This configuration can be used to customize tox environments
 [tool.tox]
 requires = [
-    "tox>=4.43",
-    "tox-uv",
+    "tox>=4.53",
+    "tox-uv>=1.35",
 ]
 env_list = [
     "typing",
-    { product = [
-        { prefix = "3.", start = 10 },
-    ] },
+    { prefix = "3.", start = 10 },
 ]
 
 [tool.tox.env_run_base]

--- a/noxfile.py
+++ b/noxfile.py
@@ -486,7 +486,7 @@ def templates(session: nox.Session, replay_file_path: Path) -> None:
     session.run("git", "init", "-b", "main", external=True)
     session.run("git", "add", "-A", external=True)
     session.run("uvx", "prek", "run", "--all-files")
-    session.run("uvx", "--with=tox-uv", "tox", "-l")
+    session.run("uvx", "--with=tox-uv", "tox", "list")
     session.run("uvx", "--with=tox-uv", "tox", "-e=typing")
 
 


### PR DESCRIPTION
## Summary by Sourcery

Update tooling versions and tox configuration used by project templates and CI resources.

Enhancements:
- Raise the minimum tox version and tox-uv requirement in mapper, tap, and target cookiecutter templates.
- Simplify tox env_list configuration in the cookiecutter template pyproject files.
- Switch the nox templates session to use the explicit `tox list` command for environment discovery.

Build:
- Bump the prek dependency version used in GitHub workflow resources.