### PR TITLE
feat: Add a new `AuthenticationError` exception type and raise it when OAuth token requests fail

### DIFF
--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -16,6 +16,7 @@ import requests
 import requests.adapters
 import urllib3
 
+from singer_sdk.exceptions import AuthenticationError
 from singer_sdk.helpers._compat import SingerSDKDeprecationWarning, deprecated
 from singer_sdk.helpers._util import utc_now
 
@@ -608,7 +609,7 @@ class OAuthAuthenticator(APIAuthenticatorBase):
         """Update `access_token` along with: `last_refreshed` and `expires_in`.
 
         Raises:
-            RuntimeError: When OAuth login fails.
+            AuthenticationError: When OAuth login fails.
         """
         self.logger.info("Requesting new access token")
         request_time = utc_now()
@@ -632,7 +633,7 @@ class OAuthAuthenticator(APIAuthenticatorBase):
                 status_code=status_code,
             )
             msg = f"Failed to update access token (status={status_code or 'Unknown'})"
-            raise RuntimeError(msg) from ex
+            raise AuthenticationError(msg) from ex
 
         self.logger.debug("OAuth authorization attempt was successful")
 
@@ -724,7 +725,7 @@ class OAuthJWTAuthenticator(OAuthAuthenticator):
         """Request payload for the OAuth request.
 
         Raises:
-            RuntimeError: If the JWT dependencies are not installed.
+            AuthenticationError: If the JWT dependencies are not installed.
             ValueError: If the private key is not set.
         """
         try:
@@ -733,7 +734,7 @@ class OAuthJWTAuthenticator(OAuthAuthenticator):
             from cryptography.hazmat.primitives import serialization  # noqa: PLC0415
         except ModuleNotFoundError as ex:  # pragma: no cover
             msg = "Install singer-sdk[jwt] to use OAuthJWTAuthenticator."
-            raise RuntimeError(msg) from ex
+            raise AuthenticationError(msg) from ex
 
         if not self.private_key:  # pragma: no cover
             msg = "Missing 'private_key' property for OAuth payload."

--- a/singer_sdk/exceptions.py
+++ b/singer_sdk/exceptions.py
@@ -217,6 +217,10 @@ class TooManyRecordsException(FatalSyncError):
     """Exception to raise when query returns more records than max_records."""
 
 
+class AuthenticationError(FatalAPIError):
+    """Exception raised when API authentication fails."""
+
+
 # ---------------------------------------------------------------------------
 # Sync — retriable
 # ---------------------------------------------------------------------------

--- a/tests/core/rest/test_authenticators.py
+++ b/tests/core/rest/test_authenticators.py
@@ -35,6 +35,7 @@ from singer_sdk.authenticators import (
     OAuthJWTAuthenticator,
     SimpleAuthenticator,
 )
+from singer_sdk.exceptions import AuthenticationError
 from singer_sdk.helpers._compat import SingerSDKDeprecationWarning
 from singer_sdk.streams.rest import RESTStream
 
@@ -247,7 +248,7 @@ def test_oauth_authenticator_handle_error(
         status_code=401,
     )
     with (
-        pytest.raises(RuntimeError, match="Failed to update access token"),
+        pytest.raises(AuthenticationError, match="Failed to update access token"),
         caplog.at_level(logging.ERROR),
     ):
         authenticator.update_access_token()
@@ -899,8 +900,8 @@ def test_oauth_authenticator_does_not_retry_client_errors(
         auth_endpoint="https://example.com/oauth",
     )
 
-    # Expect RuntimeError to be raised (existing error handling)
-    with pytest.raises(RuntimeError, match="Failed to update access token"):
+    # Expect AuthenticationError to be raised (existing error handling)
+    with pytest.raises(AuthenticationError, match="Failed to update access token"):
         authenticator.update_access_token()
 
     # Verify only 1 request was made (no retries for non-429 4xx)
@@ -930,9 +931,9 @@ def test_oauth_authenticator_fails_after_max_retries(rest_tap: Tap):
         auth_endpoint="https://example.com/oauth",
     )
 
-    # Expect RuntimeError after max retries exhausted
+    # Expect AuthenticationError after max retries exhausted
     with pytest.raises(
-        RuntimeError,
+        AuthenticationError,
         match=r"Failed to update access token \(status=503\)",
     ):
         authenticator.update_access_token()


### PR DESCRIPTION
## Summary by Sourcery

Introduce a dedicated AuthenticationError exception for OAuth authentication failures and update OAuth authenticator behavior accordingly.

New Features:
- Add an AuthenticationError exception type for API authentication failures.

Bug Fixes:
- Ensure OAuth authentication failures raise AuthenticationError instead of a generic RuntimeError, including when JWT dependencies are missing.

Tests:
- Update OAuth authenticator tests to expect AuthenticationError on failed token requests and exhausted retries.