### PR TITLE
fix: Convert class-scoped fixtures in built-in integration tests into `@classmethod`s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ parquet = [
 ]
 
 testing = [
-    "pytest>=9",
+    "pytest>=9.1",
 ]
 
 faker = [
@@ -199,8 +199,6 @@ filterwarnings = [
     'ignore:The function singer_sdk.testing.get_standard_tap_tests is deprecated:DeprecationWarning',
     # TODO: Address this SQLite warning in Python 3.13+
     'ignore::ResourceWarning',
-    # pytest warnings
-    'once:Class-scoped fixture defined as instance method is deprecated:pytest.PytestRemovedIn10Warning',
     # Our own warnings
     'once::singer_sdk.helpers._compat.SingerSDKDeprecationWarning',
     'once::singer_sdk.helpers._compat.SingerSDKPythonEOLWarning',

--- a/singer_sdk/testing/factory.py
+++ b/singer_sdk/testing/factory.py
@@ -164,7 +164,8 @@ class TapTestClassFactory:
                 yield  # noqa: PT022
 
             @pytest.fixture(scope="class")
-            def runner(self) -> TapTestRunner | TargetTestRunner:  # noqa: PLR6301
+            @classmethod
+            def runner(cls) -> TapTestRunner | TargetTestRunner:
                 # Populate runner class with cached records for use in tests
                 test_runner.sync_all()
                 return test_runner

--- a/tests/packages/test_target_csv.py
+++ b/tests/packages/test_target_csv.py
@@ -47,11 +47,13 @@ class TestSampleTargetCSV(StandardTests):
     """Standard Target Tests."""
 
     @pytest.fixture(scope="class")
-    def test_output_dir(self):
+    @classmethod
+    def test_output_dir(cls) -> Path:
         return TEST_OUTPUT_DIR
 
     @pytest.fixture(scope="class")
-    def resource(self, test_output_dir):
+    @classmethod
+    def resource(cls, test_output_dir: Path):
         test_output_dir.mkdir(parents=True, exist_ok=True)
         yield test_output_dir
         shutil.rmtree(test_output_dir)
@@ -258,9 +260,9 @@ def cli_runner():
 
 
 @pytest.fixture
-def config_file_path(target):
+def config_file_path(target: TargetCSV):
+    path = Path(target.config["target_folder"]) / "./config.json"
     try:
-        path = Path(target.config["target_folder"]) / "./config.json"
         with path.open("w") as f:
             f.write(json.dumps(dict(target.config)))
         yield path

--- a/tests/packages/test_target_parquet.py
+++ b/tests/packages/test_target_parquet.py
@@ -27,11 +27,13 @@ class TestSampleTargetParquet(StandardTests):
     """Standard Target Tests."""
 
     @pytest.fixture(scope="class")
-    def test_output_dir(self):
+    @classmethod
+    def test_output_dir(cls) -> Path:
         return SAMPLE_FILEPATH
 
     @pytest.fixture(scope="class")
-    def resource(self, test_output_dir):
+    @classmethod
+    def resource(cls, test_output_dir: Path):
         test_output_dir.mkdir(parents=True, exist_ok=True)
         yield test_output_dir
         shutil.rmtree(test_output_dir)

--- a/uv.lock
+++ b/uv.lock
@@ -3238,7 +3238,7 @@ requires-dist = [
     { name = "paramiko", marker = "extra == 'ssh'", specifier = ">=3.3.0" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15" },
     { name = "pyjwt", marker = "extra == 'jwt'", specifier = ">=2.4.0" },
-    { name = "pytest", marker = "extra == 'testing'", specifier = ">=9" },
+    { name = "pytest", marker = "extra == 'testing'", specifier = ">=9.1" },
     { name = "python-backoff", specifier = ">=2.2.2" },
     { name = "python-dotenv", specifier = ">=0.20" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
SSIA, https://github.com/pytest-dev/pytest/pull/14071

## Summary by Sourcery

Update built-in integration tests and related configuration to comply with pytest 9.1 class-scoped fixture requirements.

Build:
- Bump pytest testing dependency to >=9.1 and remove obsolete filterwarning for deprecated instance-method class-scoped fixtures.

Tests:
- Convert class-scoped fixtures in target CSV and Parquet integration tests to class methods and add type annotations for better compatibility with newer pytest versions.