### PR TITLE
fix: Avoid logging full URLs in HTTP metrics (i.e. `_LOG_REQUEST_METRIC_URLS` has no effect now)

### DIFF
--- a/singer_sdk/streams/rest.py
+++ b/singer_sdk/streams/rest.py
@@ -433,13 +433,7 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
             timeout=self.timeout,
             allow_redirects=self.allow_redirects,
         )
-        self._write_request_duration_log(
-            endpoint=self.path,
-            response=response,
-            extra_tags={"url": authenticated_request.path_url}
-            if self._LOG_REQUEST_METRIC_URLS
-            else None,
-        )
+        self._write_request_duration_log(endpoint=self.path, response=response)
         self.validate_response(response)
         return response
 
@@ -682,7 +676,7 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
         endpoint: str,
         response: requests.Response,
         context: Context | None = None,  # noqa: ARG002
-        extra_tags: dict | None = None,
+        extra_tags: dict | None = None,  # noqa: ARG002
     ) -> None:
         """Log the HTTP duration metric.
 
@@ -697,8 +691,6 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
         if not self._LOG_REQUEST_METRICS:
             return
 
-        extra_tags = extra_tags or {}
-
         point = metrics.Point(
             "timer",
             metric=metrics.Metric.HTTP_REQUEST_DURATION,
@@ -712,7 +704,6 @@ class _HTTPStream(Stream, abc.ABC, t.Generic[_TToken]):  # noqa: PLR0904
                     if response.status_code < HTTPStatus.BAD_REQUEST
                     else metrics.Status.FAILED
                 ),
-                **extra_tags,
             },
         )
         self._log_metric(point)

--- a/tests/core/rest/test_request_metrics.py
+++ b/tests/core/rest/test_request_metrics.py
@@ -4,8 +4,6 @@ import logging
 import sys
 import typing as t
 
-import pytest
-
 from singer_sdk import metrics
 from singer_sdk.streams.rest import RESTStream
 
@@ -15,6 +13,7 @@ else:
     from typing_extensions import override
 
 if t.TYPE_CHECKING:
+    import pytest
     import requests_mock
 
     from singer_sdk.streams.rest import HTTPRequest, PageContext
@@ -41,24 +40,19 @@ class _BaseTestStream(RESTStream):
         return request
 
 
-@pytest.mark.parametrize("context", [None, {"partition": "p1"}])
-@pytest.mark.parametrize("log_urls", [True, False])
 def test_metrics_logging(
     requests_mock: requests_mock.Mocker,
     rest_tap: Tap,
     caplog: pytest.LogCaptureFixture,
-    context: dict | None,
-    log_urls: bool,
 ):
     class TestStream(_BaseTestStream):
         _LOG_REQUEST_METRICS = True
-        _LOG_REQUEST_METRIC_URLS = log_urls
 
     stream = TestStream(rest_tap)
     requests_mock.get("https://example.com/test?user_id=1", json=[{"id": 1}])
 
     with caplog.at_level(logging.INFO, logger="singer_sdk.metrics"):
-        records = stream.get_records(context)
+        records = stream.get_records(None)
 
     assert list(records) == [{"id": 1}]
     assert len(caplog.records) == 2
@@ -71,10 +65,7 @@ def test_metrics_logging(
     assert point_1.metric == "http_request_duration"
     assert point_1.tags["endpoint"] == "/test"
     assert "context" not in point_1.tags
-    assert (
-        (log_urls and point_1.tags.get("url") == "/test?user_id=1")  # Log URLs
-        or (not log_urls and "url" not in point_1.tags)  # Don't log URLs
-    )
+    assert "url" not in point_1.tags
 
     assert caplog.records[1].args
     assert isinstance(caplog.records[1].args, tuple)


### PR DESCRIPTION
## Summary by Sourcery

Stop including request URLs in HTTP duration metrics and update tests accordingly.

Bug Fixes:
- Ensure HTTP request duration metrics no longer attempt to log full request URLs, making the URL logging flag effectively unused.

Tests:
- Adjust HTTP metrics logging tests to assert that request URLs are never included in metric tags and simplify parameterization.