### PR TITLE
fix: Convert class-scoped fixtures in built-in integration tests into `@classmethod`s (#3676)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ parquet = [
 ]
 
 testing = [
-    "pytest>=9",
+    "pytest>=9.1",
 ]
 
 faker = [

--- a/singer_sdk/testing/factory.py
+++ b/singer_sdk/testing/factory.py
@@ -164,7 +164,8 @@ class TapTestClassFactory:
                 yield  # noqa: PT022
 
             @pytest.fixture(scope="class")
-            def runner(self) -> TapTestRunner | TargetTestRunner:  # noqa: PLR6301
+            @classmethod
+            def runner(cls) -> TapTestRunner | TargetTestRunner:
                 # Populate runner class with cached records for use in tests
                 test_runner.sync_all()
                 return test_runner

--- a/tests/packages/test_target_csv.py
+++ b/tests/packages/test_target_csv.py
@@ -47,11 +47,13 @@ class TestSampleTargetCSV(StandardTests):
     """Standard Target Tests."""
 
     @pytest.fixture(scope="class")
-    def test_output_dir(self):
+    @classmethod
+    def test_output_dir(cls) -> Path:
         return TEST_OUTPUT_DIR
 
     @pytest.fixture(scope="class")
-    def resource(self, test_output_dir):
+    @classmethod
+    def resource(cls, test_output_dir: Path):
         test_output_dir.mkdir(parents=True, exist_ok=True)
         yield test_output_dir
         shutil.rmtree(test_output_dir)
@@ -258,9 +260,9 @@ def cli_runner():
 
 
 @pytest.fixture
-def config_file_path(target):
+def config_file_path(target: TargetCSV):
+    path = Path(target.config["target_folder"]) / "./config.json"
     try:
-        path = Path(target.config["target_folder"]) / "./config.json"
         with path.open("w") as f:
             f.write(json.dumps(dict(target.config)))
         yield path

--- a/tests/packages/test_target_parquet.py
+++ b/tests/packages/test_target_parquet.py
@@ -27,11 +27,13 @@ class TestSampleTargetParquet(StandardTests):
     """Standard Target Tests."""
 
     @pytest.fixture(scope="class")
-    def test_output_dir(self):
+    @classmethod
+    def test_output_dir(cls) -> Path:
         return SAMPLE_FILEPATH
 
     @pytest.fixture(scope="class")
-    def resource(self, test_output_dir):
+    @classmethod
+    def resource(cls, test_output_dir: Path):
         test_output_dir.mkdir(parents=True, exist_ok=True)
         yield test_output_dir
         shutil.rmtree(test_output_dir)

--- a/uv.lock
+++ b/uv.lock
@@ -3197,7 +3197,7 @@ requires-dist = [
     { name = "paramiko", marker = "extra == 'ssh'", specifier = ">=3.3.0" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15" },
     { name = "pyjwt", marker = "extra == 'jwt'", specifier = ">=2.4.0" },
-    { name = "pytest", marker = "extra == 'testing'", specifier = ">=9" },
+    { name = "pytest", marker = "extra == 'testing'", specifier = ">=9.1" },
     { name = "python-backoff", specifier = ">=2.2.2" },
     { name = "python-dotenv", specifier = ">=0.20" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
SSIA, backport of #3676

## Summary by Sourcery

Convert class-scoped pytest fixtures in built-in integration tests to class methods and update pytest version constraint for testing.

Enhancements:
- Refactor test_target_csv and test_target_parquet to define class-scoped fixtures as @classmethods for better compatibility with newer pytest versions.

Build:
- Bump pytest testing dependency to >=9.1 in pyproject.toml.

Tests:
- Adjust factory-based runner fixture to be a class method to align with updated fixture patterns in generated tests.