### PR TITLE
fix: Retain returned OAuth refresh tokens

### DIFF
--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -639,8 +639,7 @@ class OAuthAuthenticator(APIAuthenticatorBase):
 
         token_json = token_response.json()
         self.access_token = token_json["access_token"]
-        refresh_token = token_json.get("refresh_token")
-        if refresh_token:
+        if refresh_token := token_json.get("refresh_token"):
             self.refresh_token = refresh_token
         expiration = token_json.get("expires_in", self._default_expiration)
         self.expires_in = int(expiration) if expiration else None

--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -640,7 +640,7 @@ class OAuthAuthenticator(APIAuthenticatorBase):
         token_json = token_response.json()
         self.access_token = token_json["access_token"]
         refresh_token = token_json.get("refresh_token")
-        if isinstance(refresh_token, str) and refresh_token:
+        if refresh_token:
             self.refresh_token = refresh_token
         expiration = token_json.get("expires_in", self._default_expiration)
         self.expires_in = int(expiration) if expiration else None

--- a/singer_sdk/authenticators.py
+++ b/singer_sdk/authenticators.py
@@ -606,7 +606,7 @@ class OAuthAuthenticator(APIAuthenticatorBase):
 
     # Authentication and refresh
     def update_access_token(self) -> None:
-        """Update `access_token` along with: `last_refreshed` and `expires_in`.
+        """Update tokens along with: `last_refreshed` and `expires_in`.
 
         Raises:
             AuthenticationError: When OAuth login fails.
@@ -639,6 +639,9 @@ class OAuthAuthenticator(APIAuthenticatorBase):
 
         token_json = token_response.json()
         self.access_token = token_json["access_token"]
+        refresh_token = token_json.get("refresh_token")
+        if isinstance(refresh_token, str) and refresh_token:
+            self.refresh_token = refresh_token
         expiration = token_json.get("expires_in", self._default_expiration)
         self.expires_in = int(expiration) if expiration else None
         if self.expires_in is None:

--- a/tests/core/rest/test_authenticators.py
+++ b/tests/core/rest/test_authenticators.py
@@ -233,6 +233,36 @@ def test_oauth_authenticator_token_expiry_handling(
         assert not authenticator.expires_in or not authenticator.is_token_valid()
 
 
+@pytest.mark.parametrize(
+    "response_refresh_token, expected_refresh_token",
+    [
+        pytest.param("rotated-refresh-token", "rotated-refresh-token", id="returned"),
+        pytest.param(None, "existing-refresh-token", id="omitted"),
+    ],
+)
+def test_oauth_authenticator_refresh_token_handling(
+    rest_tap: Tap,
+    requests_mock: requests_mock.Mocker,
+    response_refresh_token: str | None,
+    expected_refresh_token: str,
+):
+    """Validate refresh tokens returned by the OAuth endpoint are retained."""
+    response: dict[str, t.Any] = {"access_token": "an-access-token"}
+    if response_refresh_token is not None:
+        response["refresh_token"] = response_refresh_token
+
+    requests_mock.post("https://example.com/oauth", json=response)
+    authenticator = _FakeOAuthAuthenticator(
+        stream=rest_tap.streams["some_stream"],
+        auth_endpoint="https://example.com/oauth",
+    )
+    authenticator.refresh_token = "existing-refresh-token"  # noqa: S105
+
+    authenticator.update_access_token()
+
+    assert authenticator.refresh_token == expected_refresh_token
+
+
 def test_oauth_authenticator_handle_error(
     rest_tap: Tap,
     requests_mock: requests_mock.Mocker,


### PR DESCRIPTION
## Summary
- retain a non-empty `refresh_token` returned by an OAuth token endpoint
- preserve the current refresh token when a provider omits one
- add regression coverage for both cases

## Motivation
Some OAuth providers rotate refresh tokens. Without retaining the response value, the next refresh in a long-running process can reuse an invalidated token.

This deliberately updates only the in-memory authenticator; it does not attempt config write-back (tracked separately in #106).

## Verification
- `uv run --no-sync pytest tests/core/rest/test_authenticators.py -q --benchmark-skip` (45 passed)
- `uvx ruff check singer_sdk/authenticators.py tests/core/rest/test_authenticators.py`
- `uvx ruff format --check singer_sdk/authenticators.py tests/core/rest/test_authenticators.py`
- `uv run --no-dev --with ty ty check singer_sdk/authenticators.py`

## Summary by Sourcery

Ensure OAuth authenticators retain valid refresh tokens returned by providers and add regression coverage for refresh token handling.

Bug Fixes:
- Preserve existing OAuth refresh tokens when token endpoint responses omit a refresh_token.
- Retain new non-empty OAuth refresh tokens returned by providers during token refresh.

Tests:
- Add regression tests verifying refresh tokens are updated when returned and preserved when omitted in OAuth token responses.