### PR TITLE
fix: Make the `Sink.clean_up()` method a no-op by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
   - id: check-readthedocs
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.20
+  rev: v0.15.21
   hooks:
   - id: ruff-check
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,7 +334,7 @@ extend-include = [
 ]
 line-length = 88
 preview = true
-required-version = ">=0.15.14"
+required-version = ">=0.15.21"
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -720,15 +720,21 @@ class Sink(abc.ABC):  # noqa: PLR0904
         """
         self.logger.debug("Setting up %s", self.stream_name)
 
-    def clean_up(self) -> None:
-        """Perform any clean up actions required at end of a stream.
-
-        Implementations should ensure that clean up does not affect resources
-        that may be in use from other instances of the same sink. Stream name alone
-        should not be relied on, it's recommended to use a uuid as well.
-        """
+    @t.final
+    def _clean_up(self) -> None:
+        """Perform any clean up actions required at end of a stream."""
         self.logger.debug("Cleaning up %s", self.stream_name)
         self.record_counter_metric.exit()
+        self.clean_up()
+
+    def clean_up(self) -> None:  # ruff:ignore[no-self-use]
+        """Override this method to perform clean up actions.
+
+        This will be called when a stream is finalized. Implementations should ensure
+        that clean up does not affect resources that may be in use from other instances
+        of the same sink.
+        """
+        return
 
     def process_batch_files(
         self,

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -515,12 +515,12 @@ class Target(BaseSingerReader, abc.ABC):
         self._drain_all(self._sinks_to_clear, 1)
         if is_endofpipe:
             for sink in self._sinks_to_clear:
-                sink.clean_up()
+                sink._clean_up()  # ruff:ignore[private-member-access]
         self._sinks_to_clear = []
         self._drain_all(self._sinks_active.values(), self.max_parallelism)
         if is_endofpipe:
             for sink in self._sinks_active.values():
-                sink.clean_up()
+                sink._clean_up()  # ruff:ignore[private-member-access]
 
         if self._latest_state:
             self._write_state_message(copy.deepcopy(self._latest_state))


### PR DESCRIPTION
This is to avoid forcing users to call `super().clean_up()` in their implementation.

TIL that this called the ["Template Method"](https://refactoring.guru/design-patterns/template-method), and it is something we should probably do in most of our explicitly public APIs.

## Summary by Sourcery

Introduce a finalized sink shutdown step that preserves metrics behavior while making `clean_up()` a no-op by default.

Enhancements:
- Add a final `_clean_up()` method on sinks to handle end-of-stream cleanup and metric exit calls.
- Change target draining logic to invoke the new sink `_clean_up()` method instead of `clean_up()`.

Build:
- Update Ruff pre-commit hook and required Ruff version to 0.15.21 in tooling configuration.