### PR TITLE
feat: Allow `record_counter` without a stream and tag only provided values

### DIFF
--- a/singer_sdk/metrics.py
+++ b/singer_sdk/metrics.py
@@ -376,28 +376,29 @@ def get_metrics_logger() -> logging.Logger:
 
 
 def record_counter(
-    stream: str,
+    stream: str | None = None,
     endpoint: str | None = None,
     log_interval: float = DEFAULT_LOG_INTERVAL,
     **tags: t.Any,
 ) -> Counter:
     """Use for counting records retrieved from the source.
 
-    with record_counter("my_stream", endpoint="/users") as counter:
+    with record_counter() as counter:
          for record in my_records:
              # Do something with the record
              counter.increment()
 
     Args:
         stream: The stream name.
-        endpoint: The endpoint name.
+        endpoint: The HTTP endpoint.
         log_interval: The interval at which to log the count.
         tags: Tags to add to the measurement.
 
     Returns:
         A counter for counting records.
     """
-    tags[Tag.STREAM] = stream
+    if stream:
+        tags[Tag.STREAM] = stream
     if endpoint:
         tags[Tag.ENDPOINT] = endpoint
     return Counter(Metric.RECORD_COUNT, tags, log_interval=log_interval)

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 import typing as t
 
 import pytest
 import time_machine
 
 from singer_sdk import metrics
+
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
 
 if t.TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -18,6 +24,7 @@ class CustomObject:
         self.name = name
         self.value = value
 
+    @override
     def __str__(self) -> str:
         return f"{self.name}={self.value}"
 
@@ -87,9 +94,11 @@ def test_meter():
     pid = os.getpid()
 
     class _MyMeter(metrics.Meter):
+        @override
         def __enter__(self):
             return self
 
+        @override
         def __exit__(self, exc_type, exc_val, exc_tb):
             pass
 
@@ -108,7 +117,35 @@ def test_meter():
     assert metrics.Tag.CONTEXT not in meter.tags
 
 
-def test_record_counter(caplog: pytest.LogCaptureFixture):
+@pytest.mark.parametrize(
+    "stream,endpoint,tags",
+    [
+        pytest.param(
+            None,
+            None,
+            {},
+            id="no_params",
+        ),
+        pytest.param(
+            "test_stream",
+            None,
+            {metrics.Tag.STREAM: "test_stream"},
+            id="with_stream",
+        ),
+        pytest.param(
+            None,
+            "/endpoint",
+            {metrics.Tag.ENDPOINT: "/endpoint"},
+            id="with_endpoint",
+        ),
+    ],
+)
+def test_record_counter(
+    caplog: pytest.LogCaptureFixture,
+    stream: str | None,
+    endpoint: str | None,
+    tags: dict[str, t.Any],
+):
     metrics_logger = logging.getLogger(metrics.METRICS_LOGGER_NAME)
     metrics_logger.propagate = True
 
@@ -117,8 +154,8 @@ def test_record_counter(caplog: pytest.LogCaptureFixture):
     custom_object = CustomObject("test", 1)
 
     with metrics.record_counter(
-        "test_stream",
-        endpoint="test_endpoint",
+        stream=stream,
+        endpoint=endpoint,
         custom_tag="pytest",
         custom_obj=custom_object,
     ) as counter:
@@ -137,18 +174,17 @@ def test_record_counter(caplog: pytest.LogCaptureFixture):
         assert record.levelname == "INFO"
         assert record.msg.startswith("METRIC")
 
-        assert record.args
+        assert isinstance(record.args, tuple)
         assert isinstance(record.args[0], metrics.Point)
 
         point = record.args[0].to_dict()
         assert point["type"] == "counter"
         assert point["metric"] == "record_count"
         assert point["tags"] == {
-            metrics.Tag.STREAM: "test_stream",
-            metrics.Tag.ENDPOINT: "test_endpoint",
             metrics.Tag.PID: pid,
             "custom_tag": "pytest",
             "custom_obj": custom_object,
+            **tags,
         }
 
         total += point["value"]


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Make the `stream` parameter optional in `metrics.record_counter` and update tests accordingly.

New Features:
- Allow `metrics.record_counter` to be used without specifying a stream, optionally tagging by endpoint only.

Enhancements:
- Add conditional use of typing `override` for Python 3.12+ and apply it to custom test helpers.

Tests:
- Expand `test_record_counter` with parametrized cases to cover usage with no parameters, with stream only, and with endpoint only.