### PR TITLE
feat(mappers): support explicit property schemas

### DIFF
--- a/docs/stream_maps.md
+++ b/docs/stream_maps.md
@@ -184,6 +184,29 @@ one-way hash algorithm above, define those config arguments within the optional
 `stream_map_config` setting. Values defined in `stream_map_config` will be available
 to expressions using the `config` dictionary.
 
+### Setting the JSON Schema for a Mapped Property
+
+The SDK normally infers a mapped property's JSON Schema from its expression. For
+expressions whose result cannot be inferred, define the mapping as an object containing
+an `expr` string and the JSON Schema keywords for the resulting value:
+
+```yaml
+stream_maps:
+  customers:
+    is_gmail:
+      expr: "'@gmail.com' in owner_email"
+      type: [boolean]
+    tags:
+      expr: "[tag['name'] for tag in source_tags]"
+      type: [array, "null"]
+      items:
+        type: [string, "null"]
+```
+
+The `expr` value is evaluated exactly like an existing string mapping. The remaining
+keys must form a valid JSON Schema and are copied to the mapped property's schema.
+String and `null` mapping definitions remain fully supported.
+
 ### Constructing Expressions
 
 Expressions are defined and parsed using the

--- a/singer_sdk/helpers/capabilities.py
+++ b/singer_sdk/helpers/capabilities.py
@@ -9,6 +9,7 @@ from warnings import warn
 
 from singer_sdk.typing import (
     AnyOf,
+    AnyType,
     ArrayType,
     BooleanType,
     Constant,
@@ -104,6 +105,15 @@ STREAM_MAPS_CONFIG = PropertiesList(
                         Constant("__NULL__"),  # Remove the property from the stream.
                         NullType(),  # Remove the property from the stream.
                         StringType(),  # Compute the property using this expression.
+                        ObjectType(
+                            Property(
+                                "expr",
+                                StringType,
+                                required=True,
+                                description="Expression used to compute the property.",
+                            ),
+                            additional_properties=AnyType(),
+                        ),
                     ),
                 ),
             ),

--- a/singer_sdk/helpers/capabilities.py
+++ b/singer_sdk/helpers/capabilities.py
@@ -108,7 +108,7 @@ STREAM_MAPS_CONFIG = PropertiesList(
                         ObjectType(
                             Property(
                                 "expr",
-                                StringType,
+                                StringType(),
                                 required=True,
                                 description="Expression used to compute the property.",
                             ),

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -608,7 +608,7 @@ class CustomStreamMap(StreamMap):
                     except jsonschema.SchemaError as ex:
                         msg = (
                             "Invalid JSON Schema for typed stream map "
-                            f"'{self.stream_alias}:{prop_key}': {ex.message}"
+                            f"'{self.stream_alias}:{prop_key}': {ex}"
                         )
                         raise StreamMapConfigError(msg) from ex
 

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -17,6 +17,7 @@ import logging
 import sys
 import typing as t
 
+import jsonschema
 import simpleeval
 
 import singer_sdk.typing as th
@@ -572,7 +573,7 @@ class CustomStreamMap(StreamMap):
 
         stream_map_parsed: list[tuple[str, str | None, ast.Expr | None]] = []
         for prop_key, prop_def in list(stream_map.items()):
-            if prop_def in {None, NULL_STRING}:
+            if prop_def is None or prop_def == NULL_STRING:
                 if prop_key in (self.transformed_key_properties or []):
                     msg = (
                         f"Removing key property '{prop_key}' is not permitted in "
@@ -590,29 +591,49 @@ class CustomStreamMap(StreamMap):
                         if item != prop_key
                     ]
                 stream_map_parsed.append((prop_key, prop_def, None))
-            elif isinstance(prop_def, str):
-                default_type: th.JSONTypeHelper = th.StringType()  # Fallback to string
-                existing_schema: dict = (
-                    # Use transformed schema if available
-                    transformed_schema["properties"].get(prop_key, {})
-                    # ...or original schema for passthrough
-                    or self.raw_schema["properties"].get(prop_def, {})
-                )
-                if existing_schema:
-                    # Set default type if property exists already in JSON Schema
-                    default_type = th.CustomType(existing_schema)
+            elif isinstance(prop_def, (str, dict)):
+                if isinstance(prop_def, dict):
+                    typed_prop_def = copy.deepcopy(prop_def)
+                    expression = typed_prop_def.pop("expr", None)
+                    if not isinstance(expression, str):
+                        msg = (
+                            "Typed stream map for "
+                            f"'{self.stream_alias}:{prop_key}' must include a string "
+                            "'expr' value."
+                        )
+                        raise StreamMapConfigError(msg)
 
-                transformed_schema["properties"].update(
-                    th.Property(
-                        prop_key,
-                        self._eval_type(prop_def, default=default_type),
-                    ).to_dict(),
-                )
+                    try:
+                        th.DEFAULT_JSONSCHEMA_VALIDATOR.check_schema(typed_prop_def)
+                    except jsonschema.SchemaError as ex:
+                        msg = (
+                            "Invalid JSON Schema for typed stream map "
+                            f"'{self.stream_alias}:{prop_key}': {ex.message}"
+                        )
+                        raise StreamMapConfigError(msg) from ex
+
+                    transformed_schema["properties"][prop_key] = typed_prop_def
+                else:
+                    expression = prop_def
+                    default_type: th.JSONTypeHelper = th.StringType()
+                    existing_schema: dict = transformed_schema["properties"].get(
+                        prop_key, {}
+                    ) or self.raw_schema["properties"].get(expression, {})
+                    if existing_schema:
+                        default_type = th.CustomType(existing_schema)
+
+                    transformed_schema["properties"].update(
+                        th.Property(
+                            prop_key,
+                            self._eval_type(expression, default=default_type),
+                        ).to_dict(),
+                    )
+
                 try:
-                    parsed_def: ast.Expr = ast.parse(prop_def).body[0]  # type: ignore[assignment]
-                    stream_map_parsed.append((prop_key, prop_def, parsed_def))
+                    parsed_def: ast.Expr = ast.parse(expression).body[0]  # type: ignore[assignment]
+                    stream_map_parsed.append((prop_key, expression, parsed_def))
                 except (SyntaxError, IndexError) as ex:
-                    msg = f"Failed to parse expression {prop_def}."
+                    msg = f"Failed to parse expression {expression}."
                     raise MapExpressionError(msg) from ex
 
             else:

--- a/tests/core/test_mapper.py
+++ b/tests/core/test_mapper.py
@@ -16,7 +16,7 @@ import pytest
 import time_machine
 from typing_extensions import override
 
-from singer_sdk.exceptions import MapExpressionError
+from singer_sdk.exceptions import MapExpressionError, StreamMapConfigError
 from singer_sdk.mapper import PluginMapper, RemoveRecordTransform, md5
 from singer_sdk.singerlib import Catalog
 from singer_sdk.streams.core import Stream
@@ -457,6 +457,99 @@ def test_map_transforms(
         sample_stream=sample_stream,
         sample_catalog_obj=sample_catalog_obj,
     )
+
+
+def test_typed_property_transforms(
+    sample_stream,
+    sample_catalog_obj,
+    stream_map_config,
+):
+    boolean_definition = {
+        "expr": "foo == 'bar'",
+        "type": ["boolean"],
+        "description": "Whether the source value is bar.",
+    }
+    output, output_schemas = _run_transform(
+        stream_maps={
+            "singular": {
+                "is_bar": boolean_definition,
+                "values": {
+                    "expr": "[foo, None]",
+                    "type": ["array", "null"],
+                    "items": {"type": ["string", "null"]},
+                },
+                "__else__": None,
+            },
+        },
+        stream_map_config=stream_map_config,
+        sample_stream=sample_stream,
+        sample_catalog_obj=sample_catalog_obj,
+    )
+
+    assert output["singular"] == [{"is_bar": True, "values": ["bar", None]}]
+    assert output_schemas["singular"]["properties"] == {
+        "is_bar": {
+            "type": ["boolean"],
+            "description": "Whether the source value is bar.",
+        },
+        "values": {
+            "type": ["array", "null"],
+            "items": {"type": ["string", "null"]},
+        },
+    }
+    assert boolean_definition == {
+        "expr": "foo == 'bar'",
+        "type": ["boolean"],
+        "description": "Whether the source value is bar.",
+    }
+
+
+def test_typed_property_passes_plugin_config_validation():
+    tap = MappedTap(
+        config={
+            "stream_maps": {
+                "mystream": {
+                    "is_positive": {
+                        "expr": "count > 0",
+                        "type": ["boolean"],
+                    },
+                },
+            },
+        },
+        validate_config=True,
+    )
+
+    assert tap.config["stream_maps"]["mystream"]["is_positive"] == {
+        "expr": "count > 0",
+        "type": ["boolean"],
+    }
+
+
+@pytest.mark.parametrize(
+    "property_definition, match",
+    [
+        ({"type": ["boolean"]}, "must include a string 'expr' value"),
+        ({"expr": 42, "type": ["integer"]}, "must include a string 'expr' value"),
+        (
+            {"expr": "foo", "type": "not-a-json-schema-type"},
+            "Invalid JSON Schema",
+        ),
+    ],
+)
+def test_invalid_typed_property_transform(
+    property_definition,
+    match,
+    sample_stream,
+    sample_catalog_obj,
+    stream_map_config,
+):
+    with pytest.raises(StreamMapConfigError, match=match):
+        _run_transform(
+            stream_maps={"singular": {"mapped": property_definition}},
+            stream_map_config=stream_map_config,
+            sample_stream=sample_stream,
+            sample_catalog_obj=sample_catalog_obj,
+        )
 
 
 def test_clone_and_alias_transforms(


### PR DESCRIPTION
## Summary

- allow mapped properties to define an `expr` plus arbitrary JSON Schema keywords
- validate explicit schemas and surface configuration errors early
- extend the built-in `stream_maps` config schema so `validate_config=True` accepts typed mappings
- preserve existing string/null mapping compatibility and avoid mutating user config

## Validation

- `uv run pytest -q` — 855 passed, 388 deselected, 1 expected xfail, 21 subtests passed
- changed-file pre-commit — passed
- mypy and ty on both changed Python files — passed
- Sphinx build with warnings treated as errors — passed
- focused post-review regression suite — 5 passed

## CI note

The API Changes job reports the intentional value change to the public `STREAM_MAPS_CONFIG` schema. No API is removed; extending that schema is required so SDK plugins using `validate_config=True` can accept the new typed mapping form. Comparable additive configuration-schema changes in this repository have produced the same diagnostic.

Closes #2010
