### PR TITLE
fix: Raise EmptySchemaTypeError for empty date schema types

### DIFF
--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -189,7 +189,8 @@ def is_date_or_datetime_type(type_dict: dict) -> bool:
         True if date or date-time, else False.
 
     Raises:
-        ValueError: If type is empty or null.
+        EmptySchemaTypeError: If type is empty.
+        ValueError: If type is otherwise not valid.
     """
     if not type_dict:
         raise EmptySchemaTypeError

--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -191,6 +191,9 @@ def is_date_or_datetime_type(type_dict: dict) -> bool:
     Raises:
         ValueError: If type is empty or null.
     """
+    if not type_dict:
+        raise EmptySchemaTypeError
+
     if "anyOf" in type_dict:
         return any(is_date_or_datetime_type(option) for option in type_dict["anyOf"])
 

--- a/tests/core/test_jsonschema_helpers.py
+++ b/tests/core/test_jsonschema_helpers.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 
 import pytest
 
+from singer_sdk.exceptions import EmptySchemaTypeError
 from singer_sdk.helpers._typing import (
     JSONSCHEMA_ANNOTATION_SECRET,
     JSONSCHEMA_ANNOTATION_WRITEONLY,
@@ -1177,6 +1178,11 @@ def test_is_datetime_type(schema, expected):
 )
 def test_is_date_or_datetime_type(schema, expected):
     assert is_date_or_datetime_type(schema) == expected
+
+
+def test_is_date_or_datetime_type_empty_schema():
+    with pytest.raises(EmptySchemaTypeError):
+        assert is_date_or_datetime_type({"oneOf": [{}]})
 
 
 def test_is_string_array_type():

--- a/tests/core/test_jsonschema_helpers.py
+++ b/tests/core/test_jsonschema_helpers.py
@@ -1182,7 +1182,7 @@ def test_is_date_or_datetime_type(schema, expected):
 
 def test_is_date_or_datetime_type_empty_schema():
     with pytest.raises(EmptySchemaTypeError):
-        assert is_date_or_datetime_type({"oneOf": [{}]})
+        is_date_or_datetime_type({"oneOf": [{}]})
 
 
 def test_is_string_array_type():


### PR DESCRIPTION
## Summary by Sourcery

Raise a specific EmptySchemaTypeError when date-type schemas are empty and add coverage for this behavior.

Bug Fixes:
- Ensure is_date_or_datetime_type raises EmptySchemaTypeError for empty schema types instead of a generic ValueError.

Tests:
- Add a unit test verifying that is_date_or_datetime_type raises EmptySchemaTypeError when invoked with an effectively empty date schema.