### PR TITLE
feat: Expose `emit_activate_version_messages` as a built-in tap setting

### DIFF
--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -23,6 +23,7 @@ from singer_sdk.helpers._state import StateWriter, write_stream_state
 from singer_sdk.helpers._util import dump_json, load_json, read_json_file
 from singer_sdk.helpers.capabilities import (
     BATCH_CONFIG,
+    EMIT_ACTIVATE_VERSION_CONFIG,
     PluginCapabilities,
     TapCapabilities,
 )
@@ -70,8 +71,8 @@ class Tap(BaseSingerWriter, abc.ABC):  # noqa: PLR0904
         TapCapabilities.CATALOG,
         TapCapabilities.STATE,
         TapCapabilities.DISCOVER,
-        TapCapabilities.ACTIVATE_VERSION,
         PluginCapabilities.ABOUT,
+        PluginCapabilities.ACTIVATE_VERSION,
         PluginCapabilities.STREAM_MAPS,
         PluginCapabilities.FLATTENING,
         PluginCapabilities.BATCH,
@@ -242,6 +243,12 @@ class Tap(BaseSingerWriter, abc.ABC):  # noqa: PLR0904
         PluginBase.append_builtin_config(config_jsonschema)
 
         capabilities = cls.capabilities
+        if PluginCapabilities.ACTIVATE_VERSION in capabilities:
+            merge_missing_config_jsonschema(
+                EMIT_ACTIVATE_VERSION_CONFIG,
+                config_jsonschema,
+            )
+
         if PluginCapabilities.BATCH in capabilities:
             merge_missing_config_jsonschema(BATCH_CONFIG, config_jsonschema)
 

--- a/tests/core/test_jsonschema_helpers.py
+++ b/tests/core/test_jsonschema_helpers.py
@@ -226,6 +226,7 @@ def test_tap_config_default_injection():
         "username": "foo",
         "password": "bar",
         "batch_size": -1,
+        "emit_activate_version_messages": False,
     }
 
     assert dict(tap.config) == expected_tap_config


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Expose the `emit_activate_version_messages` option as a built-in tap configuration setting when activate-version support is enabled.

New Features:
- Add `emit_activate_version_messages` as a built-in tap config option gated by the activate-version plugin capability.

Tests:
- Extend tap config default injection test to cover the new `emit_activate_version_messages` setting.