### PR TITLE
fix(targets): Catch `TypeError` in addition to `ValueError` when parsing timestamps in received records

### DIFF
--- a/singer_sdk/helpers/_typing.py
+++ b/singer_sdk/helpers/_typing.py
@@ -248,18 +248,18 @@ def handle_invalid_timestamp_in_record(
     """Apply treatment or raise an error for invalid time values."""
     treatment = treatment or conform.DatetimeErrorTreatmentEnum.ERROR
     msg = (
-        f"Could not parse value '{invalid_value}' for "
-        f"field '{':'.join(key_breadcrumb)}'."
+        f"Could not parse value '{invalid_value!r}' for "
+        f"field '{'.'.join(key_breadcrumb)}'"
     )
     if treatment == conform.DatetimeErrorTreatmentEnum.MAX:
-        logger.warning("%s. Replacing with MAX value.\n%s\n", msg, ex)
+        logger.warning("%s: %s. Replacing with MAX value.", msg, ex)
         return _MAX_TIMESTAMP if datelike_typename != "time" else _MAX_TIME
 
     if treatment == conform.DatetimeErrorTreatmentEnum.NULL:
-        logger.warning("%s. Replacing with NULL.\n%s\n", msg, ex)
+        logger.warning("%s: %s. Replacing with NULL.", msg, ex)
         return None
 
-    raise ValueError(msg)
+    raise ValueError(msg) from ex
 
 
 def is_string_array_type(type_dict: dict) -> bool:

--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -606,7 +606,7 @@ class Sink(abc.ABC):  # noqa: PLR0904
                             date_val = date_fromisoformat(date_val)
                         else:
                             date_val = datetime_fromisoformat(date_val)
-                except ValueError as ex:
+                except (ValueError, TypeError) as ex:
                     date_val = handle_invalid_timestamp_in_record(
                         record,
                         [key],

--- a/tests/core/test_record_typing.py
+++ b/tests/core/test_record_typing.py
@@ -151,7 +151,8 @@ def test_handle_invalid_timestamp_in_record(
     record = {"created_at": value}
     key_breadcrumb = ["created_at"]
     datelike_typename = "datetime"
-    ex = ValueError("invalid timestamp")
+    value_err = ValueError("invalid timestamp")
+    type_err = TypeError("can not convert to timestamp")
     logger = logging.getLogger("test-logger")
 
     handle_val = partial(
@@ -160,7 +161,6 @@ def test_handle_invalid_timestamp_in_record(
         key_breadcrumb=key_breadcrumb,
         invalid_value=value,
         datelike_typename=datelike_typename,
-        ex=ex,
         logger=logger,
     )
 
@@ -168,19 +168,34 @@ def test_handle_invalid_timestamp_in_record(
         subtests.test("default treatment"),
         pytest.raises(ValueError, match=r"Could not parse value.*"),
     ):
-        handle_val(treatment=None)
+        handle_val(treatment=None, ex=value_err)
 
     with (
         subtests.test("error"),
-        pytest.raises(ValueError, match=r"Could not parse value.*"),
+        pytest.raises(ValueError, match=r"Could not parse value.*") as exc_info,
     ):
-        handle_val(treatment=DatetimeErrorTreatmentEnum.ERROR)
+        handle_val(treatment=DatetimeErrorTreatmentEnum.ERROR, ex=value_err)
+
+    assert isinstance(exc_info.value.__cause__, ValueError)
+    assert str(exc_info.value.__cause__) == "invalid timestamp"
+
+    with (
+        subtests.test("error"),
+        pytest.raises(ValueError, match=r"Could not parse value.*") as exc_info,
+    ):
+        handle_val(treatment=DatetimeErrorTreatmentEnum.ERROR, ex=type_err)
+
+    assert isinstance(exc_info.value.__cause__, TypeError)
+    assert str(exc_info.value.__cause__) == "can not convert to timestamp"
 
     with (
         subtests.test("max (datetime)"),
         caplog.at_level(logging.INFO, logger=logger.name),
     ):
-        assert isinstance(handle_val(treatment=DatetimeErrorTreatmentEnum.MAX), str)
+        assert isinstance(
+            handle_val(treatment=DatetimeErrorTreatmentEnum.MAX, ex=value_err),
+            str,
+        )
 
     with (
         subtests.test("max (time)"),
@@ -190,6 +205,7 @@ def test_handle_invalid_timestamp_in_record(
             handle_val(
                 treatment=DatetimeErrorTreatmentEnum.MAX,
                 datelike_typename="time",
+                ex=value_err,
             ),
             str,
         )
@@ -199,5 +215,11 @@ def test_handle_invalid_timestamp_in_record(
         subtests.test("null"),
         caplog.at_level(logging.INFO, logger=logger.name),
     ):
-        assert handle_val(treatment=DatetimeErrorTreatmentEnum.NULL) is None
+        assert (
+            handle_val(
+                treatment=DatetimeErrorTreatmentEnum.NULL,
+                ex=value_err,
+            )
+            is None
+        )
         assert "Replacing with NULL." in caplog.text


### PR DESCRIPTION
## Summary by Sourcery

Handle and report invalid timestamp parsing errors more robustly when processing records.

Bug Fixes:
- Treat both ValueError and TypeError as invalid timestamp errors when parsing record timestamps and surface them consistently via handle_invalid_timestamp_in_record.

Enhancements:
- Improve error and log messages for invalid timestamp values and chain the original parsing exception as the cause.

Tests:
- Expand invalid timestamp handling tests to cover TypeError inputs, exception chaining, and updated logging behavior.