### PR TITLE
fix: Ensure filesystem write transaction in closed in file-based taps

### DIFF
--- a/singer_sdk/helpers/_batch.py
+++ b/singer_sdk/helpers/_batch.py
@@ -180,8 +180,10 @@ class StorageTarget:
         fs = self._root_path.fs
         fs.start_transaction()
         self._root_path.mkdir(parents=True, exist_ok=True)
-        yield fs
-        fs.end_transaction()
+        try:
+            yield fs
+        finally:
+            fs.end_transaction()
 
     @contextmanager
     def open(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Guarantee that filesystem transactions are ended even if an error occurs while operating on the filesystem.