### PR TITLE
chore(deps): Bump pytest to 9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,8 @@ filterwarnings = [
     'ignore:The function singer_sdk.testing.get_standard_tap_tests is deprecated:DeprecationWarning',
     # TODO: Address this SQLite warning in Python 3.13+
     'ignore::ResourceWarning',
+    # pytest warnings
+    'once:Class-scoped fixture defined as instance method is deprecated:pytest.PytestRemovedIn10Warning',
     # Our own warnings
     'once::singer_sdk.helpers._compat.SingerSDKDeprecationWarning',
     'once::singer_sdk.helpers._compat.SingerSDKPythonEOLWarning',

--- a/uv.lock
+++ b/uv.lock
@@ -2356,7 +2356,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2367,9 +2367,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
SSIA, https://github.com/pytest-dev/pytest/releases/tag/9.1.0

## Summary by Sourcery

Tests:
- Add filter for pytest class-scoped fixture deprecation warning to test configuration.