### PR TITLE
feat: Support Arrow IPC as a BATCH file encoding format

### DIFF
--- a/docs/batch.md
+++ b/docs/batch.md
@@ -54,7 +54,7 @@ AWS S3
 
 ### `encoding`
 
-The `encoding` field is used to specify the format and compression of the batch files. Currently `jsonl`, `gzip` and `parquet` are supported.
+The `encoding` field is used to specify the format and compression of the batch files. Currently the supported formats are: `jsonl`, `parquet` and `arrow`. GZip (`gzip`) compression is supported for JSONL and Parquet files.
 
 #### JSONL Batch File Format
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -182,8 +182,12 @@ The following [extra features](https://packaging.python.org/en/latest/specificat
 - `faker` - Enables the use of [Faker](https://faker.readthedocs.io/en/master/) in [stream maps](stream_maps.md).
 - `jwt` - Enables the `OAuthJWTAuthenticator` class for JWT (JSON Web Token) authentication.
 - `s3` - Enables AWS S3 as a [BATCH storage](batch.md#the-batch-message).
-- `parquet` - Enables as [BATCH encoding](batch.md#encoding).
 - `testing` - Pytest dependencies required to use the [Tap & Target Testing Framework](testing.md).
+
+### BATCH file format implementations
+
+- `arrow` - Enables Arrow IPC as [BATCH encoding](batch.md#encoding).
+- `parquet` - Enables as [BATCH encoding](batch.md#encoding).
 
 ## Resources
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -187,7 +187,7 @@ The following [extra features](https://packaging.python.org/en/latest/specificat
 ### BATCH file format implementations
 
 - `arrow` - Enables Arrow IPC as [BATCH encoding](batch.md#encoding).
-- `parquet` - Enables as [BATCH encoding](batch.md#encoding).
+- `parquet` - Enables Parquet as a [BATCH encoding](batch.md#encoding).
 
 ## Resources
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -315,6 +315,7 @@ def coverage(session: nox.Session) -> None:
 def dependencies(session: nox.Session) -> None:
     """Check issues with dependencies."""
     extras = [
+        "arrow",
         "faker",
         "jwt",
         "msgspec",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ parquet = [
     "pyarrow>=15",
 ]
 
+arrow = [
+    "pyarrow>=15",
+]
+
 testing = [
     "pytest>=9.1",
 ]
@@ -324,6 +328,7 @@ build-backend = "hatchling.build"
 singer_testing = "singer_sdk.testing.pytest_plugin"
 
 [project.entry-points."singer_sdk.batch_encoders"]
+arrow = "singer_sdk.contrib.batch_encoder_arrow:ArrowBatcher"
 jsonl = "singer_sdk.contrib.batch_encoder_jsonl:JSONLinesBatcher"
 parquet = "singer_sdk.contrib.batch_encoder_parquet:ParquetBatcher"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ parquet = [
     "pyarrow>=15",
 ]
 
+arrow = [
+    "pyarrow>=15",
+]
+
 testing = [
     "pytest>=9.1",
 ]
@@ -322,6 +326,7 @@ build-backend = "hatchling.build"
 singer_testing = "singer_sdk.testing.pytest_plugin"
 
 [project.entry-points."singer_sdk.batch_encoders"]
+arrow = "singer_sdk.contrib.batch_encoder_arrow:ArrowBatcher"
 jsonl = "singer_sdk.contrib.batch_encoder_jsonl:JSONLinesBatcher"
 parquet = "singer_sdk.contrib.batch_encoder_parquet:ParquetBatcher"
 

--- a/singer_sdk/batch.py
+++ b/singer_sdk/batch.py
@@ -81,7 +81,7 @@ class BaseBatcher(ABC):
     @abstractmethod
     def get_batches(
         self,
-        records: t.Iterator[dict],
+        records: t.Iterable[dict],
     ) -> t.Iterator[list[str]]:
         """Yield manifest of batches.
 
@@ -98,7 +98,7 @@ class Batcher(BaseBatcher):
     """Determines batch type and then serializes batches to that format."""
 
     @override
-    def get_batches(self, records: t.Iterator[dict]) -> t.Iterator[list[str]]:
+    def get_batches(self, records: t.Iterable[dict]) -> t.Iterator[list[str]]:
         """Manifest of batches.
 
         Args:

--- a/singer_sdk/contrib/batch_encoder_arrow.py
+++ b/singer_sdk/contrib/batch_encoder_arrow.py
@@ -1,48 +1,44 @@
-"""JSON Lines batch encoder."""
+"""Arrow IPC batch encoder."""
 
 from __future__ import annotations
 
-import gzip
 import sys
 import typing as t
 from uuid import uuid4
 
 from singer_sdk.batch import BaseBatcher, lazy_chunked_generator
-from singer_sdk.singerlib.json import serialize_json
 
 if sys.version_info >= (3, 12):
     from typing import override  # noqa: ICN003
 else:
     from typing_extensions import override
 
-__all__ = ["JSONLinesBatcher"]
+if t.TYPE_CHECKING:
+    from singer_sdk.helpers.types import Record
+
+__all__ = ["ArrowBatcher"]
 
 
-class JSONLinesBatcher(BaseBatcher):
-    """JSON Lines Record Batcher.
-
-    Writes raw JSON records to JSONL batch files, with one record per line.
-    The batch files contain only the record data, not Singer protocol messages.
-    """
+class ArrowBatcher(BaseBatcher):
+    """Arrow Record Batcher."""
 
     @override
     def get_batches(
         self,
-        records: t.Iterable[dict],
+        records: t.Iterable[Record],
     ) -> t.Iterator[list[str]]:
         """Yield manifest of batches.
 
-        Creates JSONL batch files containing raw JSON records (one per line).
-
         Args:
-            records: The raw record dictionaries to batch.
+            records: The records to batch.
 
         Yields:
             A list of file paths (called a manifest).
         """
+        import pyarrow as pa  # noqa: PLC0415
+
         sync_id = f"{self.tap_name}--{self.stream_name}-{uuid4()}"
-        storage = self.batch_config.storage
-        prefix = storage.prefix or ""
+        prefix = self.batch_config.storage.prefix or ""
 
         for i, chunk in enumerate(
             lazy_chunked_generator(
@@ -51,15 +47,14 @@ class JSONLinesBatcher(BaseBatcher):
             ),
             start=1,
         ):
-            filename = f"{prefix}{sync_id}-{i}.json.gz"
-            # TODO: Determine compression from config.
+            filename = f"{prefix}{sync_id}={i}.arrow"
+            storage = self.batch_config.storage
+            table = pa.Table.from_pylist(list(chunk))
             with (
                 storage.open(filename, "wb") as f,
-                gzip.GzipFile(fileobj=f, mode="wb") as gz,
+                pa.ipc.new_file(f, table.schema) as writer,  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
             ):
-                gz.writelines(
-                    (serialize_json(record) + "\n").encode() for record in chunk
-                )
+                writer.write_table(table)
 
             file_url = storage.get_url(filename)
             yield [file_url]

--- a/singer_sdk/helpers/capabilities.py
+++ b/singer_sdk/helpers/capabilities.py
@@ -195,7 +195,6 @@ BATCH_CONFIG = PropertiesList(
                     Property(
                         "format",
                         StringType,
-                        allowed_values=["jsonl", "parquet"],
                         title="Batch Encoding Format",
                         description="Format to use for batch files.",
                     ),

--- a/tests/contrib/batch/test_arrow.py
+++ b/tests/contrib/batch/test_arrow.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import decimal
+import importlib.util
+import re
+import typing as t
+
+import pytest
+
+from singer_sdk.batch import Batcher
+from singer_sdk.contrib.batch_encoder_arrow import ArrowBatcher
+from singer_sdk.helpers._batch import (
+    BaseBatchFileEncoding,
+    BatchConfig,
+    StorageTarget,
+)
+
+if t.TYPE_CHECKING:
+    from pathlib import Path
+
+
+def is_pyarrow_installed():
+    module_spec = importlib.util.find_spec("pyarrow")
+    return module_spec is not None
+
+
+skip_if_no_pyarrow = pytest.mark.skipif(
+    not is_pyarrow_installed(),
+    reason="requires pyarrow",
+)
+
+
+@skip_if_no_pyarrow
+def test_batcher(tmp_path: Path) -> None:
+    root = tmp_path.joinpath("batches")
+    root.mkdir()
+    config = BatchConfig(
+        encoding=BaseBatchFileEncoding(format="arrow"),
+        storage=StorageTarget(root=str(root)),
+        batch_size=2,
+    )
+    batcher = ArrowBatcher("tap", "stream", config)
+    records = [
+        {"id": 1, "numeric": "1.0"},
+        {"id": 2, "numeric": "2.0"},
+        {"id": 3, "numeric": "3.0"},
+    ]
+    batches = list(batcher.get_batches(records))
+    assert len(batches) == 2
+    assert batches[0][0].endswith(".arrow")
+
+
+@skip_if_no_pyarrow
+def test_batcher_with_arrow_encoding():
+    batcher = Batcher(
+        "tap-test",
+        "stream-test",
+        batch_config=BatchConfig(
+            encoding=BaseBatchFileEncoding(format="arrow"),
+            storage=StorageTarget("file:///tmp/sdk-batches"),
+            batch_size=2,
+        ),
+    )
+    records = [
+        {"id": 1, "numeric": decimal.Decimal("1.0")},
+        {"id": 2, "numeric": decimal.Decimal("2.0")},
+        {"id": 3, "numeric": decimal.Decimal("3.0")},
+    ]
+
+    batches = list(batcher.get_batches(records))
+    assert len(batches) == 2
+    assert all(len(batch) == 1 for batch in batches)
+    assert all(
+        re.match(r".*tap-test--stream-test-.*\.arrow", filepath)
+        for batch in batches
+        for filepath in batch
+    )

--- a/tests/contrib/batch/test_parquet.py
+++ b/tests/contrib/batch/test_parquet.py
@@ -32,6 +32,7 @@ skip_if_no_pyarrow = pytest.mark.skipif(
 )
 
 
+@skip_if_no_pyarrow
 def test_batcher(tmp_path: Path) -> None:
     root = tmp_path.joinpath("batches")
     root.mkdir()

--- a/uv.lock
+++ b/uv.lock
@@ -3036,6 +3036,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+arrow = [
+    { name = "pyarrow" },
+]
 faker = [
     { name = "faker" },
 ]
@@ -3214,6 +3217,7 @@ requires-dist = [
     { name = "msgspec", marker = "extra == 'msgspec'", specifier = ">=0.19.0" },
     { name = "packaging", specifier = ">=23.1" },
     { name = "paramiko", marker = "extra == 'ssh'", specifier = ">=3.3.0" },
+    { name = "pyarrow", marker = "extra == 'arrow'", specifier = ">=15" },
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=15" },
     { name = "pyjwt", marker = "extra == 'jwt'", specifier = ">=2.4.0" },
     { name = "pytest", marker = "extra == 'testing'", specifier = ">=9.1" },
@@ -3231,7 +3235,7 @@ requires-dist = [
     { name = "universal-pathlib", specifier = ">=0.2.6" },
     { name = "urllib3", specifier = ">=1.26.20" },
 ]
-provides-extras = ["faker", "jwt", "msgspec", "parquet", "s3", "sql", "ssh", "testing"]
+provides-extras = ["arrow", "faker", "jwt", "msgspec", "parquet", "s3", "sql", "ssh", "testing"]
 
 [package.metadata.requires-dev]
 benchmark = [


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Add Arrow IPC as a supported BATCH file encoding format and integrate it into the SDK and documentation.

New Features:
- Introduce an Arrow IPC batch encoder and register it as a BATCH file format option.
- Add an optional `arrow` extra to install Arrow-related dependencies.

Enhancements:
- Document Arrow IPC as a supported BATCH encoding format alongside JSONL and Parquet.
- Broaden batcher interfaces to accept generic iterables of records instead of only iterators.
- Enable dependency checking sessions to cover the new Arrow extra.
- Relax the batch encoding capability schema to allow additional formats beyond JSONL and Parquet.

Tests:
- Add tests validating Arrow batch encoding behavior and file naming, gated on `pyarrow` availability.
- Ensure existing Parquet batch tests are skipped when `pyarrow` is not installed.