### PR TITLE
feat: support filtering SQL tap schemas

### DIFF
--- a/singer_sdk/helpers/capabilities.py
+++ b/singer_sdk/helpers/capabilities.py
@@ -242,6 +242,17 @@ SQL_TAP_USE_SINGER_DECIMAL = PropertiesList(
         ),
     ),
 ).to_dict()
+SQL_TAP_FILTER_SCHEMAS = PropertiesList(
+    Property(
+        "filter_schemas",
+        ArrayType(StringType),
+        title="Filter Schemas",
+        description=(
+            "Optional list of database schemas to include during SQL tap discovery. "
+            "If unset or empty, all available schemas are discovered."
+        ),
+    ),
+).to_dict()
 TARGET_SCHEMA_CONFIG = PropertiesList(
     Property(
         "default_target_schema",

--- a/singer_sdk/sql/connector.py
+++ b/singer_sdk/sql/connector.py
@@ -1102,12 +1102,15 @@ class SQLConnector:  # noqa: PLR0904
         self,
         *,
         exclude_schemas: t.Sequence[str] = (),
+        filter_schemas: t.Sequence[str] = (),
         reflect_indices: bool = True,
     ) -> list[dict]:
         """Return a list of catalog entries from discovery.
 
         Args:
             exclude_schemas: A list of schema names to exclude from discovery.
+            filter_schemas: A list of schema names to include in discovery. If empty,
+                all available schemas are discovered.
             reflect_indices: Whether to reflect indices to detect potential primary
                 keys.
 
@@ -1121,7 +1124,10 @@ class SQLConnector:  # noqa: PLR0904
             (reflection.ObjectKind.TABLE, False),
             (reflection.ObjectKind.ANY_VIEW, True),
         )
+        included_schemas = set(filter_schemas)
         for schema_name in self.get_schema_names(engine, inspected):
+            if included_schemas and schema_name not in included_schemas:
+                continue
             if schema_name in exclude_schemas:
                 continue
 

--- a/singer_sdk/sql/tap.py
+++ b/singer_sdk/sql/tap.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import inspect
 import sys
 import typing as t
 
 from singer_sdk.configuration._dict_config import merge_missing_config_jsonschema
-from singer_sdk.helpers.capabilities import SQL_TAP_USE_SINGER_DECIMAL
+from singer_sdk.helpers.capabilities import (
+    SQL_TAP_FILTER_SCHEMAS,
+    SQL_TAP_USE_SINGER_DECIMAL,
+)
 from singer_sdk.tap_base import Tap
 
 if sys.version_info >= (3, 12):
@@ -20,6 +24,51 @@ if t.TYPE_CHECKING:
     from singer_sdk.streams.core import Stream
 
 __all__ = ["SQLTap"]
+
+_DISCOVERY_KWARGS_CACHE: dict[type[SQLConnector], frozenset[str] | None] = {}
+
+
+def _accepted_discovery_kwargs(
+    connector_type: type[SQLConnector],
+) -> frozenset[str] | None:
+    """Return discovery kwargs accepted by the connector type.
+
+    Returns:
+        Accepted keyword names, or ``None`` if all kwargs are accepted.
+    """
+    if connector_type in _DISCOVERY_KWARGS_CACHE:
+        return _DISCOVERY_KWARGS_CACHE[connector_type]
+
+    signature = inspect.signature(connector_type.discover_catalog_entries)
+    if any(
+        param.kind is inspect.Parameter.VAR_KEYWORD
+        for param in signature.parameters.values()
+    ):
+        _DISCOVERY_KWARGS_CACHE[connector_type] = None
+        return _DISCOVERY_KWARGS_CACHE[connector_type]
+
+    _DISCOVERY_KWARGS_CACHE[connector_type] = frozenset(signature.parameters)
+    return _DISCOVERY_KWARGS_CACHE[connector_type]
+
+
+def _filter_discovery_kwargs(
+    connector: SQLConnector,
+    discovery_kwargs: dict[str, t.Any],
+) -> dict[str, t.Any]:
+    """Filter discovery kwargs for custom connector method compatibility.
+
+    Returns:
+        Discovery kwargs accepted by the connector method signature.
+    """
+    accepted_kwargs = _accepted_discovery_kwargs(type(connector))
+    if accepted_kwargs is None:
+        return discovery_kwargs
+
+    return {
+        name: value
+        for name, value in discovery_kwargs.items()
+        if name in accepted_kwargs
+    }
 
 
 class SQLTap(Tap):
@@ -63,6 +112,7 @@ class SQLTap(Tap):
         Args:
             config_jsonschema: [description]
         """
+        merge_missing_config_jsonschema(SQL_TAP_FILTER_SCHEMAS, config_jsonschema)
         merge_missing_config_jsonschema(SQL_TAP_USE_SINGER_DECIMAL, config_jsonschema)
         super().append_builtin_config(config_jsonschema)
 
@@ -95,9 +145,13 @@ class SQLTap(Tap):
 
         connector = self.tap_connector
 
+        discovery_kwargs = {
+            "exclude_schemas": self.exclude_schemas,
+            "filter_schemas": self.config.get("filter_schemas") or [],
+        }
         self._catalog_dict = {
             "streams": connector.discover_catalog_entries(
-                exclude_schemas=self.exclude_schemas
+                **_filter_discovery_kwargs(connector, discovery_kwargs)
             )
         }
         return self._catalog_dict

--- a/tests/sql/test_connector.py
+++ b/tests/sql/test_connector.py
@@ -21,6 +21,8 @@ from singer_sdk.sql.connector import (
     JSONSchemaToSQL,
     SQLToJSONSchema,
 )
+from singer_sdk.sql.stream import SQLStream
+from singer_sdk.sql.tap import SQLTap
 
 if sys.version_info >= (3, 12):
     from typing import override  # noqa: ICN003
@@ -62,6 +64,71 @@ class DummySQLConnector(SQLConnector):
                 "column_type": column_type,
             },
         )
+
+
+class DummySQLStream(SQLStream):
+    """Dummy SQL stream."""
+
+    connector_class = DummySQLConnector
+
+
+class DummySQLTap(SQLTap):
+    """Dummy SQL tap."""
+
+    name = "dummy-sql-tap"
+    default_stream_class = DummySQLStream
+
+
+class LegacyDiscoverySQLConnector(DummySQLConnector):
+    """Dummy SQL connector with an older discovery signature."""
+
+    filter_schemas: t.ClassVar[t.Sequence[str] | None] = None
+
+    def discover_catalog_entries(
+        self,
+        *,
+        exclude_schemas: t.Sequence[str] = (),
+        reflect_indices: bool = True,
+    ) -> list[dict]:
+        self.__class__.filter_schemas = self.config.get("filter_schemas")
+        return super().discover_catalog_entries(
+            exclude_schemas=exclude_schemas,
+            reflect_indices=reflect_indices,
+        )
+
+
+class LegacyDiscoverySQLStream(DummySQLStream):
+    """Dummy SQL stream with a legacy connector."""
+
+    connector_class = LegacyDiscoverySQLConnector
+
+
+class LegacyDiscoverySQLTap(DummySQLTap):
+    """Dummy SQL tap with a legacy connector."""
+
+    default_stream_class = LegacyDiscoverySQLStream
+
+
+class VarKwargsDiscoverySQLConnector(DummySQLConnector):
+    """Dummy SQL connector accepting arbitrary discovery kwargs."""
+
+    discovery_kwargs: t.ClassVar[dict[str, t.Any] | None] = None
+
+    def discover_catalog_entries(self, **kwargs: t.Any) -> list[dict]:
+        self.__class__.discovery_kwargs = kwargs
+        return super().discover_catalog_entries(**kwargs)
+
+
+class VarKwargsDiscoverySQLStream(DummySQLStream):
+    """Dummy SQL stream with a kwargs discovery connector."""
+
+    connector_class = VarKwargsDiscoverySQLConnector
+
+
+class VarKwargsDiscoverySQLTap(DummySQLTap):
+    """Dummy SQL tap with a kwargs discovery connector."""
+
+    default_stream_class = VarKwargsDiscoverySQLStream
 
 
 class TestConnectorSQL:  # noqa: PLR0904
@@ -607,6 +674,137 @@ class TestDummySQLConnector:
             reflect_indices=False,
         )
         assert len(entries) == expected_streams
+
+    @pytest.mark.parametrize(
+        "filter_schemas,expected_streams",
+        [
+            ([], 1),
+            (["main"], 1),
+            (["other"], 0),
+        ],
+    )
+    def test_discover_catalog_entries_filter_schemas(
+        self,
+        connector: DummySQLConnector,
+        filter_schemas: list[str],
+        expected_streams: int,
+    ):
+        with connector._engine.connect() as conn, conn.begin():
+            conn.execute(
+                sqlalchemy.text(
+                    "CREATE TABLE test_table (id INTEGER PRIMARY KEY, name STRING)",
+                )
+            )
+
+        entries = connector.discover_catalog_entries(
+            filter_schemas=filter_schemas,
+            reflect_indices=False,
+        )
+
+        assert len(entries) == expected_streams
+
+    def test_sql_tap_passes_configured_filter_schemas(self, tmp_path: Path):
+        db_path = tmp_path / "test.sqlite"
+        sqlalchemy_url = f"sqlite:///{db_path}"
+
+        engine = sqlalchemy.create_engine(sqlalchemy_url)
+        with engine.connect() as conn, conn.begin():
+            conn.execute(
+                sqlalchemy.text(
+                    "CREATE TABLE test_table (id INTEGER PRIMARY KEY, name STRING)",
+                )
+            )
+
+        tap = DummySQLTap(
+            config={
+                "sqlalchemy_url": sqlalchemy_url,
+                "filter_schemas": ["main"],
+            },
+        )
+
+        assert [stream["stream"] for stream in tap.catalog_dict["streams"]] == [
+            "main-test_table"
+        ]
+
+    def test_sql_tap_supports_legacy_connector_discovery_signature(
+        self,
+        tmp_path: Path,
+    ):
+        db_path = tmp_path / "test.sqlite"
+        sqlalchemy_url = f"sqlite:///{db_path}"
+
+        engine = sqlalchemy.create_engine(sqlalchemy_url)
+        with engine.connect() as conn, conn.begin():
+            conn.execute(
+                sqlalchemy.text(
+                    "CREATE TABLE test_table (id INTEGER PRIMARY KEY, name STRING)",
+                )
+            )
+
+        tap = LegacyDiscoverySQLTap(
+            config={
+                "sqlalchemy_url": sqlalchemy_url,
+                "filter_schemas": ["main"],
+            },
+        )
+
+        assert [stream["stream"] for stream in tap.catalog_dict["streams"]] == [
+            "main-test_table"
+        ]
+        assert LegacyDiscoverySQLConnector.filter_schemas == ["main"]
+
+    def test_sql_tap_treats_null_filter_schemas_as_unset(self, tmp_path: Path):
+        db_path = tmp_path / "test.sqlite"
+        sqlalchemy_url = f"sqlite:///{db_path}"
+
+        engine = sqlalchemy.create_engine(sqlalchemy_url)
+        with engine.connect() as conn, conn.begin():
+            conn.execute(
+                sqlalchemy.text(
+                    "CREATE TABLE test_table (id INTEGER PRIMARY KEY, name STRING)",
+                )
+            )
+
+        tap = DummySQLTap(
+            config={
+                "sqlalchemy_url": sqlalchemy_url,
+                "filter_schemas": None,
+            },
+        )
+
+        assert [stream["stream"] for stream in tap.catalog_dict["streams"]] == [
+            "main-test_table"
+        ]
+
+    def test_sql_tap_passes_filter_schemas_to_kwargs_connector(
+        self,
+        tmp_path: Path,
+    ):
+        db_path = tmp_path / "test.sqlite"
+        sqlalchemy_url = f"sqlite:///{db_path}"
+
+        engine = sqlalchemy.create_engine(sqlalchemy_url)
+        with engine.connect() as conn, conn.begin():
+            conn.execute(
+                sqlalchemy.text(
+                    "CREATE TABLE test_table (id INTEGER PRIMARY KEY, name STRING)",
+                )
+            )
+
+        tap = VarKwargsDiscoverySQLTap(
+            config={
+                "sqlalchemy_url": sqlalchemy_url,
+                "filter_schemas": ["main"],
+            },
+        )
+
+        assert [stream["stream"] for stream in tap.catalog_dict["streams"]] == [
+            "main-test_table"
+        ]
+        assert VarKwargsDiscoverySQLConnector.discovery_kwargs == {
+            "exclude_schemas": [],
+            "filter_schemas": ["main"],
+        }
 
 
 def test_adapter_without_json_serde():


### PR DESCRIPTION
## Summary
- add a `filter_schemas` SQL tap config option for limiting schema discovery
- pass configured schema filters into SQL connector discovery
- preserve compatibility with custom connectors that override `discover_catalog_entries` without the new keyword

Closes #1930.

## Testing
- `uv run pytest tests/sql/test_connector.py -k "filter_schemas" -q`
- `uv run pytest tests/sql/test_connector.py -q`
- `uv run pytest tests/sql -q`
- `uv run pytest tests/packages/test_tap_sqlite.py -m packages -q`
- `pre-commit run --files singer_sdk/helpers/capabilities.py singer_sdk/sql/connector.py singer_sdk/sql/tap.py tests/sql/test_connector.py`

## Summary by Sourcery

Add configurable schema filtering to SQL taps while preserving compatibility with existing connectors' discovery signatures.

New Features:
- Introduce a SQL tap configuration option to filter discovered schemas via the filter_schemas setting.

Enhancements:
- Pass configured schema filters from SQLTap into SQLConnector discovery and apply them when enumerating schemas.
- Extend SQL tap configuration schema to document and validate the new filter_schemas option.
- Ensure SQL tap discovery gracefully handles custom connectors that use a legacy discover_catalog_entries signature without filter_schemas.

Tests:
- Add SQL connector and SQL tap tests covering schema filtering behavior and compatibility with legacy connector discovery implementations.