### PR TITLE
feat: Expose a new `Catalog.from_entries` to build a catalog from a list of catalog entries

### DIFF
--- a/singer_sdk/singerlib/catalog.py
+++ b/singer_sdk/singerlib/catalog.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import enum
 import logging
 import typing as t
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 
 from singer_sdk.singerlib.schema import Schema
 
 if t.TYPE_CHECKING:
     import sys
+    from collections.abc import Iterable
 
     if sys.version_info >= (3, 11):
         from typing import Self  # noqa: ICN003
@@ -111,10 +112,7 @@ class MetadataMapping(dict[Breadcrumb, AnyMetadata]):  # noqa: FURB189
     """Stream metadata mapping."""
 
     @classmethod
-    def from_iterable(
-        cls: type[MetadataMapping],
-        iterable: t.Iterable[dict[str, t.Any]],
-    ) -> MetadataMapping:
+    def from_iterable(cls: type[Self], iterable: t.Iterable[dict[str, t.Any]]) -> Self:
         """Create a metadata mapping from an iterable of metadata dictionaries.
 
         Args:
@@ -163,7 +161,7 @@ class MetadataMapping(dict[Breadcrumb, AnyMetadata]):  # noqa: FURB189
 
     @classmethod
     def get_standard_metadata(
-        cls: type[MetadataMapping],
+        cls: type[Self],
         *,
         schema: dict[str, t.Any] | None = None,
         schema_name: str | None = None,
@@ -171,7 +169,7 @@ class MetadataMapping(dict[Breadcrumb, AnyMetadata]):  # noqa: FURB189
         valid_replication_keys: list[str] | None = None,
         replication_method: str | None = None,
         selected_by_default: bool | None = None,
-    ) -> MetadataMapping:
+    ) -> Self:
         """Get default metadata for a stream.
 
         Args:
@@ -307,8 +305,8 @@ class CatalogEntry:
     """Singer catalog entry."""
 
     tap_stream_id: str
-    metadata: MetadataMapping
-    schema: Schema
+    metadata: MetadataMapping = field(default_factory=MetadataMapping)
+    schema: Schema = field(default_factory=Schema)
     stream: str | None = None
     key_properties: t.Sequence[str] | None = None
     replication_key: str | None = None
@@ -320,7 +318,7 @@ class CatalogEntry:
     replication_method: str | None = None
 
     @classmethod
-    def from_dict(cls: type[CatalogEntry], stream: dict[str, t.Any]) -> CatalogEntry:
+    def from_dict(cls: type[Self], stream: dict[str, t.Any]) -> Self:
         """Create a catalog entry from a dictionary.
 
         Args:
@@ -383,10 +381,7 @@ class Catalog(dict[str, CatalogEntry]):  # noqa: FURB189
     """Singer catalog mapping of stream entries."""
 
     @classmethod
-    def from_dict(
-        cls: type[Catalog],
-        data: dict[str, list[dict[str, t.Any]]],
-    ) -> Catalog:
+    def from_dict(cls: type[Self], data: dict[str, list[dict[str, t.Any]]]) -> Self:
         """Create a catalog from a dictionary.
 
         Args:
@@ -397,8 +392,22 @@ class Catalog(dict[str, CatalogEntry]):  # noqa: FURB189
         """
         instance = cls()
         for stream in data.get("streams", []):
-            entry = CatalogEntry.from_dict(stream)
-            instance[entry.tap_stream_id] = entry
+            instance.add_stream(CatalogEntry.from_dict(stream))
+        return instance
+
+    @classmethod
+    def from_entries(cls: type[Self], entries: Iterable[CatalogEntry]) -> Self:
+        """Create a catalog from an iterable of stream entries.
+
+        Args:
+            entries: The catalog entries.
+
+        Returns:
+            A catalog.
+        """
+        instance = cls()
+        for entry in entries:
+            instance.add_stream(entry)
         return instance
 
     def to_dict(self) -> dict[str, t.Any]:

--- a/tests/singerlib/test_catalog.py
+++ b/tests/singerlib/test_catalog.py
@@ -200,6 +200,15 @@ def test_catalog_parsing():
     assert catalog.get_stream("new") == entry
 
 
+def test_catalog_from_entries():
+    entries = [CatalogEntry(tap_stream_id="a"), CatalogEntry(tap_stream_id="b")]
+    catalog = Catalog.from_entries(entries)
+
+    assert list(catalog) == ["a", "b"]
+    assert catalog["a"] is entries[0]
+    assert catalog["b"] is entries[1]
+
+
 @pytest.mark.parametrize(
     "schema,key_properties,replication_method,valid_replication_keys,schema_name,breadcrumbs",
     [


### PR DESCRIPTION
## Summary by Sourcery

Introduce a more flexible way to construct Singer catalogs and align catalog-related classes with generic typing for better extensibility.

New Features:
- Add Catalog.from_entries to build a catalog from an iterable of CatalogEntry objects.

Enhancements:
- Default-initialize CatalogEntry metadata and schema fields to simplify entry construction.
- Update MetadataMapping and Catalog classmethods to use Self typing for improved subclassing support.
- Refine Catalog.from_dict to reuse add_stream for consistent catalog population.

Tests:
- Add tests verifying Catalog.from_entries builds catalogs correctly from multiple entries.