### PR TITLE
feat: Add `stream_name` to structured logs

### DIFF
--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -403,7 +403,7 @@ def conform_record_data_types(
     record: dict[str, t.Any],
     schema: dict,
     level: conform.TypeConformanceLevel,
-    logger: logging.Logger,
+    logger: logging.Logger | logging.LoggerAdapter,
 ) -> dict[str, t.Any]:
     """Translate values in record dictionary to singer-compatible data types.
 

--- a/singer_sdk/logging.py
+++ b/singer_sdk/logging.py
@@ -196,8 +196,9 @@ class StructuredFormatter(logging.Formatter):
             "ts": record.created,
             "thread_name": record.threadName,
             "app_name": data.pop("app_name", "singer-sdk"),
-            "stream_name": data.pop("stream_name", None),
         }
+        if stream_name := data.pop("stream_name", None):
+            log_data["stream_name"] = stream_name
 
         # Handle exception information
         if record.exc_info and (exc_dict := self._format_exception(record.exc_info)):

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -741,7 +741,7 @@ class PluginMapper:
     def __init__(
         self,
         plugin_config: dict[str, StreamMapsDict],
-        logger: logging.Logger,
+        logger: logging.Logger | logging.LoggerAdapter,
     ) -> None:
         """Initialize mapper.
 

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -126,7 +126,10 @@ class Stream(abc.ABC):  # noqa: PLR0904
             msg = "Missing argument or class variable 'name'."
             raise ValueError(msg)
 
-        self._logger: logging.Logger = tap.logger.getChild(self.name)
+        self._logger = logging.LoggerAdapter(
+            tap.logger.getChild(self.name),
+            extra={"stream_name": self.name},
+        )
         self.metrics_logger = tap.metrics_logger
         self.tap_name: str = tap.name
         self.context: types.Context | None = None
@@ -185,7 +188,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
             self._schema = json.loads(self.schema_filepath.read_text())
 
     @property
-    def logger(self) -> logging.Logger:
+    def logger(self) -> logging.LoggerAdapter:
         """Stream logger."""
         return self._logger
 


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Include stream name in structured logging for streams and update related logger typing.

Enhancements:
- Wrap stream loggers with LoggerAdapter to attach stream_name context.
- Adjust structured log formatter to add stream_name field only when present.
- Broaden logger type hints to accept LoggerAdapter in helper and mapper components.