### PR TITLE
feat: Add Singer message writer helpers to `singerlib`

### DIFF
--- a/singer_sdk/singerlib/__init__.py
+++ b/singer_sdk/singerlib/__init__.py
@@ -21,6 +21,10 @@ from singer_sdk.singerlib.messages import (
     exclude_null_dict,
     format_message,
     write_message,
+    write_record,
+    write_schema,
+    write_state,
+    write_version,
 )
 from singer_sdk.singerlib.schema import Schema, resolve_schema_references
 from singer_sdk.singerlib.utils import strftime, strptime_to_utc
@@ -46,4 +50,8 @@ __all__ = [
     "strftime",
     "strptime_to_utc",
     "write_message",
+    "write_record",
+    "write_schema",
+    "write_state",
+    "write_version",
 ]

--- a/singer_sdk/singerlib/encoding/simple.py
+++ b/singer_sdk/singerlib/encoding/simple.py
@@ -6,7 +6,7 @@ import json.decoder
 import logging
 import sys
 import typing as t
-from collections.abc import Mapping  # noqa: TC003
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 
@@ -27,6 +27,9 @@ if t.TYPE_CHECKING:
         from typing import Self  # noqa: ICN003
     else:
         from typing_extensions import Self
+
+InputKeys: t.TypeAlias = Sequence[str]
+Schema: t.TypeAlias = Mapping[str, t.Any]
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +154,7 @@ class RecordMessage(Message):
             self.time_extracted = self.time_extracted.astimezone(timezone.utc)
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, init=False)
 class SchemaMessage(Message):
     """Singer schema message."""
 
@@ -167,9 +170,31 @@ class SchemaMessage(Message):
     bookmark_properties: list[str] | None = None
     """The bookmark properties."""
 
-    def __post_init__(self) -> None:
-        """Post-init processing."""
+    def __init__(
+        self,
+        stream: str,
+        schema: Schema,
+        key_properties: InputKeys | None = None,
+        bookmark_properties: InputKeys | None = None,
+    ) -> None:
+        """Initialize schema object."""
         self.type = SingerMessageType.SCHEMA
+        self.stream = stream
+        self.schema = schema
+        self.key_properties = (
+            None
+            if key_properties is None
+            else [key_properties]
+            if isinstance(key_properties, str)
+            else [*key_properties]
+        )
+        self.bookmark_properties = (
+            None
+            if bookmark_properties is None
+            else [bookmark_properties]
+            if isinstance(bookmark_properties, str)
+            else [*bookmark_properties]
+        )
 
 
 @dataclass(slots=True)

--- a/singer_sdk/singerlib/encoding/simple.py
+++ b/singer_sdk/singerlib/encoding/simple.py
@@ -164,10 +164,10 @@ class SchemaMessage(Message):
     schema: Mapping[str, t.Any]
     """The schema definition."""
 
-    key_properties: list[str] | None = None
+    key_properties: tuple[str, ...] | None = None
     """The key properties."""
 
-    bookmark_properties: list[str] | None = None
+    bookmark_properties: tuple[str, ...] | None = None
     """The bookmark properties."""
 
     def __init__(
@@ -184,16 +184,16 @@ class SchemaMessage(Message):
         self.key_properties = (
             None
             if key_properties is None
-            else [key_properties]
+            else (key_properties,)
             if isinstance(key_properties, str)
-            else [*key_properties]
+            else tuple(key_properties)
         )
         self.bookmark_properties = (
             None
             if bookmark_properties is None
-            else [bookmark_properties]
+            else (bookmark_properties,)
             if isinstance(bookmark_properties, str)
-            else [*bookmark_properties]
+            else tuple(bookmark_properties)
         )
 
 

--- a/singer_sdk/singerlib/encoding/simple.py
+++ b/singer_sdk/singerlib/encoding/simple.py
@@ -28,7 +28,6 @@ if t.TYPE_CHECKING:
     else:
         from typing_extensions import Self
 
-InputKeys: t.TypeAlias = Sequence[str]
 Schema: t.TypeAlias = Mapping[str, t.Any]
 
 logger = logging.getLogger(__name__)
@@ -161,7 +160,7 @@ class SchemaMessage(Message):
     stream: str
     """The stream name."""
 
-    schema: Mapping[str, t.Any]
+    schema: Schema
     """The schema definition."""
 
     key_properties: tuple[str, ...] | None = None
@@ -174,8 +173,8 @@ class SchemaMessage(Message):
         self,
         stream: str,
         schema: Schema,
-        key_properties: InputKeys | None = None,
-        bookmark_properties: InputKeys | None = None,
+        key_properties: Sequence[str] | None = None,
+        bookmark_properties: Sequence[str] | None = None,
     ) -> None:
         """Initialize schema object."""
         self.type = SingerMessageType.SCHEMA

--- a/singer_sdk/singerlib/encoding/simple.py
+++ b/singer_sdk/singerlib/encoding/simple.py
@@ -79,7 +79,7 @@ class RecordMessage(Message):
     stream: str
     """The stream name."""
 
-    record: dict[str, t.Any]
+    record: Mapping[str, t.Any]
     """The record data."""
 
     version: int | None = None
@@ -90,7 +90,7 @@ class RecordMessage(Message):
 
     @classmethod
     @override
-    def from_dict(cls: type[RecordMessage], data: dict[str, t.Any]) -> RecordMessage:
+    def from_dict(cls: type[RecordMessage], data: Mapping[str, t.Any]) -> RecordMessage:
         """Create a record message from a dictionary.
 
         This overrides the default conversion logic, since it uses unnecessary
@@ -158,28 +158,18 @@ class SchemaMessage(Message):
     stream: str
     """The stream name."""
 
-    schema: dict[str, t.Any]
+    schema: Mapping[str, t.Any]
     """The schema definition."""
 
-    key_properties: t.Sequence[str] | None = None
+    key_properties: list[str] | None = None
     """The key properties."""
 
     bookmark_properties: list[str] | None = None
     """The bookmark properties."""
 
     def __post_init__(self) -> None:
-        """Post-init processing.
-
-        Raises:
-            ValueError: If bookmark_properties is not a string or list of strings.
-        """
+        """Post-init processing."""
         self.type = SingerMessageType.SCHEMA
-
-        if isinstance(self.bookmark_properties, (str, bytes)):
-            self.bookmark_properties = [self.bookmark_properties]  # type: ignore[unreachable]
-        if self.bookmark_properties and not isinstance(self.bookmark_properties, list):
-            msg = "bookmark_properties must be a string or list of strings"  # type: ignore[unreachable]
-            raise ValueError(msg)
 
 
 @dataclass(slots=True)

--- a/singer_sdk/singerlib/messages.py
+++ b/singer_sdk/singerlib/messages.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import typing as t
+
 from .encoding import SimpleSingerWriter as SingerWriter
 from .encoding.base import SingerMessageType
 from .encoding.simple import (
@@ -13,6 +15,10 @@ from .encoding.simple import (
     exclude_null_dict,
 )
 
+if t.TYPE_CHECKING:
+    from collections.abc import Mapping
+    from datetime import datetime
+
 __all__ = [
     "ActivateVersionMessage",
     "Message",
@@ -23,8 +29,81 @@ __all__ = [
     "exclude_null_dict",
     "format_message",
     "write_message",
+    "write_record",
+    "write_schema",
+    "write_state",
+    "write_version",
 ]
 
 WRITER = SingerWriter()
 format_message = WRITER.format_message
 write_message = WRITER.write_message
+
+
+def write_record(
+    stream_name: str,
+    record: dict[str, t.Any],
+    *,
+    version: int | None = None,
+    time_extracted: datetime | None = None,
+) -> None:
+    """Write a RECORD message to stdout.
+
+    Args:
+        stream_name: The stream name.
+        record: The record data.
+        version: The record version.
+        time_extracted: The time the record was extracted.
+    """
+    write_message(
+        RecordMessage(
+            stream=stream_name,
+            record=record,
+            version=version,
+            time_extracted=time_extracted,
+        ),
+    )
+
+
+def write_schema(
+    stream_name: str,
+    schema: dict[str, t.Any],
+    *,
+    key_properties: list[str] | None = None,
+    bookmark_properties: list[str] | None = None,
+) -> None:
+    """Write a SCHEMA message to stdout.
+
+    Args:
+        stream_name: The stream name.
+        schema: The JSON schema.
+        key_properties: The key properties.
+        bookmark_properties: The bookmark properties.
+    """
+    write_message(
+        SchemaMessage(
+            stream=stream_name,
+            schema=schema,
+            key_properties=key_properties,
+            bookmark_properties=bookmark_properties,
+        ),
+    )
+
+
+def write_state(value: Mapping[str, t.Any]) -> None:
+    """Write a STATE message to stdout.
+
+    Args:
+        value: The state value.
+    """
+    write_message(StateMessage(value=value))
+
+
+def write_version(stream_name: str, version: int) -> None:
+    """Write an ACTIVATE_VERSION message to stdout.
+
+    Args:
+        stream_name: The stream name.
+        version: The version to activate.
+    """
+    write_message(ActivateVersionMessage(stream=stream_name, version=version))

--- a/singer_sdk/singerlib/messages.py
+++ b/singer_sdk/singerlib/messages.py
@@ -16,7 +16,7 @@ from .encoding.simple import (
 )
 
 if t.TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
     from datetime import datetime
 
 __all__ = [
@@ -42,7 +42,7 @@ write_message = WRITER.write_message
 
 def write_record(
     stream_name: str,
-    record: dict[str, t.Any],
+    record: Mapping[str, t.Any],
     *,
     version: int | None = None,
     time_extracted: datetime | None = None,
@@ -67,10 +67,10 @@ def write_record(
 
 def write_schema(
     stream_name: str,
-    schema: dict[str, t.Any],
+    schema: Mapping[str, t.Any],
     *,
-    key_properties: list[str] | None = None,
-    bookmark_properties: list[str] | None = None,
+    key_properties: Sequence[str] | None = None,
+    bookmark_properties: Sequence[str] | None = None,
 ) -> None:
     """Write a SCHEMA message to stdout.
 
@@ -84,8 +84,20 @@ def write_schema(
         SchemaMessage(
             stream=stream_name,
             schema=schema,
-            key_properties=key_properties,
-            bookmark_properties=bookmark_properties,
+            key_properties=(
+                None
+                if key_properties is None
+                else [key_properties]
+                if isinstance(key_properties, str)
+                else [*key_properties]
+            ),
+            bookmark_properties=(
+                None
+                if bookmark_properties is None
+                else [bookmark_properties]
+                if isinstance(bookmark_properties, str)
+                else [*bookmark_properties]
+            ),
         ),
     )
 

--- a/singer_sdk/singerlib/messages.py
+++ b/singer_sdk/singerlib/messages.py
@@ -84,20 +84,8 @@ def write_schema(
         SchemaMessage(
             stream=stream_name,
             schema=schema,
-            key_properties=(
-                None
-                if key_properties is None
-                else [key_properties]
-                if isinstance(key_properties, str)
-                else [*key_properties]
-            ),
-            bookmark_properties=(
-                None
-                if bookmark_properties is None
-                else [bookmark_properties]
-                if isinstance(bookmark_properties, str)
-                else [*bookmark_properties]
-            ),
+            key_properties=key_properties,
+            bookmark_properties=bookmark_properties,
         ),
     )
 

--- a/tests/singerlib/test_messages.py
+++ b/tests/singerlib/test_messages.py
@@ -138,16 +138,6 @@ def test_schema_messages_string_bookmark_properties():
     assert schema.bookmark_properties == ["id"]
 
 
-def test_bookmark_properties_not_string_or_list():
-    """Check that schema message's bookmark_properties must be a string or list."""
-    with pytest.raises(ValueError, match="must be a string or list"):
-        singer.SchemaMessage(
-            stream="test",
-            schema={"type": "object", "properties": {"id": {"type": "integer"}}},
-            bookmark_properties=1,
-        )
-
-
 def test_state_message():
     state = singer.StateMessage(value={"bookmarks": {"test": {"id": 1}}})
     assert state.value == {"bookmarks": {"test": {"id": 1}}}

--- a/tests/singerlib/test_messages.py
+++ b/tests/singerlib/test_messages.py
@@ -179,9 +179,24 @@ def test_write_record_write_schema_write_state(capsys: pytest.CaptureFixture):
     singer.write_state({"bookmarks": {}})
 
     lines = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
-    assert [line["type"] for line in lines] == [
-        "SCHEMA",
-        "ACTIVATE_VERSION",
-        "RECORD",
-        "STATE",
-    ]
+
+    assert lines[0] == {
+        "stream": "s",
+        "type": "SCHEMA",
+        "schema": {"properties": {"a": {"type": "integer"}}},
+    }
+    assert lines[1] == {
+        "stream": "s",
+        "type": "ACTIVATE_VERSION",
+        "version": 123,
+    }
+    assert lines[2] == {
+        "stream": "s",
+        "type": "RECORD",
+        "record": {"a": 1},
+        "version": 123,
+    }
+    assert lines[3] == {
+        "type": "STATE",
+        "value": {"bookmarks": {}},
+    }

--- a/tests/singerlib/test_messages.py
+++ b/tests/singerlib/test_messages.py
@@ -174,29 +174,82 @@ def test_activate_version_message():
 
 def test_write_record_write_schema_write_state(capsys: pytest.CaptureFixture):
     singer.write_schema("s", {"properties": {"a": {"type": "integer"}}})
+    singer.write_schema(
+        "s",
+        {"properties": {"a": {"type": "integer"}}},
+        key_properties=["a"],
+    )
+    singer.write_schema(
+        "s",
+        {"properties": {"updated_at": {"type": "string", "format": "date-time"}}},
+        bookmark_properties=["updated_at"],
+    )
+
     singer.write_version("s", 123)
-    singer.write_record("s", {"a": 1}, version=123)
+
+    singer.write_record("s", {"a": 1})
+    singer.write_record("s", {"a": 2}, version=123)
+    singer.write_record(
+        "s",
+        {"a": 3},
+        time_extracted=datetime.datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
     singer.write_state({"bookmarks": {}})
 
     lines = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
 
-    assert lines[0] == {
-        "stream": "s",
-        "type": "SCHEMA",
-        "schema": {"properties": {"a": {"type": "integer"}}},
-    }
-    assert lines[1] == {
+    assert lines[0:3] == [
+        {
+            "stream": "s",
+            "type": "SCHEMA",
+            "schema": {"properties": {"a": {"type": "integer"}}},
+        },
+        {
+            "stream": "s",
+            "type": "SCHEMA",
+            "schema": {"properties": {"a": {"type": "integer"}}},
+            "key_properties": ["a"],
+        },
+        {
+            "stream": "s",
+            "type": "SCHEMA",
+            "schema": {
+                "properties": {
+                    "updated_at": {"type": "string", "format": "date-time"},
+                }
+            },
+            "bookmark_properties": ["updated_at"],
+        },
+    ]
+
+    assert lines[3] == {
         "stream": "s",
         "type": "ACTIVATE_VERSION",
         "version": 123,
     }
-    assert lines[2] == {
-        "stream": "s",
-        "type": "RECORD",
-        "record": {"a": 1},
-        "version": 123,
-    }
-    assert lines[3] == {
+
+    assert lines[4:7] == [
+        {
+            "stream": "s",
+            "type": "RECORD",
+            "record": {"a": 1},
+        },
+        {
+            "stream": "s",
+            "type": "RECORD",
+            "record": {"a": 2},
+            "version": 123,
+        },
+        {
+            "stream": "s",
+            "type": "RECORD",
+            "record": {"a": 3},
+            "time_extracted": "2026-01-01T00:00:00+00:00",
+        },
+    ]
+
+    assert lines[-1] == {
         "type": "STATE",
         "value": {"bookmarks": {}},
     }

--- a/tests/singerlib/test_messages.py
+++ b/tests/singerlib/test_messages.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import io
+import json
 from contextlib import redirect_stdout
 
 import pytest
@@ -169,3 +170,18 @@ def test_activate_version_message():
     }
 
     assert singer.ActivateVersionMessage.from_dict(version.to_dict()) == version
+
+
+def test_write_record_write_schema_write_state(capsys: pytest.CaptureFixture):
+    singer.write_schema("s", {"properties": {"a": {"type": "integer"}}})
+    singer.write_version("s", 123)
+    singer.write_record("s", {"a": 1}, version=123)
+    singer.write_state({"bookmarks": {}})
+
+    lines = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [line["type"] for line in lines] == [
+        "SCHEMA",
+        "ACTIVATE_VERSION",
+        "RECORD",
+        "STATE",
+    ]

--- a/tests/singerlib/test_messages.py
+++ b/tests/singerlib/test_messages.py
@@ -135,7 +135,7 @@ def test_schema_messages_string_bookmark_properties():
         schema={"type": "object", "properties": {"id": {"type": "integer"}}},
         bookmark_properties="id",
     )
-    assert schema.bookmark_properties == ["id"]
+    assert schema.bookmark_properties == ("id",)
 
 
 def test_state_message():


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Add convenience helpers in singerlib for writing Singer RECORD, SCHEMA, STATE, and ACTIVATE_VERSION messages and align schema message types with more general mappings/sequences.

New Features:
- Expose write_record, write_schema, write_state, and write_version helper functions from singerlib to simplify emitting Singer messages.

Enhancements:
- Relax type constraints on Singer message payloads to accept generic mappings/sequences and normalize schema key and bookmark properties to tuples instead of lists.

Tests:
- Add integration-style tests verifying the new write_* helpers emit correctly formatted JSON lines and adjust schema message tests to match the updated bookmark_properties type.