### PR TITLE
feat(targets): Allow target implementations to completely control how new Sink instances are created

### DIFF
--- a/singer_sdk/sql/target.py
+++ b/singer_sdk/sql/target.py
@@ -82,6 +82,35 @@ class SQLTarget(Target):
 
         super().append_builtin_config(config_jsonschema)
 
+    def create_sink(
+        self,
+        *,
+        stream_name: str,
+        schema: dict,
+        key_properties: t.Sequence[str] | None = None,
+    ) -> Sink:
+        """Instantiate a new SQL sink for the given stream.
+
+        Injects ``self.target_connector`` so all sinks share a single connection.
+        Override to pass additional constructor arguments.
+
+        Args:
+            stream_name: Name of the stream.
+            schema: Schema of the stream.
+            key_properties: Primary key of the stream.
+
+        Returns:
+            A new sink instance for the stream.
+        """
+        sink_class = self.get_sink_class(stream_name=stream_name)
+        return sink_class(
+            target=self,
+            stream_name=stream_name,
+            schema=schema,
+            key_properties=key_properties,
+            connector=self.target_connector,
+        )
+
     @t.final
     def add_sqlsink(
         self,
@@ -102,13 +131,10 @@ class SQLTarget(Target):
             A new sink for the stream.
         """
         self.logger.debug("Initializing target sink '%s'...", self.name)
-        sink_class = self.get_sink_class(stream_name=stream_name)
-        sink = sink_class(
-            target=self,
+        sink = self.create_sink(
             stream_name=stream_name,
             schema=schema,
             key_properties=key_properties,
-            connector=self.target_connector,
         )
         sink.setup()
         self._sinks_active[stream_name] = sink

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -228,6 +228,36 @@ class Target(BaseSingerReader, abc.ABC):
         """
         return stream_name in self._sinks_active
 
+    def create_sink(
+        self,
+        *,
+        stream_name: str,
+        schema: dict,
+        key_properties: t.Sequence[str] | None = None,
+    ) -> Sink:
+        """Instantiate a new sink object for the given stream.
+
+        Override this method to customize how sinks are constructed — for example,
+        to inject a shared resource (a database connection, an auth token, a thread
+        pool) at construction time without requiring sinks to reach back into the
+        target at runtime.
+
+        Args:
+            stream_name: Name of the stream.
+            schema: Schema of the stream.
+            key_properties: Primary key of the stream.
+
+        Returns:
+            A new sink instance for the stream.
+        """
+        sink_class = self.get_sink_class(stream_name=stream_name)
+        return sink_class(
+            target=self,
+            stream_name=stream_name,
+            schema=schema,
+            key_properties=key_properties,
+        )
+
     @t.final
     def add_sink(
         self,
@@ -248,9 +278,7 @@ class Target(BaseSingerReader, abc.ABC):
             A new sink for the stream.
         """
         self.logger.debug("Initializing target sink '%s'...", self.name)
-        sink_class = self.get_sink_class(stream_name=stream_name)
-        sink = sink_class(
-            target=self,
+        sink = self.create_sink(
             stream_name=stream_name,
             schema=schema,
             key_properties=key_properties,

--- a/tests/core/test_target_base.py
+++ b/tests/core/test_target_base.py
@@ -146,6 +146,59 @@ def test_add_sqlsink_and_get_sink():
         )
 
 
+def test_create_sink_override():
+    """Target.create_sink() can be overridden to inject extra constructor args."""
+    injected = {}
+
+    class CustomSink(BatchSinkMock):
+        def __init__(self, *args, extra=None, **kwargs):
+            super().__init__(*args, **kwargs)
+            injected["extra"] = extra
+
+    class CustomTarget(TargetMock):
+        def create_sink(self, *, stream_name, schema, key_properties=None):
+            return CustomSink(
+                target=self,
+                stream_name=stream_name,
+                schema=schema,
+                key_properties=key_properties,
+                extra="injected_value",
+            )
+
+    schema = {"properties": {"id": {"type": ["integer"]}}}
+    target = CustomTarget()
+    sink = target.add_sink("test_stream", schema, [])
+    assert isinstance(sink, CustomSink)
+    assert injected["extra"] == "injected_value"
+
+
+def test_sql_create_sink_override():
+    """SQLTarget.create_sink() can be overridden to inject extra constructor args."""
+    injected = {}
+
+    class CustomSQLSink(SQLSinkMock):
+        def __init__(self, *args, extra=None, **kwargs):
+            super().__init__(*args, **kwargs)
+            injected["extra"] = extra
+
+    class CustomSQLTarget(SQLTargetMock):
+        def create_sink(self, *, stream_name, schema, key_properties=None):
+            return CustomSQLSink(
+                target=self,
+                stream_name=stream_name,
+                schema=schema,
+                key_properties=key_properties,
+                connector=self.target_connector,
+                extra="sql_injected",
+            )
+
+    schema = {"properties": {"id": {"type": ["integer"]}}}
+    target = CustomSQLTarget(config={"sqlalchemy_url": "sqlite:///"})
+    sink = target.add_sqlsink("test_stream", schema, [])
+    assert isinstance(sink, CustomSQLSink)
+    assert injected["extra"] == "sql_injected"
+
+
 def test_batch_size_rows_and_max_size():
     input_schema_1 = {
         "properties": {


### PR DESCRIPTION
Related

- Closes https://github.com/meltano/sdk/issues/3642

## Summary by Sourcery

Allow target implementations to override SQL sink instantiation while keeping sink registration logic internal.

Enhancements:
- Introduce overridable create_sink method on SQL targets that centralizes SQL sink instantiation and connector injection.

Tests:
- Add tests verifying that custom Target and SQLTarget implementations can override create_sink to inject additional constructor arguments into sink instances.