### PR TITLE
fix: Remove noisy `context` tag from `http_request_duration` metric log

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -414,12 +414,14 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
     def _request(
         self,
         prepared_request: requests.PreparedRequest,
-        context: Context | None,
+        context: Context | None = None,  # noqa: ARG002
     ) -> requests.Response:
-        """TODO.
+        """Make an HTTP request.
+
+        TODO(maintainers): Remove unused function parameters.
 
         Args:
-            prepared_request: TODO
+            prepared_request: The HTTP request object.
             context: Stream partition or context dictionary.
 
         Returns:
@@ -434,7 +436,6 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
         self._write_request_duration_log(
             endpoint=self.path,
             response=response,
-            context=context,
             extra_tags={"url": authenticated_request.path_url}
             if self._LOG_REQUEST_METRIC_URLS
             else None,
@@ -680,10 +681,12 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
         self,
         endpoint: str,
         response: requests.Response,
-        context: Context | None,
-        extra_tags: dict | None,
+        context: Context | None = None,  # noqa: ARG002
+        extra_tags: dict | None = None,
     ) -> None:
-        """TODO.
+        """Log the HTTP duration metric.
+
+        TODO(maintainers): Remove unused function parameters.
 
         Args:
             endpoint: The endpoint of the request.
@@ -695,8 +698,6 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
             return
 
         extra_tags = extra_tags or {}
-        if context:
-            extra_tags[metrics.Tag.CONTEXT] = context
 
         point = metrics.Point(
             "timer",

--- a/tests/core/rest/test_request_metrics.py
+++ b/tests/core/rest/test_request_metrics.py
@@ -70,7 +70,7 @@ def test_metrics_logging(
     assert isinstance(point_1, metrics.Point)
     assert point_1.metric == "http_request_duration"
     assert point_1.tags["endpoint"] == "/test"
-    assert point_1.tags.get("context") == context
+    assert "context" not in point_1.tags
     assert (
         (log_urls and point_1.tags.get("url") == "/test?user_id=1")  # Log URLs
         or (not log_urls and "url" not in point_1.tags)  # Don't log URLs


### PR DESCRIPTION
## Summary by Sourcery

Remove the noisy context tag from HTTP request duration metrics and update related logging behavior and tests.

Bug Fixes:
- Stop including the context tag in http_request_duration metric logs to reduce noise in emitted metrics.

Enhancements:
- Improve REST stream request and metric logging docstrings and make unused context parameters optional with explicit TODO notes for future cleanup.

Tests:
- Update request metrics tests to assert that the context tag is no longer present on http_request_duration points.