### PR TITLE
fix: Ensure stream name is include in log message when ACTIVATE_VERSION forces _sdc metadata columns

### DIFF
--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -443,6 +443,7 @@ class Target(BaseSingerReader, abc.ABC):
                     "`_sdc_deleted_at` metadata properties so they will be added to "
                     "the schema for '%s' even though `add_record_metadata` is "
                     "disabled.",
+                    sink.stream_name,
                 )
             sink.activate_version(message_dict["version"])
 

--- a/tests/packages/snapshots/test_target_csv/test_countries_to_csv_mapped/activate_version/singer.log
+++ b/tests/packages/snapshots/test_target_csv/test_countries_to_csv_mapped/activate_version/singer.log
@@ -5,6 +5,6 @@ INFO mapper-custom Found '__else__=None' default mapper. Unmapped streams will b
 INFO tap-countries.continents Beginning sync of 'continents' in full_table mode
 INFO tap-countries.countries Beginning sync of 'countries' in full_table mode
 INFO mapper-custom Reader 'mapper-custom' completed processing 263 lines of input (2 schemas, 257 records, 0 batch manifests, 2 state messages, 2 activate version messages).
-WARNING target-csv The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for '%s' even though `add_record_metadata` is disabled.
+WARNING target-csv The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for 'continents' even though `add_record_metadata` is disabled.
 WARNING target-csv.continents ACTIVATE_VERSION message received but not implemented by this target. Ignoring.
 INFO target-csv Reader 'target-csv' completed processing 11 lines of input (1 schemas, 7 records, 0 batch manifests, 2 state messages, 1 activate version messages).

--- a/tests/packages/snapshots/test_target_sqlite/test_sqlite_activate_version/singer.log
+++ b/tests/packages/snapshots/test_target_sqlite/test_sqlite_activate_version/singer.log
@@ -1,5 +1,5 @@
 INFO sqlconnector Creating empty table zzz_tmp_test_sqlite_activate_version
-WARNING target-sqlite The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for '%s' even though `add_record_metadata` is disabled.
+WARNING target-sqlite The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for 'zzz_tmp_test_sqlite_activate_version' even though `add_record_metadata` is disabled.
 INFO target-sqlite.zzz_tmp_test_sqlite_activate_version Inserting with SQL: INSERT INTO zzz_tmp_test_sqlite_activate_version (col_a) VALUES (:col_a)
-WARNING target-sqlite The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for '%s' even though `add_record_metadata` is disabled.
+WARNING target-sqlite The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for 'zzz_tmp_test_sqlite_activate_version' even though `add_record_metadata` is disabled.
 INFO target-sqlite.zzz_tmp_test_sqlite_activate_version Inserting with SQL: INSERT INTO zzz_tmp_test_sqlite_activate_version (col_a) VALUES (:col_a)


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Bug Fixes:
- Include the stream name in the log message emitted when ACTIVATE_VERSION forces _sdc metadata columns to be added.