### PR TITLE
chore: Merge branch 'v0.54' into main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Singer SDK Version
       description: Version of the library you are using
-      placeholder: "0.54.2"
+      placeholder: "0.54.3"
     validations:
       required: true
   - type: checkboxes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.54.3 (2026-05-27)
+
+### 🐛 Fixes
+
+- [#3650](https://github.com/meltano/sdk/issues/3650) Ensure stream name is include in log message when ACTIVATE_VERSION forces \_sdc metadata columns
+
 ## v0.54.2 (2026-05-18)
 
 ### 🐛 Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixes
 
-- [#3650](https://github.com/meltano/sdk/issues/3650) Ensure stream name is include in log message when ACTIVATE_VERSION forces \_sdc metadata columns
+- [#3650](https://github.com/meltano/sdk/issues/3650) Ensure stream name is included in log message when ACTIVATE_VERSION forces \_sdc metadata columns.
 
 ## v0.54.2 (2026-05-18)
 

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -36,9 +36,9 @@ license-files = [ "LICENSE" ]
 requires-python = ">=3.10"
 dependencies = [
     {%- if cookiecutter.faker_extra %}
-    "singer-sdk[faker]~=0.54.2",
+    "singer-sdk[faker]~=0.54.3",
     {%- else %}
-    "singer-sdk~=0.54.2",
+    "singer-sdk~=0.54.3",
     {%- endif %}
     "typing-extensions>=4.5.0; python_version < '3.13'",
 ]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -39,9 +39,9 @@ license-files = [ "LICENSE" ]
 requires-python = ">=3.10"
 dependencies = [
     {%- if extras %}
-    "singer-sdk[{{ extras|join(',') }}]~=0.54.2",
+    "singer-sdk[{{ extras|join(',') }}]~=0.54.3",
     {%- else %}
-    "singer-sdk~=0.54.2",
+    "singer-sdk~=0.54.3",
     {%- endif %}
     {%- if cookiecutter.stream_type in ["REST", "GraphQL"] %}
     "requests~=2.34.0",

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -35,9 +35,9 @@ license-files = [ "LICENSE" ]
 requires-python = ">=3.10"
 dependencies = [
     {%- if cookiecutter.faker_extra %}
-    "singer-sdk[faker]~=0.54.2",
+    "singer-sdk[faker]~=0.54.3",
     {%- else %}
-    "singer-sdk~=0.54.2",
+    "singer-sdk~=0.54.3",
     {%- endif %}
     {%- if cookiecutter.serialization_method == "SQL" %}
     "sqlalchemy~=2.0",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ copyright = f"{datetime.now().year}, Arch Data, Inc and Contributors"  # noqa: A
 author = "Meltano Core Team and Contributors"
 
 # The full version, including alpha/beta/rc tags
-release = "0.54.2"
+release = "0.54.3"
 
 
 # -- General configuration -------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,7 @@ testpaths = ["tests"]
 
 [tool.commitizen]
 name = "cz_version_bump"
-version = "0.54.2"
+version = "0.54.3"
 changelog_merge_prerelease = true
 prerelease_offset = 1
 tag_format = "v$major.$minor.$patch$prerelease"

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -443,6 +443,7 @@ class Target(BaseSingerReader, abc.ABC):
                     "`_sdc_deleted_at` metadata properties so they will be added to "
                     "the schema for '%s' even though `add_record_metadata` is "
                     "disabled.",
+                    sink.stream_name,
                 )
             sink.activate_version(message_dict["version"])
 

--- a/tests/packages/snapshots/test_target_csv/test_countries_to_csv_mapped/activate_version/singer.log
+++ b/tests/packages/snapshots/test_target_csv/test_countries_to_csv_mapped/activate_version/singer.log
@@ -5,6 +5,6 @@ INFO mapper-custom Found '__else__=None' default mapper. Unmapped streams will b
 INFO tap-countries.continents Beginning sync of 'continents' in full_table mode
 INFO tap-countries.countries Beginning sync of 'countries' in full_table mode
 INFO mapper-custom Reader 'mapper-custom' completed processing 263 lines of input (2 schemas, 257 records, 0 batch manifests, 2 state messages, 2 activate version messages).
-WARNING target-csv The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for '%s' even though `add_record_metadata` is disabled.
+WARNING target-csv The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for 'continents' even though `add_record_metadata` is disabled.
 WARNING target-csv.continents ACTIVATE_VERSION message received but not implemented by this target. Ignoring.
 INFO target-csv Reader 'target-csv' completed processing 11 lines of input (1 schemas, 7 records, 0 batch manifests, 2 state messages, 1 activate version messages).

--- a/tests/packages/snapshots/test_target_sqlite/test_sqlite_activate_version/singer.log
+++ b/tests/packages/snapshots/test_target_sqlite/test_sqlite_activate_version/singer.log
@@ -1,5 +1,5 @@
 INFO sqlconnector Creating empty table zzz_tmp_test_sqlite_activate_version
-WARNING target-sqlite The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for '%s' even though `add_record_metadata` is disabled.
+WARNING target-sqlite The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for 'zzz_tmp_test_sqlite_activate_version' even though `add_record_metadata` is disabled.
 INFO target-sqlite.zzz_tmp_test_sqlite_activate_version Inserting with SQL: INSERT INTO zzz_tmp_test_sqlite_activate_version (col_a) VALUES (:col_a)
-WARNING target-sqlite The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for '%s' even though `add_record_metadata` is disabled.
+WARNING target-sqlite The `ACTIVATE_VERSION` feature uses the `_sdc_deleted_at` and `_sdc_deleted_at` metadata properties so they will be added to the schema for 'zzz_tmp_test_sqlite_activate_version' even though `add_record_metadata` is disabled.
 INFO target-sqlite.zzz_tmp_test_sqlite_activate_version Inserting with SQL: INSERT INTO zzz_tmp_test_sqlite_activate_version (col_a) VALUES (:col_a)


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Release version 0.54.3 and update templates and metadata to reference the new version.

Bug Fixes:
- Ensure stream name is included in log messages when ACTIVATE_VERSION forces _sdc metadata columns.

Build:
- Bump project version to 0.54.3 in pyproject configuration and documentation tooling.

Documentation:
- Update changelog, documentation config, and GitHub bug report template to reference version 0.54.3.

Tests:
- Refresh snapshot logs for ACTIVATE_VERSION behavior in target CSV and SQLite test fixtures.

Chores:
- Update cookiecutter tap/target/mapper templates to depend on singer-sdk 0.54.3.