### PR TITLE
fix: Handle multiple cancellation/interruption signals

### DIFF
--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -283,6 +283,7 @@ class PluginBase(abc.ABC):
         self.__initialized_at = int(time.time() * 1000)
 
         # Signal handling
+        self._is_terminating = False
         self._setup_signal_handlers()
 
     def _setup_signal_handlers(self) -> None:  # pragma: no cover
@@ -492,6 +493,16 @@ class PluginBase(abc.ABC):
             signum: Signal number.
             frame: Frame.
         """
+        if self._is_terminating:
+            # Duplicate signal, e.g. delivered both directly by the OS and
+            # forwarded by an orchestrator such as Meltano. Let the in-flight
+            # shutdown finish.
+            return
+        self._is_terminating = True
+        self._terminate()
+
+    def _terminate(self) -> t.NoReturn:
+        """Exit after a graceful shutdown."""
         self.logger.info("Gracefully shutting down...")
         sys.exit(0)
 

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -497,6 +497,10 @@ class PluginBase(abc.ABC):
             # Duplicate signal, e.g. delivered both directly by the OS and
             # forwarded by an orchestrator such as Meltano. Let the in-flight
             # shutdown finish.
+            self.logger.debug(
+                "Termination signal %s received while shutdown already in progress",
+                signum,
+            )
             return
         self._is_terminating = True
         self._terminate()

--- a/singer_sdk/plugin_base.py
+++ b/singer_sdk/plugin_base.py
@@ -484,7 +484,7 @@ class PluginBase(abc.ABC):
 
     def _handle_termination(  # pragma: no cover
         self,
-        signum: int,  # noqa: ARG002
+        signum: int,
         frame: FrameType | None,  # noqa: ARG002
     ) -> None:
         """Handle termination signal.

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -581,6 +581,12 @@ class Target(BaseSingerReader, abc.ABC):
             signum: Signal number.
             frame: Frame object.
         """
+        if self._is_terminating:
+            # Duplicate signal, e.g. delivered both directly by the OS and
+            # forwarded by an orchestrator such as Meltano. Let the in-flight
+            # drain finish.
+            return
+        self._is_terminating = True
         self.logger.info(
             "Received termination signal %d, draining all sinks...",
             signum,
@@ -588,7 +594,7 @@ class Target(BaseSingerReader, abc.ABC):
         try:
             self.drain_all(is_endofpipe=True)
         finally:
-            super()._handle_termination(signum, frame)
+            self._terminate()
 
     @classmethod
     @override

--- a/tests/core/test_plugin_base.py
+++ b/tests/core/test_plugin_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import signal
 import typing as t
 
 import pytest
@@ -174,3 +175,17 @@ def test_singer_command_excepthook(
 
     assert not caplog.messages
     assert "KeyboardInterrupt" in capsys.readouterr().err
+
+
+def test_handle_termination_is_idempotent():
+    """A duplicate termination signal must not restart the shutdown."""
+    plugin = PluginTest(config={"prop1": "hello"})
+
+    with pytest.raises(SystemExit) as exc_info:
+        plugin._handle_termination(signal.SIGTERM, None)
+
+    assert exc_info.value.code == 0
+
+    # e.g. the same signal delivered both directly by the OS and forwarded
+    # by an orchestrator such as Meltano
+    assert plugin._handle_termination(signal.SIGTERM, None) is None

--- a/tests/core/test_target_base.py
+++ b/tests/core/test_target_base.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import copy
+import signal
+from unittest import mock
 
 import pytest
 
@@ -234,3 +236,24 @@ def test_batch_size_rows_and_max_size():
     assert sink_set._batch_size_rows == 100000
     assert sink_set.batch_size_rows == 100000
     assert sink_set.max_size == 100000
+
+
+def test_duplicate_termination_signal_does_not_redrain():
+    """A second signal arriving mid-drain is ignored and sinks drain once."""
+    target = TargetMock()
+    drain_calls: list[dict] = []
+
+    def fake_drain_all(**kwargs) -> None:
+        drain_calls.append(kwargs)
+        # simulate the duplicate signal arriving while the drain is in flight,
+        # e.g. delivered by the OS process group and forwarded by Meltano
+        target._handle_termination(signal.SIGINT, None)
+
+    with (
+        mock.patch.object(target, "drain_all", side_effect=fake_drain_all),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        target._handle_termination(signal.SIGTERM, None)
+
+    assert exc_info.value.code == 0
+    assert len(drain_calls) == 1


### PR DESCRIPTION
e.g. Ctrl+C-ing a `meltano run` (on Unix at least) delivers SIGINT to the entire foreground process group.

So Meltano, the tap, and the target each get their own SIGINT copy simultaneously. Then Meltano's SIGINT handling sends SIGTERM explicitly to each plugin subprocess, so plugins receive two signals.

This change avoids re-entry when we're already dealing with a cancellation signal.

## Links

- https://github.com/meltano/meltano/pull/10155

## Summary by Sourcery

Make plugin and target termination handling idempotent to avoid duplicate shutdown on multiple signals.

Bug Fixes:
- Ignore duplicate termination signals during plugin shutdown to prevent repeated graceful exits.
- Ignore duplicate termination signals during target sink draining to avoid re-running the drain process.

Tests:
- Add tests ensuring plugin termination handler exits once and is no-op on subsequent signals.
- Add tests ensuring target drains sinks only once when multiple termination signals are received.

## Summary by Sourcery

Make plugin and target termination handling idempotent so duplicate OS and orchestrator signals do not trigger repeated shutdown or drain operations.

Bug Fixes:
- Prevent plugins from re-running shutdown logic when multiple termination signals are received.
- Prevent targets from re-draining sinks when duplicate termination signals arrive mid-drain.

Tests:
- Add tests verifying plugin termination handler exits once and is a no-op on subsequent signals.
- Add tests verifying targets drain sinks only once when multiple termination signals are delivered during shutdown.