### PR TITLE
fix: Normalize single-element OpenAPI `allOf` object schemas

### DIFF
--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -359,7 +359,7 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
 
         # If the allOf array has only one element, just flatten it.
         if len(subschemas) == 1:
-            return subschemas[0]  # type: ignore[no-any-return]
+            return self.normalize_schema(subschemas[0])
 
         # TODO: merge subschemas:
         # - Taking the most restrictive constraints for each property

--- a/tests/core/schema/test_source.py
+++ b/tests/core/schema/test_source.py
@@ -771,6 +771,14 @@ class TestOpenAPISchemaNormalization:
                     "AllOfSingleElement": {
                         "allOf": [{"type": "string"}],
                     },
+                    "AllOfSingleElementObject": {
+                        "allOf": [
+                            {
+                                "type": "object",
+                                "properties": {"name": {"type": "string"}},
+                            }
+                        ],
+                    },
                     "AllOfSchemas": {
                         "allOf": [
                             {
@@ -941,6 +949,16 @@ class TestOpenAPISchemaNormalization:
         schema = source.get_schema("AllOfSingleElement")
         normalized = source.preprocess_schema(schema)
         assert normalized == {"type": "string"}
+        assert "allOf" not in normalized
+
+    def test_normalize_all_of_single_object(self, source: OpenAPISchema):
+        """Test that a single-element allOf with an object schema is flattened."""
+        schema = source.get_schema("AllOfSingleElementObject")
+        normalized = source.preprocess_schema(schema)
+        assert normalized == {
+            "type": ["object", "null"],
+            "properties": {"name": {"type": ["string", "null"]}},
+        }
         assert "allOf" not in normalized
 
     def test_normalize_all_of_merge(self, source: OpenAPISchema):


### PR DESCRIPTION
## Summary by Sourcery

Normalize single-element OpenAPI `allOf` schemas by fully preprocessing the subschema, including object types, instead of returning it as-is.

Bug Fixes:
- Ensure single-element `allOf` object schemas are flattened and normalized consistently with other nullable object schemas.

Tests:
- Add coverage to verify normalization of single-element `allOf` object schemas and their properties.