### PR TITLE
feat: allow disabling SQL view discovery

### DIFF
--- a/singer_sdk/helpers/capabilities.py
+++ b/singer_sdk/helpers/capabilities.py
@@ -32,6 +32,9 @@ else:
 
 # Default JSON Schema to support config for built-in capabilities:
 
+SQL_TAP_DISCOVER_VIEWS_DEFAULT = True
+SQL_TAP_DISCOVER_MATERIALIZED_VIEWS_DEFAULT = True
+
 STREAM_MAPS_CONFIG = PropertiesList(
     Property(
         "stream_maps",
@@ -239,6 +242,24 @@ SQL_TAP_USE_SINGER_DECIMAL = PropertiesList(
             "Whether to use use strings with `x-singer.decimal` format for "
             "decimals in the discovered schema. "
             "This is useful to avoid precision loss when working with large numbers."
+        ),
+    ),
+).to_dict()
+SQL_TAP_DISCOVERY_CONFIG = PropertiesList(
+    Property(
+        "discover_views",
+        BooleanType,
+        default=SQL_TAP_DISCOVER_VIEWS_DEFAULT,
+        title="Discover Views",
+        description="Whether to include database views during SQL tap discovery.",
+    ),
+    Property(
+        "discover_materialized_views",
+        BooleanType,
+        default=SQL_TAP_DISCOVER_MATERIALIZED_VIEWS_DEFAULT,
+        title="Discover Materialized Views",
+        description=(
+            "Whether to include database materialized views during SQL tap discovery."
         ),
     ),
 ).to_dict()

--- a/singer_sdk/sql/connector.py
+++ b/singer_sdk/sql/connector.py
@@ -1102,12 +1102,17 @@ class SQLConnector:  # noqa: PLR0904
         self,
         *,
         exclude_schemas: t.Sequence[str] = (),
+        discover_views: bool = True,
+        discover_materialized_views: bool = True,
         reflect_indices: bool = True,
     ) -> list[dict]:
         """Return a list of catalog entries from discovery.
 
         Args:
             exclude_schemas: A list of schema names to exclude from discovery.
+            discover_views: Whether to include database views in discovery.
+            discover_materialized_views: Whether to include database materialized views
+                in discovery.
             reflect_indices: Whether to reflect indices to detect potential primary
                 keys.
 
@@ -1117,10 +1122,12 @@ class SQLConnector:  # noqa: PLR0904
         result: list[dict] = []
         engine = self._engine
         inspected = sa.inspect(engine)
-        object_kinds = (
-            (reflection.ObjectKind.TABLE, False),
-            (reflection.ObjectKind.ANY_VIEW, True),
-        )
+        object_kinds = [(reflection.ObjectKind.TABLE, False)]
+        if discover_views:
+            object_kinds.append((reflection.ObjectKind.VIEW, True))
+        if discover_materialized_views:
+            object_kinds.append((reflection.ObjectKind.MATERIALIZED_VIEW, True))
+
         for schema_name in self.get_schema_names(engine, inspected):
             if schema_name in exclude_schemas:
                 continue

--- a/singer_sdk/sql/tap.py
+++ b/singer_sdk/sql/tap.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import inspect
 import sys
 import typing as t
 
 from singer_sdk.configuration._dict_config import merge_missing_config_jsonschema
-from singer_sdk.helpers.capabilities import SQL_TAP_USE_SINGER_DECIMAL
+from singer_sdk.helpers.capabilities import (
+    SQL_TAP_DISCOVER_MATERIALIZED_VIEWS_DEFAULT,
+    SQL_TAP_DISCOVER_VIEWS_DEFAULT,
+    SQL_TAP_DISCOVERY_CONFIG,
+    SQL_TAP_USE_SINGER_DECIMAL,
+)
 from singer_sdk.tap_base import Tap
 
 if sys.version_info >= (3, 12):
@@ -20,6 +26,29 @@ if t.TYPE_CHECKING:
     from singer_sdk.streams.core import Stream
 
 __all__ = ["SQLTap"]
+
+
+def _filter_discovery_kwargs(
+    connector: SQLConnector,
+    discovery_kwargs: dict[str, t.Any],
+) -> dict[str, t.Any]:
+    """Filter discovery kwargs for custom connector method compatibility.
+
+    Returns:
+        Discovery kwargs accepted by the connector method signature.
+    """
+    signature = inspect.signature(connector.discover_catalog_entries)
+    if any(
+        param.kind is inspect.Parameter.VAR_KEYWORD
+        for param in signature.parameters.values()
+    ):
+        return discovery_kwargs
+
+    return {
+        name: value
+        for name, value in discovery_kwargs.items()
+        if name in signature.parameters
+    }
 
 
 class SQLTap(Tap):
@@ -63,6 +92,7 @@ class SQLTap(Tap):
         Args:
             config_jsonschema: [description]
         """
+        merge_missing_config_jsonschema(SQL_TAP_DISCOVERY_CONFIG, config_jsonschema)
         merge_missing_config_jsonschema(SQL_TAP_USE_SINGER_DECIMAL, config_jsonschema)
         super().append_builtin_config(config_jsonschema)
 
@@ -95,9 +125,20 @@ class SQLTap(Tap):
 
         connector = self.tap_connector
 
+        discovery_kwargs = {
+            "exclude_schemas": self.exclude_schemas,
+            "discover_views": self.config.get(
+                "discover_views",
+                SQL_TAP_DISCOVER_VIEWS_DEFAULT,
+            ),
+            "discover_materialized_views": self.config.get(
+                "discover_materialized_views",
+                SQL_TAP_DISCOVER_MATERIALIZED_VIEWS_DEFAULT,
+            ),
+        }
         self._catalog_dict = {
             "streams": connector.discover_catalog_entries(
-                exclude_schemas=self.exclude_schemas
+                **_filter_discovery_kwargs(connector, discovery_kwargs),
             )
         }
         return self._catalog_dict

--- a/tests/sql/test_connector.py
+++ b/tests/sql/test_connector.py
@@ -12,10 +12,11 @@ import sqlalchemy.exc
 import sqlalchemy.schema
 import sqlalchemy.types
 from sqlalchemy.dialects import registry, sqlite
+from sqlalchemy.engine import reflection
 from sqlalchemy.engine.default import DefaultDialect
 
 from singer_sdk.exceptions import ConfigValidationError
-from singer_sdk.sql import SQLConnector
+from singer_sdk.sql import SQLConnector, SQLStream, SQLTap
 from singer_sdk.sql.connector import (
     FullyQualifiedName,
     JSONSchemaToSQL,
@@ -62,6 +63,56 @@ class DummySQLConnector(SQLConnector):
                 "column_type": column_type,
             },
         )
+
+
+class SpySQLConnector(SQLConnector):
+    """SQL connector that captures discovery options."""
+
+    discovery_kwargs: t.ClassVar[dict[str, t.Any]] = {}
+
+    def discover_catalog_entries(self, **kwargs: t.Any) -> list[dict]:
+        """Capture discovery kwargs and return an empty catalog."""
+        self.__class__.discovery_kwargs = kwargs
+        return []
+
+
+class LegacyDiscoverySQLConnector(SQLConnector):
+    """SQL connector with a legacy discovery signature."""
+
+    exclude_schemas: t.ClassVar[t.Sequence[str] | None] = None
+
+    def discover_catalog_entries(
+        self,
+        *,
+        exclude_schemas: t.Sequence[str] = (),
+    ) -> list[dict]:
+        self.__class__.exclude_schemas = exclude_schemas
+        return []
+
+
+class SpySQLStream(SQLStream):
+    connector_class = SpySQLConnector
+
+
+class LegacyDiscoverySQLStream(SQLStream):
+    connector_class = LegacyDiscoverySQLConnector
+
+
+class SpySQLTap(SQLTap):
+    name = "spy-sql-tap"
+    default_stream_class = SpySQLStream
+
+
+class LegacyDiscoverySQLTap(SQLTap):
+    name = "legacy-discovery-sql-tap"
+    exclude_schemas: t.ClassVar[list[str]] = ["ignored_schema"]
+    default_stream_class = LegacyDiscoverySQLStream
+
+
+@pytest.fixture(autouse=True)
+def reset_sql_discovery_spies() -> None:
+    SpySQLConnector.discovery_kwargs = {}
+    LegacyDiscoverySQLConnector.exclude_schemas = None
 
 
 class TestConnectorSQL:  # noqa: PLR0904
@@ -607,6 +658,92 @@ class TestDummySQLConnector:
             reflect_indices=False,
         )
         assert len(entries) == expected_streams
+
+    def test_discover_catalog_entries_can_exclude_views(
+        self,
+        connector: DummySQLConnector,
+    ):
+        with connector._engine.connect() as conn, conn.begin():
+            conn.execute(
+                sqlalchemy.text(
+                    "CREATE TABLE test_table (id INTEGER PRIMARY KEY, name STRING)",
+                )
+            )
+            conn.execute(
+                sqlalchemy.text(
+                    "CREATE VIEW test_view AS SELECT id, name FROM test_table",
+                )
+            )
+
+        entries = connector.discover_catalog_entries(
+            discover_views=False,
+            reflect_indices=False,
+        )
+
+        assert {entry["table_name"] for entry in entries} == {"test_table"}
+
+    def test_discover_catalog_entries_can_filter_materialized_views(
+        self,
+        connector: DummySQLConnector,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        inspected = mock.Mock()
+        inspected.get_multi_pk_constraint.return_value = {}
+        inspected.get_multi_indexes.return_value = {}
+        inspected.get_multi_columns.return_value = {}
+        monkeypatch.setattr(sqlalchemy, "inspect", lambda _engine: inspected)
+        monkeypatch.setattr(
+            connector,
+            "get_schema_names",
+            lambda *_args: ["main"],
+        )
+
+        connector.discover_catalog_entries(
+            discover_views=False,
+            discover_materialized_views=True,
+            reflect_indices=False,
+        )
+
+        inspected.get_multi_columns.assert_has_calls(
+            [
+                mock.call(schema="main", kind=reflection.ObjectKind.TABLE),
+                mock.call(
+                    schema="main",
+                    kind=reflection.ObjectKind.MATERIALIZED_VIEW,
+                ),
+            ],
+        )
+        assert inspected.get_multi_columns.call_count == 2
+
+
+def test_sql_tap_passes_discovery_settings_from_config():
+    tap = SpySQLTap(
+        config={
+            "sqlalchemy_url": "sqlite:///",
+            "discover_views": False,
+            "discover_materialized_views": True,
+        },
+    )
+
+    assert tap.catalog_dict == {"streams": []}
+    assert SpySQLConnector.discovery_kwargs == {
+        "exclude_schemas": [],
+        "discover_views": False,
+        "discover_materialized_views": True,
+    }
+
+
+def test_sql_tap_supports_legacy_discovery_connector_signature():
+    tap = LegacyDiscoverySQLTap(
+        config={
+            "sqlalchemy_url": "sqlite:///",
+            "discover_views": False,
+            "discover_materialized_views": False,
+        },
+    )
+
+    assert tap.catalog_dict == {"streams": []}
+    assert LegacyDiscoverySQLConnector.exclude_schemas == ["ignored_schema"]
 
 
 def test_adapter_without_json_serde():


### PR DESCRIPTION
Fixes #2806.

## Summary

- Add built-in SQL tap settings for `discover_views` and `discover_materialized_views`.
- Pass those settings from `SQLTap` into catalog discovery.
- Let `SQLConnector.discover_catalog_entries()` reflect tables, views, and materialized views according to those flags while preserving the existing default behavior.
- Add connector and tap-level regression coverage.

## Validation

- `uv run pytest tests/sql/test_connector.py::TestDummySQLConnector::test_discover_catalog_entries_can_exclude_views tests/sql/test_connector.py::TestDummySQLConnector::test_discover_catalog_entries_can_filter_materialized_views tests/sql/test_connector.py::test_sql_tap_passes_discovery_settings_from_config -q`
- `uv run pytest tests/sql/test_connector.py -q`
- `uv run pytest tests/sql -q`
- `pre-commit run --files singer_sdk/helpers/capabilities.py singer_sdk/sql/connector.py singer_sdk/sql/tap.py tests/sql/test_connector.py`
- `NOX_DEFAULT_VENV_BACKEND=uv nox -rs tests-3.11 -- tests/sql`
- `uv run pytest tests/packages/test_tap_sqlite.py -m packages -q`

## Summary by Sourcery

Allow SQL taps and connectors to control whether views and materialized views are included during catalog discovery while preserving existing default behavior.

New Features:
- Add SQL tap configuration options to toggle discovery of views and materialized views.
- Expose discovery flags on SQLConnector.discover_catalog_entries to control reflection of tables, views, and materialized views.

Tests:
- Add regression tests for SQLConnector discovery filtering of views and materialized views and for passing tap-level discovery settings into the connector.