### PR TITLE
refactor: Annotate `config` as an immutable mapping in more places

### DIFF
--- a/packages/meltano-tap-sqlite/tap_sqlite/tap.py
+++ b/packages/meltano-tap-sqlite/tap_sqlite/tap.py
@@ -8,6 +8,9 @@ from singer_sdk import typing as th
 from singer_sdk.contrib.msgspec import MsgSpecWriter
 from singer_sdk.sql import SQLConnector, SQLStream, SQLTap
 
+if t.TYPE_CHECKING:
+    from collections.abc import Mapping
+
 DB_PATH_CONFIG = "path_to_db"
 
 
@@ -17,7 +20,7 @@ class SQLiteConnector(SQLConnector):
     This class handles all DDL and type conversions.
     """
 
-    def get_sqlalchemy_url(self, config: dict[str, t.Any]) -> str:  # noqa: PLR6301
+    def get_sqlalchemy_url(self, config: Mapping[str, t.Any]) -> str:  # noqa: PLR6301
         """Generates a SQLAlchemy URL for SQLite."""
         return f"sqlite:///{config[DB_PATH_CONFIG]}"
 

--- a/packages/meltano-target-sqlite/target_sqlite/target.py
+++ b/packages/meltano-target-sqlite/target_sqlite/target.py
@@ -12,6 +12,9 @@ from singer_sdk import typing as th
 from singer_sdk.contrib.msgspec import MsgSpecReader
 from singer_sdk.sql import SQLConnector, SQLSink, SQLTarget
 
+if t.TYPE_CHECKING:
+    from collections.abc import Mapping
+
 DB_PATH_CONFIG = "path_to_db"
 
 
@@ -78,7 +81,7 @@ class SQLiteConnector(SQLConnector):
     allow_merge_upsert = True
     allow_overwrite: bool = True
 
-    def get_sqlalchemy_url(self, config: dict[str, t.Any]) -> str:  # noqa: PLR6301
+    def get_sqlalchemy_url(self, config: Mapping[str, t.Any]) -> str:  # noqa: PLR6301
         """Generates a SQLAlchemy URL for SQLite."""
         return f"sqlite:///{config[DB_PATH_CONFIG]}"
 

--- a/samples/sample_tap_bigquery/tap_bigquery/tap.py
+++ b/samples/sample_tap_bigquery/tap_bigquery/tap.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import typing as t
+
 from singer_sdk import SQLConnector, SQLStream, SQLTap
 from singer_sdk import typing as th  # JSON schema typing helpers
+
+if t.TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 class BigQueryConnector(SQLConnector):
     """Connects to the BigQuery SQL source."""
 
-    def get_sqlalchemy_url(self, config: dict) -> str:  # noqa: PLR6301
+    def get_sqlalchemy_url(self, config: Mapping) -> str:  # noqa: PLR6301
         """Concatenate a SQLAlchemy URL for use in connecting to the source."""
         return f"bigquery://{config['project_id']}"
 

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -442,7 +442,7 @@ class PluginBase(abc.ABC):
         Returns:
             A frozen (read-only) config dictionary map.
         """
-        return t.cast("dict", MappingProxyType(self._config))
+        return MappingProxyType(self._config)
 
     def _validate_config(self, *, raise_errors: bool = True) -> list[str]:
         """Validate configuration input against the plugin configuration JSON schema.

--- a/singer_sdk/sql/connector.py
+++ b/singer_sdk/sql/connector.py
@@ -32,6 +32,8 @@ __all__ = [
 ]
 
 if t.TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from sqlalchemy.engine.interfaces import (
         Dialect,
         ReflectedColumn,
@@ -146,7 +148,7 @@ class SQLToJSONSchema:
         self.use_singer_decimal = use_singer_decimal
 
     @classmethod
-    def from_config(cls: type[SQLToJSONSchema], config: dict) -> SQLToJSONSchema:
+    def from_config(cls: type[SQLToJSONSchema], config: Mapping) -> SQLToJSONSchema:
         """Create a new instance from a configuration dictionary.
 
         Override this to instantiate this converter with values from the tap's
@@ -320,7 +322,7 @@ class JSONSchemaToSQL:
     @classmethod
     def from_config(
         cls: type[JSONSchemaToSQL],
-        config: dict,  # noqa: ARG003
+        config: Mapping,  # noqa: ARG003
         *,
         max_varchar_length: int | None,
     ) -> JSONSchemaToSQL:
@@ -607,7 +609,7 @@ class SQLConnector:  # noqa: PLR0904
 
     def __init__(
         self,
-        config: dict | None = None,
+        config: Mapping[str, t.Any] | None = None,
         sqlalchemy_url: str | None = None,
     ) -> None:
         """Initialize the SQL connector.
@@ -616,12 +618,12 @@ class SQLConnector:  # noqa: PLR0904
             config: The parent tap or target object's config.
             sqlalchemy_url: Optional URL for the connection.
         """
-        self._config: dict[str, t.Any] = config or {}
+        self._config = config or {}
         self._sqlalchemy_url: str | None = sqlalchemy_url or None
         self._tables_prepared: dict[str, bool] = {}
 
     @property
-    def config(self) -> dict:
+    def config(self) -> Mapping[str, t.Any]:
         """If set, provides access to the tap or target config.
 
         Returns:
@@ -742,7 +744,7 @@ class SQLConnector:  # noqa: PLR0904
 
         return self._sqlalchemy_url
 
-    def get_sqlalchemy_url(self, config: dict[str, t.Any]) -> str:  # noqa: PLR6301
+    def get_sqlalchemy_url(self, config: Mapping[str, t.Any]) -> str:  # noqa: PLR6301
         """Return the SQLAlchemy URL string.
 
         Developers can generally override just one of the following:


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Annotate configuration parameters and properties as read-only mappings across SQL connectors and samples to better reflect immutability in type hints.

Enhancements:
- Update SQL connector and schema converter APIs to accept generic Mapping types instead of mutable dict for configuration values.
- Adjust sample BigQuery and SQLite connectors to use Mapping in get_sqlalchemy_url signatures, aligning them with the core connector interface.
- Return a MappingProxyType directly for plugin config to reflect an immutable configuration mapping in type annotations.