### PR TITLE
fix: Normalize nullable-only `anyOf` members in OpenAPI specs

### DIFF
--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -48,7 +48,6 @@ if t.TYPE_CHECKING:
 
 Schema: t.TypeAlias = dict[str, t.Any]
 
-
 _TKey = TypeVar("_TKey", bound=t.Hashable, default=str)
 _TStream = TypeVar("_TStream", bound="Stream", default="Stream")
 
@@ -407,7 +406,12 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
         if "oneOf" in result:
             result = self.handle_one_of(result)
         if "anyOf" in result:
-            result["anyOf"] = [self.normalize_schema(s) for s in result["anyOf"]]
+            result["anyOf"] = list(
+                filter(
+                    bool,
+                    (self.normalize_schema(member) for member in result["anyOf"]),
+                )
+            )
 
         types_raw = result.get("type", [])
         types = [types_raw] if isinstance(types_raw, str) else types_raw

--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -312,7 +312,7 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
         schema.pop("pattern", None)
         return schema
 
-    def handle_one_of(self, schema: Schema) -> Schema:
+    def _handle_one_of(self, schema: Schema) -> Schema:
         """Handle oneOf constructs in a JSON schema.
 
         - Single element: unwrap.
@@ -344,21 +344,22 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
 
         return {**rest, "oneOf": [self.normalize_schema(s) for s in subschemas]}
 
-    def handle_all_of(self, subschemas: list[Schema]) -> Schema:  # noqa: PLR6301
+    def _handle_all_of(self, schema: Schema) -> Schema:
         """Handle allOf constructs in a JSON schema.
 
         Args:
-            subschemas: A list of JSON schemas.
+            schema: A JSON schema containing an ``allOf`` keyword.
 
         Returns:
             A merged JSON schema.
         """
+        subschemas = schema["allOf"]
         if not subschemas:
             return {}
 
         # If the allOf array has only one element, just flatten it.
         if len(subschemas) == 1:
-            return subschemas[0]
+            return subschemas[0]  # type: ignore[no-any-return]
 
         # TODO: merge subschemas:
         # - Taking the most restrictive constraints for each property
@@ -373,25 +374,26 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
                 else:
                     result[key] = value
 
-        return result
+        return self.normalize_schema(result)
 
-    def handle_any_of(self, subschemas: list[Schema]) -> list[Schema]:
+    def _handle_any_of(self, schema: Schema) -> Schema:
         """Handle anyOf constructs in a JSON schema.
 
         Args:
-            subschemas: A list of JSON schemas.
+            schema: A JSON schema containing an ``anyOf`` keyword.
 
         Returns:
             A processed anyOf list of schemas.
         """
+        subschemas = schema["anyOf"]
         result: list[Schema] = []
-        for schema in subschemas:
-            if schema.get("nullable") and "type" not in schema:
-                result.append(self.normalize_schema({"type": "null", **schema}))
+        for subschema in subschemas:
+            if subschema.get("nullable") and "type" not in subschema:
+                result.append(self.normalize_schema({"type": "null", **subschema}))
             else:
-                result.append(self.normalize_schema(schema))
+                result.append(self.normalize_schema(subschema))
 
-        return result
+        return {"anyOf": result}
 
     def normalize_schema(
         self,
@@ -420,11 +422,11 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
             result["items"] = self.handle_array_items(items)
 
         if "allOf" in result:
-            result = self.normalize_schema(self.handle_all_of(result["allOf"]))
+            result = self._handle_all_of(result)
         if "oneOf" in result:
-            result = self.handle_one_of(result)
+            result = self._handle_one_of(result)
         if "anyOf" in result:
-            result["anyOf"] = self.handle_any_of(result["anyOf"])
+            result = self._handle_any_of(result)
 
         types_raw = result.get("type", [])
         types = [types_raw] if isinstance(types_raw, str) else types_raw

--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -388,7 +388,7 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
         for schema in subschemas:
             if schema.get("nullable"):
                 schema.pop("nullable")
-                result.append({"type": ["null"]}, **schema)
+                result.append({"type": ["null"], **schema})
             else:
                 result.append(self.normalize_schema(schema))
 

--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -375,6 +375,24 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
 
         return result
 
+    def handle_any_of(self, subschemas: list[Schema]) -> list[Schema]:
+        """Handle anyOf constructs in a JSON schema.
+
+        Args:
+            subschemas: A list of JSON schemas.
+
+        Returns:
+            A processed anyOf list of schemas.
+        """
+        result: list[Schema] = []
+        for schema in subschemas:
+            if schema == {"nullable": True}:
+                result.append({"type": ["null"]})
+            else:
+                result.append(self.normalize_schema(schema))
+
+        return result
+
     def normalize_schema(
         self,
         schema: Schema,
@@ -406,12 +424,7 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
         if "oneOf" in result:
             result = self.handle_one_of(result)
         if "anyOf" in result:
-            result["anyOf"] = list(
-                filter(
-                    bool,
-                    (self.normalize_schema(member) for member in result["anyOf"]),
-                )
-            )
+            result["anyOf"] = self.handle_any_of(result["anyOf"])
 
         types_raw = result.get("type", [])
         types = [types_raw] if isinstance(types_raw, str) else types_raw

--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -386,9 +386,8 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
         """
         result: list[Schema] = []
         for schema in subschemas:
-            if schema.get("nullable"):
-                schema.pop("nullable")
-                result.append({"type": ["null"], **schema})
+            if schema.get("nullable") and "type" not in schema:
+                result.append(self.normalize_schema({"type": "null", **schema}))
             else:
                 result.append(self.normalize_schema(schema))
 

--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -386,8 +386,9 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
         """
         result: list[Schema] = []
         for schema in subschemas:
-            if schema == {"nullable": True}:
-                result.append({"type": ["null"]})
+            if schema.get("nullable"):
+                schema.pop("nullable")
+                result.append({"type": ["null"]}, **schema)
             else:
                 result.append(self.normalize_schema(schema))
 

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -892,8 +892,11 @@ class TestOpenAPISchemaNormalization:
         assert len(schema["anyOf"]) == 3
 
         normalized = source.preprocess_schema(schema)
-        assert len(normalized["anyOf"]) == 2
-        assert all(elem["type"] == ["object", "null"] for elem in normalized["anyOf"])
+        assert [elem["type"] for elem in normalized["anyOf"]] == [
+            ["object", "null"],
+            ["object", "null"],
+            ["null"],
+        ]
 
     def test_normalize_all_of_no_elements(self, source: OpenAPISchema):
         """Test that an empty allOf is normalized to an empty schema."""

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -749,6 +749,13 @@ class TestOpenAPISchemaNormalization:
                             {"type": "object", "properties": {"z": {"type": "string"}}},
                         ],
                     },
+                    "AnyOfNullable": {
+                        "anyOf": [
+                            {"type": "object", "properties": {"x": {"type": "string"}}},
+                            {"type": "object", "properties": {"y": {"type": "string"}}},
+                            {"nullable": True},
+                        ],
+                    },
                     "AllOfNoElements": {
                         "allOf": [],
                     },
@@ -877,6 +884,15 @@ class TestOpenAPISchemaNormalization:
         assert all(elem["type"] == "object" for elem in schema["anyOf"])
 
         normalized = source.preprocess_schema(schema)
+        assert all(elem["type"] == ["object", "null"] for elem in normalized["anyOf"])
+
+    def test_normalize_any_of_nullable(self, source: OpenAPISchema):
+        """Test that anyOf with nullable variants are correctly normalized."""
+        schema = source.fetch_schema("AnyOfNullable")
+        assert len(schema["anyOf"]) == 3
+
+        normalized = source.preprocess_schema(schema)
+        assert len(normalized["anyOf"]) == 2
         assert all(elem["type"] == ["object", "null"] for elem in normalized["anyOf"])
 
     def test_normalize_all_of_no_elements(self, source: OpenAPISchema):

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -753,7 +753,7 @@ class TestOpenAPISchemaNormalization:
                         "anyOf": [
                             {"type": "object", "properties": {"x": {"type": "string"}}},
                             {"type": "object", "properties": {"y": {"type": "string"}}},
-                            {"nullable": True},
+                            {"nullable": True, "description": "Makes this nullable"},
                         ],
                     },
                     "AllOfNoElements": {
@@ -897,6 +897,7 @@ class TestOpenAPISchemaNormalization:
             ["object", "null"],
             ["null"],
         ]
+        assert "description" in normalized["anyOf"][-1]
 
     def test_normalize_all_of_no_elements(self, source: OpenAPISchema):
         """Test that an empty allOf is normalized to an empty schema."""

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -895,7 +895,7 @@ class TestOpenAPISchemaNormalization:
         assert [elem["type"] for elem in normalized["anyOf"]] == [
             ["object", "null"],
             ["object", "null"],
-            ["null"],
+            "null",
         ]
         assert "description" in normalized["anyOf"][-1]
 

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -756,6 +756,13 @@ class TestOpenAPISchemaNormalization:
                             {"nullable": True, "description": "Makes this nullable"},
                         ],
                     },
+                    "AnyOfNullableWithRef": {
+                        "anyOf": [
+                            {"type": "object", "properties": {"x": {"type": "string"}}},
+                            {"type": "object", "properties": {"y": {"type": "string"}}},
+                            {"nullable": True, "$ref": "#/components/schemas/Status"},
+                        ],
+                    },
                     "AllOfNoElements": {
                         "allOf": [],
                     },
@@ -786,6 +793,7 @@ class TestOpenAPISchemaNormalization:
                     "Status": {
                         "type": "string",
                         "enum": ["active", "inactive", "pending"],
+                        "description": "A status",
                     },
                     "Priority": {
                         "type": "integer",
@@ -900,6 +908,22 @@ class TestOpenAPISchemaNormalization:
         assert normalized["anyOf"][-1] == {
             "type": "null",
             "description": "Makes this nullable",
+        }
+
+    def test_normalize_any_of_nullable_with_ref(self, source: OpenAPISchema):
+        """Test that anyOf with nullable with $ref variants are correctly normalized."""
+        schema = source.fetch_schema("AnyOfNullableWithRef")
+        assert len(schema["anyOf"]) == 3
+
+        normalized = source.preprocess_schema(schema)
+        assert [elem["type"] for elem in normalized["anyOf"]] == [
+            ["object", "null"],
+            ["object", "null"],
+            ["string", "null"],
+        ]
+        assert normalized["anyOf"][-1] == {
+            "type": ["string", "null"],
+            "description": "A status",
         }
 
     def test_normalize_all_of_no_elements(self, source: OpenAPISchema):

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -897,7 +897,10 @@ class TestOpenAPISchemaNormalization:
             ["object", "null"],
             "null",
         ]
-        assert "description" in normalized["anyOf"][-1]
+        assert normalized["anyOf"][-1] == {
+            "type": "null",
+            "description": "Makes this nullable",
+        }
 
     def test_normalize_all_of_no_elements(self, source: OpenAPISchema):
         """Test that an empty allOf is normalized to an empty schema."""


### PR DESCRIPTION
## Summary by Sourcery

Normalize OpenAPI `anyOf` schemas containing nullable-only members and add coverage for this behavior.

Bug Fixes:
- Ensure `anyOf` variants that are only marked `nullable` without an explicit `type` are normalized into explicit `null` schemas alongside other normalized members.

Enhancements:
- Introduce a dedicated `handle_any_of` helper to centralize and standardize normalization of `anyOf` subschemas.

Tests:
- Add OpenAPI fixture and tests verifying normalization of `anyOf` schemas with nullable variants, including preservation of descriptions.