### PR TITLE
chore: Update templates

### DIFF
--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       name: {{ '${{ steps.baipp.outputs.package_name }}' }}
       version: {{ '${{ steps.baipp.outputs.package_version }}' }}
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -49,4 +49,4 @@ jobs:
     - name: Publish
       ## TODO: create a trusted publisher on PyPI
       ## https://docs.pypi.org/trusted-publishers/
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/run-zizmor.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/run-zizmor.yml
@@ -23,9 +23,9 @@ jobs:
       security-events: write # for GitHub's Advanced Security via zizmor
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     outputs:
       supported-python-versions: {{ '${{ steps.baipp.outputs.supported_python_classifiers_json_array }}' }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -53,11 +53,11 @@ jobs:
       matrix:
         python-version: {{ '${{ fromJson(needs.build-package.outputs.supported-python-versions) }}' }}
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Setup uv
-      uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Run Tox
@@ -68,11 +68,11 @@ jobs:
     name: Type Checking
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Setup uv
-      uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
     - name: Run Tox
       run: >
         uvx

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/zizmorcore/zizmor-pre-commit
-  rev: v1.26.1
+  rev: v1.28.0
   hooks:
   - id: zizmor
 
@@ -33,13 +33,13 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.20
+  rev: v0.16.0
   hooks:
   - id: ruff-check
   - id: ruff-format
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.11.27
+  rev: 0.11.31
   hooks:
   - id: uv-audit
   - id: uv-lock

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/pyproject.toml
@@ -110,12 +110,12 @@ testpaths = [
 
 [tool.ruff]
 line-length = 100
-required-version = ">=0.15"
+required-version = ">=0.16.0"
 
 [tool.ruff.lint]
 future-annotations = true
 ignore = [
-    "COM812",  # missing-trailing-comma
+    "missing-trailing-comma",
 ]
 select = ["ALL"]
 
@@ -124,7 +124,7 @@ allow-star-arg-any = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
-  "S101",  # assert is used by pytest
+  "assert",
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/{{cookiecutter.library_name}}/mapper.py
+++ b/cookiecutter/mapper-template/{{cookiecutter.mapper_id}}/{{cookiecutter.library_name}}/mapper.py
@@ -66,6 +66,9 @@ class {{ cookiecutter.name }}Mapper(InlineMapper):
 
         Args:
             message_dict: A SCHEMA message JSON dictionary.
+
+        Yields:
+            Transformed SCHEMA messages.
         """
         yield singer.SchemaMessage.from_dict(message_dict)
 
@@ -78,6 +81,9 @@ class {{ cookiecutter.name }}Mapper(InlineMapper):
 
         Args:
             message_dict: A RECORD message JSON dictionary.
+
+        Yields:
+            Transformed RECORD messages.
         """
         yield singer.RecordMessage.from_dict(message_dict)
 
@@ -87,6 +93,9 @@ class {{ cookiecutter.name }}Mapper(InlineMapper):
 
         Args:
             message_dict: A STATE message JSON dictionary.
+
+        Yields:
+            An intact state message.
         """
         yield singer.StateMessage.from_dict(message_dict)
 
@@ -99,6 +108,9 @@ class {{ cookiecutter.name }}Mapper(InlineMapper):
 
         Args:
             message_dict: An ACTIVATE_VERSION message JSON dictionary.
+
+        Yields:
+            Transformed ACTIVATE_VERSION messages.
         """
         yield singer.ActivateVersionMessage.from_dict(message_dict)
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       name: {{ '${{ steps.baipp.outputs.package_name }}' }}
       version: {{ '${{ steps.baipp.outputs.package_version }}' }}
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -49,4 +49,4 @@ jobs:
     - name: Publish
       ## TODO: create a trusted publisher on PyPI
       ## https://docs.pypi.org/trusted-publishers/
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/run-zizmor.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/run-zizmor.yml
@@ -23,9 +23,9 @@ jobs:
       security-events: write # for GitHub's Advanced Security via zizmor
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     outputs:
       supported-python-versions: {{ '${{ steps.baipp.outputs.supported_python_classifiers_json_array }}' }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -53,11 +53,11 @@ jobs:
       matrix:
         python-version: {{ '${{ fromJson(needs.build-package.outputs.supported-python-versions) }}' }}
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Setup uv
-      uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Run Tox
@@ -68,11 +68,11 @@ jobs:
     name: Type Checking
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Setup uv
-      uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
     - name: Run Tox
       run: >
         uvx

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/zizmorcore/zizmor-pre-commit
-  rev: v1.26.1
+  rev: v1.28.0
   hooks:
   - id: zizmor
 
@@ -33,13 +33,13 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.20
+  rev: v0.16.0
   hooks:
   - id: ruff-check
   - id: ruff-format
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.11.27
+  rev: 0.11.31
   hooks:
   - id: uv-audit
   - id: uv-lock

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/pyproject.toml
@@ -124,12 +124,12 @@ testpaths = [
 
 [tool.ruff]
 line-length = 100
-required-version = ">=0.15"
+required-version = ">=0.16.0"
 
 [tool.ruff.lint]
 future-annotations = true
 ignore = [
-    "COM812",  # missing-trailing-comma
+    "missing-trailing-comma",
 ]
 select = ["ALL"]
 
@@ -138,7 +138,7 @@ allow-star-arg-any = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
-  "S101",  # assert is used by pytest
+  "assert",
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/graphql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/graphql-client.py
@@ -6,7 +6,6 @@ import decimal
 import sys
 from typing import TYPE_CHECKING
 
-import requests  # noqa: TC002
 from singer_sdk.streams import {{ cookiecutter.stream_type }}Stream
 
 {%- if cookiecutter.auth_method in ("OAuth2", "JWT") %}
@@ -22,6 +21,7 @@ else:
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    import requests
     from singer_sdk.helpers.types import Context
 
 
@@ -31,7 +31,7 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     @override
     @property
     def url_base(self) -> str:
-        """Return the API URL root, configurable via tap settings."""
+        """The API URL root, configurable via tap settings."""
         # TODO: hardcode a value here, or retrieve it from self.config
         return "https://api.mysample.com"
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/rest-client.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from singer_sdk import SchemaDirectory, StreamSchema
 from singer_sdk.authenticators import APIKeyAuthenticator
 from singer_sdk.helpers.jsonpath import extract_jsonpath
-from singer_sdk.pagination import BaseAPIPaginator  # noqa: TC002
 from singer_sdk.streams import {{ cookiecutter.stream_type }}Stream
 
 from {{ cookiecutter.library_name }} import schemas
@@ -22,7 +21,6 @@ from {{ cookiecutter.library_name }} import schemas
 from singer_sdk import SchemaDirectory, StreamSchema
 from singer_sdk.authenticators import BearerTokenAuthenticator
 from singer_sdk.helpers.jsonpath import extract_jsonpath
-from singer_sdk.pagination import BaseAPIPaginator  # noqa: TC002
 from singer_sdk.streams import {{ cookiecutter.stream_type }}Stream
 
 from {{ cookiecutter.library_name }} import schemas
@@ -31,7 +29,6 @@ from {{ cookiecutter.library_name }} import schemas
 from requests.auth import HTTPBasicAuth
 from singer_sdk import SchemaDirectory, StreamSchema
 from singer_sdk.helpers.jsonpath import extract_jsonpath
-from singer_sdk.pagination import BaseAPIPaginator  # noqa: TC002
 from singer_sdk.streams import {{ cookiecutter.stream_type }}Stream
 
 from {{ cookiecutter.library_name }} import schemas
@@ -39,7 +36,6 @@ from {{ cookiecutter.library_name }} import schemas
 {% elif cookiecutter.auth_method == "Custom or N/A" -%}
 from singer_sdk import SchemaDirectory, StreamSchema
 from singer_sdk.helpers.jsonpath import extract_jsonpath
-from singer_sdk.pagination import BaseAPIPaginator  # noqa: TC002
 from singer_sdk.streams import {{ cookiecutter.stream_type }}Stream
 
 from {{ cookiecutter.library_name }} import schemas
@@ -47,7 +43,6 @@ from {{ cookiecutter.library_name }} import schemas
 {% elif cookiecutter.auth_method in ("OAuth2", "JWT") -%}
 from singer_sdk import SchemaDirectory, StreamSchema
 from singer_sdk.helpers.jsonpath import extract_jsonpath
-from singer_sdk.pagination import BaseAPIPaginator  # noqa: TC002
 from singer_sdk.streams import {{ cookiecutter.stream_type }}Stream
 
 from {{ cookiecutter.library_name }} import schemas
@@ -69,6 +64,7 @@ if TYPE_CHECKING:
     {%- else %}
     from singer_sdk.helpers.types import Context
     {%- endif %}
+    from singer_sdk.pagination import BaseAPIPaginator
     from singer_sdk.streams.rest import HTTPRequest, PageContext
 
 
@@ -83,14 +79,14 @@ class {{ cookiecutter.source_name }}Stream({{ cookiecutter.stream_type }}Stream)
     records_jsonpath = "$[*]"
 
     # Update this value if necessary or override `get_new_paginator`.
-    next_page_token_jsonpath = "$.next_page"  # noqa: S105
+    next_page_token_jsonpath = "$.next_page"  # ruff:ignore[hardcoded-password-string]
 
     schema: ClassVar[StreamSchema] = StreamSchema(SCHEMAS_DIR)
 
     @override
     @property
     def url_base(self) -> str:
-        """Return the API URL root, configurable via tap settings."""
+        """The API URL root, configurable via tap settings."""
         # TODO: hardcode a value here, or retrieve it from self.config
         return "https://api.mysample.com"
 

--- a/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
+++ b/cookiecutter/tap-template/{{cookiecutter.tap_id}}/{{cookiecutter.library_name}}/sql-client.py
@@ -232,7 +232,7 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
         # Add custom WHERE clauses from configuration, etc.
         # query = query.where(...)
 
-        return query  # noqa: RET504
+        return query  # ruff:ignore[unnecessary-assign]
 
     @override
     def get_records(self, context: Context | None) -> Iterable[Record]:
@@ -268,7 +268,7 @@ class {{ cookiecutter.source_name }}Stream(SQLStream):
                 query = query.where(replication_key_col >= start_val)
 
         # 3. Execute query and yield records
-        with self.connector._connect() as connection:  # noqa: SLF001
+        with self.connector._connect() as connection:  # ruff:ignore[private-member-access]
             for record in connection.execute(query).mappings():
                 yield dict(record)
 

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       name: {{ '${{ steps.baipp.outputs.package_name }}' }}
       version: {{ '${{ steps.baipp.outputs.package_version }}' }}
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -49,4 +49,4 @@ jobs:
     - name: Publish
       ## TODO: create a trusted publisher on PyPI
       ## https://docs.pypi.org/trusted-publishers/
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/run-zizmor.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/run-zizmor.yml
@@ -23,9 +23,9 @@ jobs:
       security-events: write # for GitHub's Advanced Security via zizmor
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     outputs:
       supported-python-versions: {{ '${{ steps.baipp.outputs.supported_python_classifiers_json_array }}' }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -53,11 +53,11 @@ jobs:
       matrix:
         python-version: {{ '${{ fromJson(needs.build-package.outputs.supported-python-versions) }}' }}
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Setup uv
-      uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
     - name: Run Tox
@@ -68,11 +68,11 @@ jobs:
     name: Type Checking
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Setup uv
-      uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
     - name: Run Tox
       run: >
         uvx

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/zizmorcore/zizmor-pre-commit
-  rev: v1.26.1
+  rev: v1.28.0
   hooks:
   - id: zizmor
 
@@ -33,13 +33,13 @@ repos:
   - id: check-meltano
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.20
+  rev: v0.16.0
   hooks:
   - id: ruff-check
   - id: ruff-format
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.11.27
+  rev: 0.11.31
   hooks:
   - id: uv-audit
   - id: uv-lock

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/pyproject.toml
@@ -117,12 +117,12 @@ testpaths = [
 
 [tool.ruff]
 line-length = 100
-required-version = ">=0.15"
+required-version = ">=0.16.0"
 
 [tool.ruff.lint]
 future-annotations = true
 ignore = [
-    "COM812",  # missing-trailing-comma
+    "missing-trailing-comma",
 ]
 select = ["ALL"]
 
@@ -131,7 +131,7 @@ allow-star-arg-any = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
-  "S101",  # assert is used by pytest
+  "assert",
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/tests/test_core.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/tests/test_core.py
@@ -24,7 +24,8 @@ class TestTarget{{ cookiecutter.destination_name }}(StandardTargetTests):  # typ
     """Standard Target Tests."""
 
     @pytest.fixture(scope="class")
-    def resource(self):  # noqa: ANN201
+    @classmethod
+    def resource(cls):  # ruff:ignore[missing-return-type-class-method]
         """Generic external resource.
 
         This fixture is useful for setup and teardown of external resources,
@@ -32,6 +33,9 @@ class TestTarget{{ cookiecutter.destination_name }}(StandardTargetTests):  # typ
 
         Example usage can be found in the SDK samples test suite:
         https://github.com/meltano/sdk/tree/main/tests/packages
+
+        Returns:
+            The fixture value.
         """
         return "resource"
 

--- a/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_sql.py
+++ b/cookiecutter/target-template/{{cookiecutter.target_id}}/{{cookiecutter.library_name}}/sinks_sql.py
@@ -37,6 +37,9 @@ class {{ cookiecutter.destination_name }}Connector(SQLConnector):
 
         Args:
             config: The configuration for the connector.
+
+        Returns:
+            A SQLAlchemy URL string.
         """
         return super().get_sqlalchemy_url(config)
 
@@ -75,6 +78,9 @@ class {{ cookiecutter.destination_name }}Sink(SQLSink):
         The default implementation uses a generic SQLAlchemy bulk insert operation.
         This method may optionally be overridden by developers in order to provide
         faster, native bulk uploads.
+
+        Returns:
+            The number of inserted records.
         """
         return super().bulk_insert_records(
             full_table_name=full_table_name,

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,15 +21,15 @@ nox.options.reuse_venv = "yes"
 
 RUFF_OVERRIDES = """\
 extend = "./pyproject.toml"
+preview = true
 
 [lint]
 extend-ignore = [
-  # Ignore TODO comments
-  "TD002",
-  "TD003",
-  "FIX002",
-  # Commented code
-  "ERA001",
+  "commented-out-code",
+  "line-contains-todo",
+  "missing-copyright-notice",
+  "missing-todo-author",
+  "missing-todo-link",
 ]
 """
 


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Refresh cookiecutter tap/target/mapper templates and tooling configuration to align with newer linting and CI conventions.

Enhancements:
- Enable Ruff preview features and update ignore codes to the new named-style across templates.
- Clarify and extend docstrings in generated mapper and target methods with yield/return descriptions.
- Adjust imports, type hints, and Ruff suppressions in generated client code for better type checking and lint compliance.

Build:
- Bump GitHub Actions in generated workflows (checkout, setup-uv, PyPI publish, zizmor) to newer pinned versions.
- Update pre-commit hook versions for zizmor, Ruff, and uv across templates.
- Raise the required Ruff version in template pyproject files.