### PR TITLE
fix(targets): Reset duplicate-merged tally between batches

### DIFF
--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -719,6 +719,7 @@ class Sink(abc.ABC):  # noqa: PLR0904
                 self._batch_records_read - self._batch_dupe_records_merged,
             )
         self._batch_records_read = 0
+        self._batch_dupe_records_merged = 0
 
     def activate_version(self, new_version: int) -> None:
         """Bump the active version of the target table.

--- a/tests/core/test_target_base.py
+++ b/tests/core/test_target_base.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import copy
+import io
+import json
 
 import pytest
 
@@ -234,3 +236,45 @@ def test_batch_size_rows_and_max_size():
     assert sink_set._batch_size_rows == 100000
     assert sink_set.batch_size_rows == 100000
     assert sink_set.max_size == 100000
+
+
+def _make_singer_input(n_records: int) -> io.StringIO:
+    messages = [
+        {
+            "type": "SCHEMA",
+            "stream": "test",
+            "schema": {"properties": {"id": {"type": "integer"}}},
+            "key_properties": ["id"],
+        },
+        *[
+            {"type": "RECORD", "stream": "test", "record": {"id": i}}
+            for i in range(1, n_records + 1)
+        ],
+    ]
+    return io.StringIO("\n".join(json.dumps(m) for m in messages))
+
+
+@pytest.mark.parametrize(
+    "batch_size_rows, n_records",
+    [
+        (1, 5),
+        (2, 5),
+        (3, 10),
+        (5, 5),
+        (5, 7),
+        (10, 5),
+    ],
+)
+def test_all_records_written_with_batch_size_rows(
+    batch_size_rows: int,
+    n_records: int,
+) -> None:
+    """Regression test: no records are lost when batch_size_rows < total records."""
+    target = TargetMock(config={"batch_size_rows": batch_size_rows})
+    target.listen(_make_singer_input(n_records))
+
+    expected_batches = -(-n_records // batch_size_rows)  # ceiling division
+    assert target.num_records_processed == n_records
+    assert len(target.records_written) == n_records
+    assert target.num_batches_processed == expected_batches
+    assert [r["id"] for r in target.records_written] == list(range(1, n_records + 1))


### PR DESCRIPTION
## Summary

- `Sink.mark_drained()` reset `_batch_records_read` to 0 but never reset `_batch_dupe_records_merged`
- On each subsequent drain, `tally_record_written()` subtracted all accumulated duplicates (not just those from the current batch), making `_total_records_written` increasingly wrong
- Fixed by resetting `_batch_dupe_records_merged = 0` alongside `_batch_records_read = 0` in `mark_drained()`
- Added parametrized regression test that verifies all records are written across multiple drain cycles when `batch_size_rows < total_records`

## Test plan

- [ ] `uv run pytest tests/core/test_target_base.py -v`

## Summary by Sourcery

Reset duplicate-merge batch counters correctly between drain cycles and add regression coverage to ensure all records are written when using row-based batching.

Bug Fixes:
- Reset the per-batch duplicate-merged counter when draining so total records written is tallied correctly across multiple batches.

Tests:
- Add a parametrized regression test to verify no records are lost and batch counts are correct when batch_size_rows is smaller than the total number of records.