### PR TITLE
fix: Preserve other OpenAPI schema keywords when normalizing `anyOf` members

### DIFF
--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -393,7 +393,8 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
             else:
                 result.append(self.normalize_schema(subschema))
 
-        return {"anyOf": result}
+        schema["anyOf"] = result
+        return schema
 
     def normalize_schema(
         self,

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -749,6 +749,7 @@ class TestOpenAPISchemaNormalization:
                             {"type": "object", "properties": {"y": {"type": "string"}}},
                             {"type": "object", "properties": {"z": {"type": "string"}}},
                         ],
+                        "description": "One of a few options",
                     },
                     "AnyOfNullable": {
                         "anyOf": [
@@ -894,6 +895,7 @@ class TestOpenAPISchemaNormalization:
 
         normalized = source.preprocess_schema(schema)
         assert all(elem["type"] == ["object", "null"] for elem in normalized["anyOf"])
+        assert normalized["description"] == "One of a few options"
 
     def test_normalize_any_of_nullable(self, source: OpenAPISchema):
         """Test that anyOf with nullable variants are correctly normalized."""


### PR DESCRIPTION
## Summary by Sourcery

Preserve existing OpenAPI schema metadata when normalizing `anyOf` members.

Bug Fixes:
- Ensure normalization of `anyOf` schemas retains other top-level keywords such as descriptions.

Tests:
- Extend `anyOf` normalization tests to assert that non-`anyOf` keywords like `description` are preserved.