### PR TITLE
SPAM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # HTTP cache
 http_cache.sqlite
+.http_cache/
 
 # Local Poetry configuration file
 

--- a/packages/meltano-tap-countries/tap_countries/streams.py
+++ b/packages/meltano-tap-countries/tap_countries/streams.py
@@ -12,10 +12,9 @@ import abc
 import sys
 import typing as t
 
-from requests_cache.session import CachedSession
-
 from singer_sdk import SchemaDirectory, StreamSchema
 from singer_sdk import typing as th
+from singer_sdk.helpers.http_cache import SafeCachedSession
 from singer_sdk.streams.graphql import GraphQLStream
 from tap_countries import schemas
 
@@ -38,15 +37,8 @@ class CountriesAPIStream(GraphQLStream, abc.ABC):
 
     @property
     @override
-    def requests_session(self) -> CachedSession:
-        return CachedSession(
-            ".http_cache",
-            backend="filesystem",
-            serializer="json",
-            allowable_methods=("POST", "HEAD"),
-            ignored_parameters=["User-Agent"],
-            match_headers=True,
-        )
+    def requests_session(self) -> SafeCachedSession:
+        return SafeCachedSession(allowable_methods=("POST", "HEAD"))
 
 
 class CountriesStream(CountriesAPIStream):

--- a/packages/meltano-tap-countries/tap_countries/streams.py
+++ b/packages/meltano-tap-countries/tap_countries/streams.py
@@ -38,7 +38,10 @@ class CountriesAPIStream(GraphQLStream, abc.ABC):
     @property
     @override
     def requests_session(self) -> SafeCachedSession:
-        return SafeCachedSession(allowable_methods=("POST", "HEAD"))
+        return SafeCachedSession(
+            cache_name="tap-countries",
+            allowable_methods=("POST", "HEAD"),
+        )
 
 
 class CountriesStream(CountriesAPIStream):

--- a/packages/meltano-tap-dummyjson/tap_dummyjson/auth.py
+++ b/packages/meltano-tap-dummyjson/tap_dummyjson/auth.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import requests.auth
-from requests_cache import CachedSession
+from requests import Session
 from singer_sdk.authenticators import SingletonMeta
 
 if sys.version_info >= (3, 12):
@@ -50,14 +50,9 @@ class DummyJSONAuthenticator(requests.auth.AuthBase, metaclass=SingletonMeta):
         self.password = password
 
         self._token: _Token | None = None
-        self.session = CachedSession(
-            ".http_cache",
-            backend="filesystem",
-            serializer="json",
-            allowable_methods=("POST",),
-            ignored_parameters=["User-Agent"],
-            match_headers=True,
-        )
+        # Authentication responses contain reusable credentials and must never be
+        # persisted to a filesystem cache.
+        self.session = Session()
 
     @override
     def __call__(self, r: PreparedRequest) -> PreparedRequest:

--- a/packages/meltano-tap-dummyjson/tap_dummyjson/client.py
+++ b/packages/meltano-tap-dummyjson/tap_dummyjson/client.py
@@ -37,7 +37,7 @@ class DummyJSONStream(RESTStream):
     @property
     @override
     def requests_session(self) -> SafeCachedSession:
-        return SafeCachedSession()
+        return SafeCachedSession(cache_name="tap-dummyjson")
 
     @property
     @override

--- a/packages/meltano-tap-dummyjson/tap_dummyjson/client.py
+++ b/packages/meltano-tap-dummyjson/tap_dummyjson/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from typing import TYPE_CHECKING
 
-from requests_cache import CachedSession
+from singer_sdk.helpers.http_cache import SafeCachedSession
 from singer_sdk.pagination import OffsetPaginator
 from singer_sdk.streams import RESTStream
 
@@ -36,14 +36,8 @@ class DummyJSONStream(RESTStream):
 
     @property
     @override
-    def requests_session(self) -> CachedSession:
-        return CachedSession(
-            ".http_cache",
-            backend="filesystem",
-            serializer="json",
-            ignored_parameters=["Authorization", "User-Agent"],
-            match_headers=True,
-        )
+    def requests_session(self) -> SafeCachedSession:
+        return SafeCachedSession()
 
     @property
     @override

--- a/packages/meltano-tap-gitlab/pyproject.toml
+++ b/packages/meltano-tap-gitlab/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
+    "requests-cache>=1.3",
     "singer-sdk",
     "typing-extensions>=4.5.0; python_version < '3.12'",
 ]

--- a/packages/meltano-tap-gitlab/tap_gitlab/streams.py
+++ b/packages/meltano-tap-gitlab/tap_gitlab/streams.py
@@ -49,7 +49,7 @@ class GitlabStream(RESTStream[str]):
     @property
     @override
     def requests_session(self) -> SafeCachedSession:
-        return SafeCachedSession()
+        return SafeCachedSession(cache_name="tap-gitlab")
 
     @property
     @override

--- a/packages/meltano-tap-gitlab/tap_gitlab/streams.py
+++ b/packages/meltano-tap-gitlab/tap_gitlab/streams.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import sys
 import typing as t
 
-from requests_cache import CachedSession
-
 from singer_sdk import RESTStream, SchemaDirectory, StreamSchema
 from singer_sdk.authenticators import SimpleAuthenticator
+from singer_sdk.helpers.http_cache import SafeCachedSession
 from singer_sdk.pagination import SimpleHeaderPaginator
 from singer_sdk.typing import (
     ArrayType,
@@ -49,14 +48,8 @@ class GitlabStream(RESTStream[str]):
 
     @property
     @override
-    def requests_session(self) -> CachedSession:
-        return CachedSession(
-            ".http_cache",
-            backend="filesystem",
-            serializer="json",
-            ignored_parameters=["Private-Token", "User-Agent"],
-            match_headers=True,
-        )
+    def requests_session(self) -> SafeCachedSession:
+        return SafeCachedSession()
 
     @property
     @override

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,10 @@ msgspec = [
     "msgspec>=0.19.0",
 ]
 
+cache = [
+    "requests-cache>=1.3",
+]
+
 sql = [
     "sqlalchemy>=2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ msgspec = [
 ]
 
 cache = [
+    # ``attrs`` backs ``requests-cache``'s cached models; ``http_cache`` imports it
+    # directly to copy them, so it is declared rather than relied on transitively.
+    "attrs>=21.2",
     "requests-cache>=1.3",
 ]
 

--- a/singer_sdk/helpers/http_cache.py
+++ b/singer_sdk/helpers/http_cache.py
@@ -7,23 +7,24 @@ Requires the optional ``requests-cache`` dependency, available as
 from __future__ import annotations
 
 import json
-import sys
 import typing as t
-from tempfile import TemporaryDirectory
+from hashlib import sha256
+from pathlib import Path
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-from requests_cache import CachedSession
-
-if sys.version_info >= (3, 12):
-    from typing import override  # noqa: ICN003
-else:
-    from typing_extensions import override
+import attr
+from requests.cookies import RequestsCookieJar
+from requests.structures import CaseInsensitiveDict
+from requests_cache import CachedSession, create_key
+from requests_cache.serializers import SerializerPipeline, Stage, json_serializer
 
 if t.TYPE_CHECKING:
-    from collections.abc import Iterable, MutableMapping
-    from pathlib import Path
+    from collections.abc import Iterable, Iterator, MutableMapping
 
-    from requests import PreparedRequest, Response
+    from requests import PreparedRequest, Request
+    from requests_cache.models import CachedRequest, CachedResponse
+
+    _AnyRequest = PreparedRequest | Request | CachedRequest
 
 _HeaderValue = t.TypeVar("_HeaderValue")
 
@@ -53,6 +54,15 @@ _SENSITIVE_PARAMETERS = frozenset({
     "token",
     "x-amz-signature",
 })
+# requests-cache matches `ignored_parameters` against header names *as sent*: its
+# `filter_sort_dict` tests `name in ignored_parameters` against the original casing
+# yielded by `CaseInsensitiveDict.items()`. List both the canonical HTTP casing and
+# the lower-case (HTTP/2) form so its own redaction keeps working.
+_IGNORED_PARAMETERS = sorted(
+    _SENSITIVE_PARAMETERS
+    | _SENSITIVE_HEADERS
+    | {name.title() for name in _SENSITIVE_HEADERS}
+)
 
 
 def _decode_text(value: object) -> str | None:
@@ -67,12 +77,23 @@ def _decode_text(value: object) -> str | None:
     return None
 
 
-def _strip_headers(headers: MutableMapping[str, _HeaderValue] | None) -> None:
-    if headers is None:
-        return
+def _strip_headers(headers: MutableMapping[str, _HeaderValue]) -> None:
     for name in list(headers):
         if name.lower() in _SENSITIVE_HEADERS:
             del headers[name]
+
+
+def _sanitised_headers(
+    headers: MutableMapping[str, str] | None,
+) -> CaseInsensitiveDict:
+    stripped: CaseInsensitiveDict = CaseInsensitiveDict(headers or {})
+    _strip_headers(stripped)
+    return stripped
+
+
+def _content_type(headers: MutableMapping[str, str] | None) -> str:
+    raw = _decode_text(CaseInsensitiveDict(headers or {}).get("Content-Type")) or ""
+    return raw.partition(";")[0].lower()
 
 
 def _strip_url(url: str) -> str:
@@ -91,10 +112,6 @@ def _strip_url(url: str) -> str:
     # removing everything through the last `@` preserves the host and port exactly.
     netloc = parts.netloc.rsplit("@", maxsplit=1)[-1]
     return urlunsplit((parts.scheme, netloc, parts.path, query, parts.fragment))
-
-
-def _strip_optional_url(url: str | None) -> str | None:
-    return None if url is None else _strip_url(url)
 
 
 def _strip_json_credentials(value: object) -> object:
@@ -133,54 +150,170 @@ def _strip_json_body(body: str | None) -> str | None:
     return json.dumps(_strip_json_credentials(payload))
 
 
-def _strip_request(request: PreparedRequest | None) -> None:
+def _sanitised_request(request: CachedRequest | None) -> CachedRequest | None:
+    """Return a copy of ``request`` with every credential-bearing field removed."""
     if request is None:
-        return
-    _strip_headers(request.headers)
-    request.url = _strip_optional_url(request.url)
-    cookies = getattr(request, "_cookies", None)
-    if cookies is not None:
-        cookies.clear()
+        return None
 
-    raw_content_type = _decode_text(request.headers.get("Content-Type")) or ""
-    content_type = raw_content_type.partition(";")[0].lower()
-    if not request.body:
-        return
+    body: str | bytes | None = request.body
+    if body:
+        content_type = _content_type(request.headers)
+        text = _decode_text(body)
+        if content_type == "application/x-www-form-urlencoded":
+            body = _strip_form_body(text)
+        elif content_type == "application/json":
+            body = _strip_json_body(text)
+        else:
+            # Do not guess whether opaque or unsupported bodies are credential-free.
+            body = None
 
-    body = _decode_text(request.body)
-    if content_type == "application/x-www-form-urlencoded":
-        request.body = _strip_form_body(body)
-    elif content_type == "application/json":
-        request.body = _strip_json_body(body)
-    else:
-        # Do not guess whether opaque or unsupported bodies are credential-free.
-        request.body = None
+    return attr.evolve(
+        request,
+        body=body,
+        cookies=RequestsCookieJar(),
+        headers=_sanitised_headers(request.headers),
+        url=_strip_url(request.url or ""),
+    )
 
 
-def sanitise_response_for_cache(
-    response: Response,
-    *args: object,
-    **kwargs: object,
-) -> Response:
-    """Remove authentication material before requests-cache serialises a response.
+def _sanitised_cached_request(request: CachedRequest) -> CachedRequest:
+    """Return a sanitised copy of a request that is always present.
 
     Returns:
-        The response with credential-bearing persistence fields removed.
+        The sanitised request. ``_sanitised_request`` only returns ``None`` for a
+        ``None`` input, so the result is never ``None`` here.
     """
-    del args, kwargs
-    for item in [*response.history, response]:
-        _strip_headers(item.headers)
-        _strip_request(item.request)
-        item.url = _strip_url(item.url)
-        item.cookies.clear()
+    return t.cast("CachedRequest", _sanitised_request(request))
 
-        raw = item.raw
-        _strip_headers(getattr(raw, "headers", None))
-        if hasattr(raw, "_request_url"):
-            raw._request_url = _strip_optional_url(raw._request_url)  # noqa: SLF001
 
-    _strip_request(response.next)
-    return response
+def _sanitised_content(response: CachedResponse) -> bytes:
+    """Strip recognised credential fields from a JSON response body.
+
+    Only JSON bodies are rewritten: other content types are the payload the cache
+    exists to serve, and cannot be parsed for credentials without guessing.
+
+    Returns:
+        The body to persist, with recognised credential fields removed.
+    """
+    content: bytes = response.content
+    if not content or _content_type(response.headers) != "application/json":
+        return content
+    stripped = _strip_json_body(_decode_text(content))
+    return content if stripped is None else stripped.encode()
+
+
+def sanitise_cached_response(response: CachedResponse) -> CachedResponse:
+    """Return a sanitised copy of a response on its way into the cache.
+
+    ``CachedResponse.from_response`` shares the live response's header mapping,
+    cookie jar and request headers, so this copies instead of stripping in place:
+    the caller keeps ``response.cookies``, and a 302 handed to
+    ``Session.resolve_redirects`` keeps the ``Authorization`` for the next hop.
+
+    Returns:
+        A copy with credential-bearing persistence fields removed.
+    """
+    return attr.evolve(
+        response,
+        content=_sanitised_content(response),
+        cookies=RequestsCookieJar(),
+        headers=_sanitised_headers(response.headers),
+        history=[sanitise_cached_response(item) for item in response.history],
+        # ``response.next`` is a property that re-prepares a ``PreparedRequest``;
+        # the ``_next`` field it derives from is the ``CachedRequest`` that is
+        # actually persisted, and is what ``evolve`` writes here.
+        next=_sanitised_request(response._next),  # noqa: SLF001
+        request=_sanitised_cached_request(response.request),
+        url=_strip_url(response.url),
+    )
+
+
+#: Every byte written to a cache file passes through the serializer, so registering
+#: the sanitisation here - rather than as a session response hook, which
+#: ``Session.send()`` skips for requests it did not prepare - leaves no bypass.
+_SANITISING_JSON_SERIALIZER = SerializerPipeline(
+    [
+        Stage(dumps=sanitise_cached_response, loads=lambda value: value),
+        *json_serializer.stages,
+    ],
+    name=json_serializer.name,
+    is_binary=json_serializer.is_binary,
+)
+
+
+def _json_credentials(value: object) -> Iterator[tuple[str, str]]:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if str(key).lower() in _SENSITIVE_PARAMETERS:
+                yield str(key).lower(), json.dumps(item, sort_keys=True)
+            else:
+                yield from _json_credentials(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _json_credentials(item)
+
+
+def _body_credentials(request: _AnyRequest) -> Iterator[tuple[str, str]]:
+    body = _decode_text(getattr(request, "body", None))
+    if not body:
+        return
+    content_type = _content_type(getattr(request, "headers", None))
+    if content_type == "application/x-www-form-urlencoded":
+        yield from (
+            (name.lower(), value)
+            for name, value in parse_qsl(body, keep_blank_values=True)
+            if name.lower() in _SENSITIVE_PARAMETERS
+        )
+    elif content_type == "application/json":
+        try:
+            payload = json.loads(body)
+        except ValueError:
+            return
+        yield from _json_credentials(payload)
+
+
+def _credential_material(request: _AnyRequest) -> list[tuple[str, str]]:
+    """Collect the real credential values a request carries.
+
+    Returns:
+        Sorted ``(name, value)`` pairs for every credential found.
+    """
+    headers: MutableMapping[str, str] = getattr(request, "headers", None) or {}
+    material = [
+        (name.lower(), _decode_text(headers[name]) or "")
+        for name in headers
+        if name.lower() in _SENSITIVE_HEADERS
+    ]
+
+    # Userinfo needs no entry here: requests-cache redacts *query parameters* named
+    # in ``ignored_parameters``, never the netloc, so ``create_key`` already keeps
+    # ``https://t:A@host`` and ``https://t:B@host`` on separate keys.
+    parts = urlsplit(getattr(request, "url", None) or "")
+    material.extend(
+        (name.lower(), value)
+        for name, value in parse_qsl(parts.query, keep_blank_values=True)
+        if name.lower() in _SENSITIVE_PARAMETERS
+    )
+    material.extend(_body_credentials(request))
+    return sorted(material)
+
+
+def _cache_key(request: _AnyRequest, **kwargs: t.Any) -> str:
+    """Build a cache key that distinguishes requests by their real credentials.
+
+    requests-cache redacts ignored parameters *into* the key: it substitutes the
+    literal ``REDACTED`` so "the cache key will still match whether the parameter
+    was present or not", which collapses distinct tokens, and distinct pagination
+    cursors named ``token``, onto one entry. Mixing in a non-reversible digest of
+    the real values keeps them apart without persisting them.
+
+    Returns:
+        The requests-cache key, suffixed with a digest of the credentials.
+    """
+    digest = sha256()
+    for name, value in _credential_material(request):
+        digest.update(f"{name}={value}\n".encode())
+    return f"{create_key(request=request, **kwargs)}{digest.hexdigest()[:16]}"
 
 
 class SafeCachedSession(CachedSession):
@@ -189,30 +322,25 @@ class SafeCachedSession(CachedSession):
     def __init__(
         self,
         *,
+        cache_name: str = "http-cache",
         cache_path: str | Path | None = None,
         allowable_methods: Iterable[str] = ("GET", "HEAD"),
     ) -> None:
-        """Initialise a sanitising session with a temporary default cache path."""
-        self._temporary_cache: TemporaryDirectory[str] | None = None
-        if cache_path is None:
-            self._temporary_cache = TemporaryDirectory(prefix="singer-sdk-http-cache-")
-            cache_path = self._temporary_cache.name
-        super().__init__(
-            cache_path,
-            backend="filesystem",
-            serializer="json",
-            allowable_methods=allowable_methods,
-            ignored_parameters=sorted(_SENSITIVE_HEADERS | _SENSITIVE_PARAMETERS),
-            match_headers=True,
-        )
-        self.hooks["response"].append(sanitise_response_for_cache)
+        """Initialise a sanitising session with a stable per-tap cache path.
 
-    @override
-    def close(self) -> None:
-        """Close the cache backend and remove an automatically-created cache."""
-        try:
-            super().close()
-        finally:
-            if self._temporary_cache is not None:
-                self._temporary_cache.cleanup()
-                self._temporary_cache = None
+        Args:
+            cache_name: Name of this tap's cache, used when ``cache_path`` is unset.
+            cache_path: Explicit cache directory. A relative path is resolved inside
+                the user cache directory.
+            allowable_methods: HTTP methods whose responses may be cached.
+        """
+        super().__init__(
+            cache_path if cache_path is not None else Path("singer-sdk") / cache_name,
+            backend="filesystem",
+            serializer=_SANITISING_JSON_SERIALIZER,
+            use_cache_dir=True,
+            allowable_methods=allowable_methods,
+            ignored_parameters=_IGNORED_PARAMETERS,
+            match_headers=True,
+            key_fn=_cache_key,
+        )

--- a/singer_sdk/helpers/http_cache.py
+++ b/singer_sdk/helpers/http_cache.py
@@ -63,7 +63,10 @@ def _strip_url(url: str | None) -> str | None:
         ],
         doseq=True,
     )
-    return urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))
+    # urlsplit().hostname drops userinfo but normalising the host can alter IPv6;
+    # removing everything through the last `@` preserves the host and port exactly.
+    netloc = parts.netloc.rsplit("@", maxsplit=1)[-1]
+    return urlunsplit((parts.scheme, netloc, parts.path, query, parts.fragment))
 
 
 def _strip_json_credentials(value: object) -> object:
@@ -91,14 +94,23 @@ def _strip_request(request: PreparedRequest | None) -> None:
     if not request.body:
         return
     if content_type == "application/x-www-form-urlencoded":
-        body = (
-            request.body.decode() if isinstance(request.body, bytes) else request.body
-        )
-        request.body = urlencode([
-            (name, value)
-            for name, value in parse_qsl(body, keep_blank_values=True)
-            if name.lower() not in _SENSITIVE_PARAMETERS
-        ])
+        try:
+            body = (
+                request.body.decode()
+                if isinstance(request.body, bytes)
+                else request.body
+            )
+            request.body = urlencode([
+                (name, value)
+                for name, value in parse_qsl(
+                    body,
+                    keep_blank_values=True,
+                    strict_parsing=True,
+                )
+                if name.lower() not in _SENSITIVE_PARAMETERS
+            ])
+        except (AttributeError, TypeError, UnicodeDecodeError, ValueError):
+            request.body = None
     elif content_type == "application/json":
         try:
             body = (
@@ -108,9 +120,10 @@ def _strip_request(request: PreparedRequest | None) -> None:
             )
             request.body = json.dumps(_strip_json_credentials(json.loads(body)))
         except (TypeError, UnicodeDecodeError, json.JSONDecodeError):
-            # An unparseable body is not persisted by the sample sessions because
-            # they only cache their declared safe request methods.
-            pass
+            request.body = None
+    else:
+        # Do not guess whether opaque or unsupported bodies are credential-free.
+        request.body = None
 
 
 def sanitise_response_for_cache(

--- a/singer_sdk/helpers/http_cache.py
+++ b/singer_sdk/helpers/http_cache.py
@@ -1,19 +1,31 @@
-"""Safe filesystem caching for SDK sample taps."""
+"""Safe filesystem caching for SDK sample taps.
+
+Requires the optional ``requests-cache`` dependency, available as
+``singer-sdk[cache]``.
+"""
 
 from __future__ import annotations
 
 import json
+import sys
 import typing as t
 from tempfile import TemporaryDirectory
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from requests_cache import CachedSession
 
+if sys.version_info >= (3, 12):
+    from typing import override  # noqa: ICN003
+else:
+    from typing_extensions import override
+
 if t.TYPE_CHECKING:
     from collections.abc import Iterable, MutableMapping
     from pathlib import Path
 
     from requests import PreparedRequest, Response
+
+_HeaderValue = t.TypeVar("_HeaderValue")
 
 _SENSITIVE_HEADERS = frozenset({
     "authorization",
@@ -43,7 +55,19 @@ _SENSITIVE_PARAMETERS = frozenset({
 })
 
 
-def _strip_headers(headers: MutableMapping[str, object] | None) -> None:
+def _decode_text(value: object) -> str | None:
+    """Return ``value`` as text, or ``None`` when it is not safely decodable."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            return bytes(value).decode()
+        except UnicodeDecodeError:
+            return None
+    return None
+
+
+def _strip_headers(headers: MutableMapping[str, _HeaderValue] | None) -> None:
     if headers is None:
         return
     for name in list(headers):
@@ -51,7 +75,7 @@ def _strip_headers(headers: MutableMapping[str, object] | None) -> None:
             del headers[name]
 
 
-def _strip_url(url: str | None) -> str | None:
+def _strip_url(url: str) -> str:
     if not url:
         return url
     parts = urlsplit(url)
@@ -69,6 +93,10 @@ def _strip_url(url: str | None) -> str | None:
     return urlunsplit((parts.scheme, netloc, parts.path, query, parts.fragment))
 
 
+def _strip_optional_url(url: str | None) -> str | None:
+    return None if url is None else _strip_url(url)
+
+
 def _strip_json_credentials(value: object) -> object:
     if isinstance(value, dict):
         return {
@@ -81,46 +109,49 @@ def _strip_json_credentials(value: object) -> object:
     return value
 
 
+def _strip_form_body(body: str | None) -> str | None:
+    if body is None:
+        return None
+    try:
+        pairs = parse_qsl(body, keep_blank_values=True, strict_parsing=True)
+    except ValueError:
+        return None
+    return urlencode([
+        (name, value)
+        for name, value in pairs
+        if name.lower() not in _SENSITIVE_PARAMETERS
+    ])
+
+
+def _strip_json_body(body: str | None) -> str | None:
+    if body is None:
+        return None
+    try:
+        payload = json.loads(body)
+    except ValueError:
+        return None
+    return json.dumps(_strip_json_credentials(payload))
+
+
 def _strip_request(request: PreparedRequest | None) -> None:
     if request is None:
         return
     _strip_headers(request.headers)
-    request.url = _strip_url(request.url)
+    request.url = _strip_optional_url(request.url)
     cookies = getattr(request, "_cookies", None)
     if cookies is not None:
         cookies.clear()
 
-    content_type = request.headers.get("Content-Type", "").partition(";")[0].lower()
+    raw_content_type = _decode_text(request.headers.get("Content-Type")) or ""
+    content_type = raw_content_type.partition(";")[0].lower()
     if not request.body:
         return
+
+    body = _decode_text(request.body)
     if content_type == "application/x-www-form-urlencoded":
-        try:
-            body = (
-                request.body.decode()
-                if isinstance(request.body, bytes)
-                else request.body
-            )
-            request.body = urlencode([
-                (name, value)
-                for name, value in parse_qsl(
-                    body,
-                    keep_blank_values=True,
-                    strict_parsing=True,
-                )
-                if name.lower() not in _SENSITIVE_PARAMETERS
-            ])
-        except (AttributeError, TypeError, UnicodeDecodeError, ValueError):
-            request.body = None
+        request.body = _strip_form_body(body)
     elif content_type == "application/json":
-        try:
-            body = (
-                request.body.decode()
-                if isinstance(request.body, bytes)
-                else request.body
-            )
-            request.body = json.dumps(_strip_json_credentials(json.loads(body)))
-        except (TypeError, UnicodeDecodeError, json.JSONDecodeError):
-            request.body = None
+        request.body = _strip_json_body(body)
     else:
         # Do not guess whether opaque or unsupported bodies are credential-free.
         request.body = None
@@ -146,7 +177,7 @@ def sanitise_response_for_cache(
         raw = item.raw
         _strip_headers(getattr(raw, "headers", None))
         if hasattr(raw, "_request_url"):
-            raw._request_url = _strip_url(raw._request_url)  # noqa: SLF001
+            raw._request_url = _strip_optional_url(raw._request_url)  # noqa: SLF001
 
     _strip_request(response.next)
     return response
@@ -176,6 +207,7 @@ class SafeCachedSession(CachedSession):
         )
         self.hooks["response"].append(sanitise_response_for_cache)
 
+    @override
     def close(self) -> None:
         """Close the cache backend and remove an automatically-created cache."""
         try:

--- a/singer_sdk/helpers/http_cache.py
+++ b/singer_sdk/helpers/http_cache.py
@@ -1,0 +1,173 @@
+"""Safe filesystem caching for SDK sample taps."""
+
+from __future__ import annotations
+
+import json
+import typing as t
+from tempfile import TemporaryDirectory
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from requests_cache import CachedSession
+
+if t.TYPE_CHECKING:
+    from collections.abc import Iterable, MutableMapping
+    from pathlib import Path
+
+    from requests import PreparedRequest, Response
+
+_SENSITIVE_HEADERS = frozenset({
+    "authorization",
+    "cookie",
+    "private-token",
+    "proxy-authorization",
+    "set-cookie",
+    "x-access-token",
+    "x-api-key",
+    "x-api-token",
+    "x-auth-token",
+})
+_SENSITIVE_PARAMETERS = frozenset({
+    "access_token",
+    "api_key",
+    "apikey",
+    "auth",
+    "authorization",
+    "client_secret",
+    "cookie",
+    "password",
+    "private_token",
+    "refresh_token",
+    "signature",
+    "token",
+    "x-amz-signature",
+})
+
+
+def _strip_headers(headers: MutableMapping[str, object] | None) -> None:
+    if headers is None:
+        return
+    for name in list(headers):
+        if name.lower() in _SENSITIVE_HEADERS:
+            del headers[name]
+
+
+def _strip_url(url: str | None) -> str | None:
+    if not url:
+        return url
+    parts = urlsplit(url)
+    query = urlencode(
+        [
+            (name, value)
+            for name, value in parse_qsl(parts.query, keep_blank_values=True)
+            if name.lower() not in _SENSITIVE_PARAMETERS
+        ],
+        doseq=True,
+    )
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))
+
+
+def _strip_json_credentials(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            key: _strip_json_credentials(item)
+            for key, item in value.items()
+            if str(key).lower() not in _SENSITIVE_PARAMETERS
+        }
+    if isinstance(value, list):
+        return [_strip_json_credentials(item) for item in value]
+    return value
+
+
+def _strip_request(request: PreparedRequest | None) -> None:
+    if request is None:
+        return
+    _strip_headers(request.headers)
+    request.url = _strip_url(request.url)
+    cookies = getattr(request, "_cookies", None)
+    if cookies is not None:
+        cookies.clear()
+
+    content_type = request.headers.get("Content-Type", "").partition(";")[0].lower()
+    if not request.body:
+        return
+    if content_type == "application/x-www-form-urlencoded":
+        body = (
+            request.body.decode() if isinstance(request.body, bytes) else request.body
+        )
+        request.body = urlencode([
+            (name, value)
+            for name, value in parse_qsl(body, keep_blank_values=True)
+            if name.lower() not in _SENSITIVE_PARAMETERS
+        ])
+    elif content_type == "application/json":
+        try:
+            body = (
+                request.body.decode()
+                if isinstance(request.body, bytes)
+                else request.body
+            )
+            request.body = json.dumps(_strip_json_credentials(json.loads(body)))
+        except (TypeError, UnicodeDecodeError, json.JSONDecodeError):
+            # An unparseable body is not persisted by the sample sessions because
+            # they only cache their declared safe request methods.
+            pass
+
+
+def sanitise_response_for_cache(
+    response: Response,
+    *args: object,
+    **kwargs: object,
+) -> Response:
+    """Remove authentication material before requests-cache serialises a response.
+
+    Returns:
+        The response with credential-bearing persistence fields removed.
+    """
+    del args, kwargs
+    for item in [*response.history, response]:
+        _strip_headers(item.headers)
+        _strip_request(item.request)
+        item.url = _strip_url(item.url)
+        item.cookies.clear()
+
+        raw = item.raw
+        _strip_headers(getattr(raw, "headers", None))
+        if hasattr(raw, "_request_url"):
+            raw._request_url = _strip_url(raw._request_url)  # noqa: SLF001
+
+    _strip_request(response.next)
+    return response
+
+
+class SafeCachedSession(CachedSession):
+    """A cache session whose default filesystem lives outside the repository."""
+
+    def __init__(
+        self,
+        *,
+        cache_path: str | Path | None = None,
+        allowable_methods: Iterable[str] = ("GET", "HEAD"),
+    ) -> None:
+        """Initialise a sanitising session with a temporary default cache path."""
+        self._temporary_cache: TemporaryDirectory[str] | None = None
+        if cache_path is None:
+            self._temporary_cache = TemporaryDirectory(prefix="singer-sdk-http-cache-")
+            cache_path = self._temporary_cache.name
+        super().__init__(
+            cache_path,
+            backend="filesystem",
+            serializer="json",
+            allowable_methods=allowable_methods,
+            ignored_parameters=sorted(_SENSITIVE_HEADERS | _SENSITIVE_PARAMETERS),
+            match_headers=True,
+        )
+        self.hooks["response"].append(sanitise_response_for_cache)
+
+    def close(self) -> None:
+        """Close the cache backend and remove an automatically-created cache."""
+        try:
+            super().close()
+        finally:
+            if self._temporary_cache is not None:
+                self._temporary_cache.cleanup()
+                self._temporary_cache = None

--- a/tests/helpers/test_http_cache.py
+++ b/tests/helpers/test_http_cache.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import requests
+
+from singer_sdk.helpers.http_cache import SafeCachedSession
+
+
+class _SyntheticAdapter(requests.adapters.BaseAdapter):
+    def send(self, request, **kwargs):  # noqa: ARG002
+        response = requests.Response()
+        response.status_code = 200
+        response.url = request.url
+        response.request = request
+        response.headers["Set-Cookie"] = "session=SYNTHETIC-COOKIE-SECRET"
+        response._content = b'{"result": "synthetic"}'
+        response.raw = requests.packages.urllib3.response.HTTPResponse(
+            body=response._content,
+            headers={"Set-Cookie": "session=SYNTHETIC-COOKIE-SECRET"},
+            status=200,
+            request_url=request.url,
+        )
+        return response
+
+    def close(self) -> None:
+        pass
+
+
+def test_cache_files_never_persist_synthetic_credentials(tmp_path: Path) -> None:
+    marker_values = {
+        "SYNTHETIC-AUTH-SECRET",
+        "SYNTHETIC-GITLAB-SECRET",
+        "SYNTHETIC-COOKIE-SECRET",
+        "SYNTHETIC-QUERY-SECRET",
+        "SYNTHETIC-BODY-SECRET",
+    }
+    with SafeCachedSession(cache_path=tmp_path, allowable_methods=("POST",)) as session:
+        session.mount("https://", _SyntheticAdapter())
+        response = session.post(
+            "https://example.invalid/data?access_token=SYNTHETIC-QUERY-SECRET&safe=yes",
+            headers={
+                "Authorization": "Bearer SYNTHETIC-AUTH-SECRET",
+                "Private-Token": "SYNTHETIC-GITLAB-SECRET",
+                "Cookie": "session=SYNTHETIC-COOKIE-SECRET",
+            },
+            json={"token": "SYNTHETIC-BODY-SECRET", "safe": "yes"},
+        )
+
+    assert response.status_code == 200
+    persisted = b"\n".join(
+        path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()
+    ).lower()
+    for marker in marker_values:
+        assert marker.lower().encode() not in persisted
+    for header in (b"authorization", b"private-token", b"set-cookie", b"cookie"):
+        assert header not in persisted
+
+
+def test_default_cache_is_outside_current_directory(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with SafeCachedSession() as session:
+        assert not Path(session.cache.cache_dir).is_relative_to(tmp_path)
+    assert not (tmp_path / ".http_cache").exists()

--- a/tests/helpers/test_http_cache.py
+++ b/tests/helpers/test_http_cache.py
@@ -51,8 +51,7 @@ def test_cache_files_never_persist_synthetic_credentials(tmp_path: Path) -> None
         )
         session.mount("https://", adapter)
         response = session.post(
-            "https://example.invalid/data"
-            "?access_token=SYNTHETIC-QUERY-SECRET&safe=yes",
+            "https://example.invalid/data?access_token=SYNTHETIC-QUERY-SECRET&safe=yes",
             headers={
                 "Authorization": "Bearer SYNTHETIC-AUTH-SECRET",
                 "Private-Token": "SYNTHETIC-GITLAB-SECRET",

--- a/tests/helpers/test_http_cache.py
+++ b/tests/helpers/test_http_cache.py
@@ -5,43 +5,82 @@ from pathlib import Path
 
 import pytest
 import requests
+from requests_cache import CachedResponse
+from requests_cache.cache_keys import redact_response
 
 from singer_sdk.helpers.http_cache import (
     SafeCachedSession,
+    _cache_key,
     _decode_text,
+    _json_credentials,
     _strip_form_body,
     _strip_json_body,
-    _strip_request,
     _strip_url,
-    sanitise_response_for_cache,
 )
 
 
 class _SyntheticAdapter(requests.adapters.BaseAdapter):
-    def __init__(self, *, response_url: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        response_url: str | None = None,
+        redirect_to: str | None = None,
+        body: str | None = None,
+        content_type: str = "application/json",
+    ) -> None:
         self.response_url = response_url
+        self.redirect_to = redirect_to
+        self.body = body
+        self.content_type = content_type
         self.seen_headers = {}
         self.seen_body = None
+        self.seen_requests: list[requests.PreparedRequest] = []
 
     def send(self, request, **kwargs):  # noqa: ARG002
+        self.seen_requests.append(request)
         self.seen_headers = dict(request.headers)
         self.seen_body = request.body
         response = requests.Response()
-        response.status_code = 200
         response.url = self.response_url or request.url
         response.request = request
-        response.headers["Set-Cookie"] = "session=SYNTHETIC-COOKIE-SECRET"
-        response._content = b'{"result": "synthetic"}'
+        headers = {
+            "Content-Type": self.content_type,
+            "Set-Cookie": "session=SYNTHETIC-COOKIE-SECRET",
+        }
+        if self.redirect_to and len(self.seen_requests) == 1:
+            response.status_code = 302
+            headers["Location"] = self.redirect_to
+        else:
+            response.status_code = 200
+        response.headers.update(headers)
+        response.cookies.set("session", "SYNTHETIC-COOKIE-SECRET")
+        response._content = (
+            self.body or json.dumps({"call": len(self.seen_requests)})
+        ).encode()
         response.raw = requests.packages.urllib3.response.HTTPResponse(
             body=response._content,
-            headers={"Set-Cookie": "session=SYNTHETIC-COOKIE-SECRET"},
-            status=200,
+            headers=headers,
+            status=response.status_code,
             request_url=request.url,
+            preload_content=False,
         )
         return response
 
     def close(self) -> None:
         pass
+
+
+def _cache_files(cache_path: Path) -> list[Path]:
+    return [path for path in cache_path.rglob("*.json") if path.is_file()]
+
+
+def _persisted(cache_path: Path) -> bytes:
+    """Return every byte written to the response cache, asserting some was."""
+    files = _cache_files(cache_path)
+    assert files, "no cache file was written"
+    persisted = b"\n".join(path.read_bytes() for path in files)
+    assert persisted.strip(), "cache files are empty"
+    return persisted
 
 
 def test_cache_files_never_persist_synthetic_credentials(tmp_path: Path) -> None:
@@ -73,13 +112,178 @@ def test_cache_files_never_persist_synthetic_credentials(tmp_path: Path) -> None
     assert response.status_code == 200
     assert "SYNTHETIC-AUTH-SECRET" in adapter.seen_headers["Authorization"]
     assert b"SYNTHETIC-BODY-SECRET" in adapter.seen_body
-    persisted = b"\n".join(
-        path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()
-    ).lower()
+    persisted = _persisted(tmp_path).lower()
     for marker in marker_values:
         assert marker.lower().encode() not in persisted
     for header in (b"authorization", b"private-token", b"set-cookie", b"cookie"):
         assert header not in persisted
+
+
+def test_requests_cache_still_redacts_canonically_cased_headers(
+    tmp_path: Path,
+) -> None:
+    """requests-cache is the second layer, and it matches header names as sent.
+
+    ``filter_sort_dict`` tests ``name in ignored_parameters`` against the original
+    casing yielded by ``CaseInsensitiveDict.items()``, so a lower-case-only list
+    silently disables its own redaction.
+    """
+    adapter = _SyntheticAdapter()
+    prepared = requests.Request(
+        "GET",
+        "https://example.invalid/data",
+        headers={"Authorization": "Bearer SYNTHETIC-AUTH-SECRET"},
+    ).prepare()
+
+    with SafeCachedSession(cache_path=tmp_path) as session:
+        redacted = redact_response(
+            CachedResponse.from_response(adapter.send(prepared)),
+            session.settings.ignored_parameters,
+        )
+
+    assert redacted.headers["Set-Cookie"] == "REDACTED"
+    assert redacted.request.headers["Authorization"] == "REDACTED"
+
+
+def test_cache_files_never_persist_credentials_sent_via_send(tmp_path: Path) -> None:
+    """A request prepared elsewhere must not skip sanitisation.
+
+    ``requests.Session.send`` only dispatches ``request.hooks``; session hooks are
+    merged in by ``prepare_request``, so a hook is no control at all here.
+    """
+    with SafeCachedSession(cache_path=tmp_path) as session:
+        session.mount("https://", _SyntheticAdapter())
+        prepared = requests.Request(
+            "GET",
+            "https://example.invalid/data?access_token=SYNTHETIC-QUERY-SECRET",
+            headers={"Authorization": "Bearer SYNTHETIC-AUTH-SECRET"},
+        ).prepare()
+        response = session.send(prepared)
+
+    assert response.status_code == 200
+    persisted = _persisted(tmp_path).lower()
+    for marker in (b"synthetic-auth-secret", b"synthetic-query-secret"):
+        assert marker not in persisted
+    assert b"authorization" not in persisted
+
+
+def test_cache_files_never_persist_response_body_credentials(tmp_path: Path) -> None:
+    body = json.dumps({"access_token": "SYNTHETIC-SESSION-SECRET", "safe": "yes"})
+    with SafeCachedSession(cache_path=tmp_path) as session:
+        session.mount("https://", _SyntheticAdapter(body=body))
+        response = session.get("https://example.invalid/session")
+
+    assert response.text == body
+    persisted = _persisted(tmp_path)
+    assert b"SYNTHETIC-SESSION-SECRET" not in persisted
+    assert b"safe" in persisted
+
+
+def test_cache_hit_is_served_without_a_second_request(tmp_path: Path) -> None:
+    with SafeCachedSession(cache_path=tmp_path) as session:
+        adapter = _SyntheticAdapter()
+        session.mount("https://", adapter)
+        first = session.get("https://example.invalid/data")
+        second = session.get("https://example.invalid/data")
+
+    assert len(adapter.seen_requests) == 1
+    assert not first.from_cache
+    assert second.from_cache
+    assert second.json() == first.json()
+
+
+def test_distinct_credentials_do_not_share_a_cache_entry(tmp_path: Path) -> None:
+    """Two tenants must never be served each other's cached body."""
+    with SafeCachedSession(cache_path=tmp_path) as session:
+        adapter = _SyntheticAdapter()
+        session.mount("https://", adapter)
+        first = session.get("https://example.invalid/data?access_token=TENANT-A")
+        second = session.get("https://example.invalid/data?access_token=TENANT-B")
+
+    assert len(adapter.seen_requests) == 2
+    assert not second.from_cache
+    assert first.json() == {"call": 1}
+    assert second.json() == {"call": 2}
+
+
+def test_distinct_authorization_headers_do_not_share_a_cache_entry(
+    tmp_path: Path,
+) -> None:
+    with SafeCachedSession(cache_path=tmp_path) as session:
+        adapter = _SyntheticAdapter()
+        session.mount("https://", adapter)
+        first = session.get(
+            "https://example.invalid/data",
+            headers={"Authorization": "Bearer TENANT-A"},
+        )
+        second = session.get(
+            "https://example.invalid/data",
+            headers={"Authorization": "Bearer TENANT-B"},
+        )
+
+    assert len(adapter.seen_requests) == 2
+    assert not second.from_cache
+    assert first.json() == {"call": 1}
+    assert second.json() == {"call": 2}
+
+
+def test_pagination_cursor_named_token_is_not_collapsed(tmp_path: Path) -> None:
+    """``token`` is a credential name *and* a common cursor name."""
+    with SafeCachedSession(cache_path=tmp_path) as session:
+        adapter = _SyntheticAdapter()
+        session.mount("https://", adapter)
+        page_1 = session.get("https://example.invalid/data?token=page-1")
+        page_2 = session.get("https://example.invalid/data?token=page-2")
+
+    assert len(adapter.seen_requests) == 2
+    assert page_1.json() == {"call": 1}
+    assert page_2.json() == {"call": 2}
+
+
+def test_redirect_hop_keeps_its_credentials(tmp_path: Path) -> None:
+    """Sanitising the live response would strip the request 302 handling reuses."""
+    with SafeCachedSession(cache_path=tmp_path) as session:
+        adapter = _SyntheticAdapter(redirect_to="https://example.invalid/moved")
+        session.mount("https://", adapter)
+        response = session.get(
+            "https://example.invalid/data",
+            headers={"Authorization": "Bearer SYNTHETIC-AUTH-SECRET"},
+            allow_redirects=True,
+        )
+
+    assert len(adapter.seen_requests) == 2
+    assert response.history
+    followed = adapter.seen_requests[1]
+    assert followed.headers["Authorization"] == "Bearer SYNTHETIC-AUTH-SECRET"
+    assert b"SYNTHETIC-AUTH-SECRET" not in _persisted(tmp_path)
+
+
+def test_next_request_keeps_its_credentials(tmp_path: Path) -> None:
+    with SafeCachedSession(cache_path=tmp_path) as session:
+        session.mount(
+            "https://", _SyntheticAdapter(redirect_to="https://example.invalid/moved")
+        )
+        response = session.get(
+            "https://example.invalid/data",
+            headers={"Authorization": "Bearer SYNTHETIC-AUTH-SECRET"},
+            allow_redirects=False,
+        )
+
+    assert response.status_code == 302
+    assert response.next is not None
+    assert response.next.headers["Authorization"] == "Bearer SYNTHETIC-AUTH-SECRET"
+    # A 302 is not a cacheable status, so nothing should have been written at all.
+    assert not _cache_files(tmp_path)
+
+
+def test_caller_still_sees_response_cookies(tmp_path: Path) -> None:
+    with SafeCachedSession(cache_path=tmp_path) as session:
+        session.mount("https://", _SyntheticAdapter())
+        response = session.get("https://example.invalid/data")
+
+    assert response.cookies["session"] == "SYNTHETIC-COOKIE-SECRET"
+    assert response.headers["Set-Cookie"] == "session=SYNTHETIC-COOKIE-SECRET"
+    assert b"SYNTHETIC-COOKIE-SECRET" not in _persisted(tmp_path)
 
 
 def test_cache_clears_unproven_post_bodies(tmp_path: Path) -> None:
@@ -98,9 +302,7 @@ def test_cache_clears_unproven_post_bodies(tmp_path: Path) -> None:
             )
             assert response.status_code == 200
 
-    persisted = b"\n".join(
-        path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()
-    )
+    persisted = _persisted(tmp_path)
     for marker, _ in markers_and_content_types:
         assert marker.encode() not in persisted
 
@@ -113,6 +315,18 @@ def test_default_cache_is_outside_current_directory(
     with SafeCachedSession() as session:
         assert not Path(session.cache.cache_dir).is_relative_to(tmp_path)
     assert not (tmp_path / ".http_cache").exists()
+
+
+def test_default_cache_location_is_stable_across_sessions() -> None:
+    """A per-instance temporary directory would make every request a miss."""
+    with (
+        SafeCachedSession(cache_name="test-stable") as first,
+        SafeCachedSession(cache_name="test-stable") as second,
+    ):
+        assert first.cache.cache_dir == second.cache.cache_dir
+
+    with SafeCachedSession(cache_name="test-other") as other:
+        assert other.cache.cache_dir != first.cache.cache_dir
 
 
 @pytest.mark.parametrize(
@@ -132,6 +346,13 @@ def test_decode_text(value: object, expected: str | None) -> None:
 
 def test_empty_url_is_returned_unchanged() -> None:
     assert not _strip_url("")
+
+
+def test_url_credentials_are_removed() -> None:
+    assert (
+        _strip_url("https://user:pass@example.invalid/x?token=secret&safe=kept")
+        == "https://example.invalid/x?safe=kept"
+    )
 
 
 def test_undecodable_bodies_are_dropped() -> None:
@@ -154,25 +375,41 @@ def test_json_body_sanitises_nested_lists() -> None:
     assert json.loads(stripped) == {"items": [{}, {"safe": "list-kept"}]}
 
 
-def test_strip_request_tolerates_missing_cookie_jar() -> None:
-    request = requests.Request(
-        "GET",
-        "https://example.invalid/x?access_token=SYNTHETIC-BARE-SECRET",
-        headers={"Authorization": "Bearer SYNTHETIC-BARE-SECRET"},
-    ).prepare()
-    del request._cookies
+def test_credentials_are_key_material_at_any_depth() -> None:
+    """requests-cache redacts only top-level parameters, so nesting is the gap.
 
-    _strip_request(request)
+    A session-level test cannot prove this: a body nested one level deep already
+    produces two distinct requests-cache keys on its own, so the recursion below
+    is what keeps a *redacted* nested credential apart, not what separates the
+    bodies.
+    """
+    nested_in_list = dict(_json_credentials({"items": [{"token": "IN-A-LIST"}]}))
+    nested_in_dict = dict(_json_credentials({"outer": {"token": "IN-A-DICT"}}))
 
-    assert "Authorization" not in request.headers
-    assert "SYNTHETIC-BARE-SECRET" not in request.url
+    assert nested_in_list == {"token": '"IN-A-LIST"'}
+    assert nested_in_dict == {"token": '"IN-A-DICT"'}
 
 
-def test_sanitise_response_tolerates_missing_raw() -> None:
-    response = requests.Response()
-    response.status_code = 200
-    response.url = "https://example.invalid/x?access_token=SYNTHETIC-RAW-SECRET"
+def test_url_userinfo_does_not_share_a_cache_entry() -> None:
+    """Userinfo is a credential, and requests-cache keys on it without our help."""
+    first = requests.PreparedRequest()
+    first.prepare(method="GET", url="https://tenant:USERINFO-A@example.invalid/data")
+    second = requests.PreparedRequest()
+    second.prepare(method="GET", url="https://tenant:USERINFO-B@example.invalid/data")
+    for request in (first, second):
+        del request.headers["Authorization"]
 
-    assert response.raw is None
-    assert sanitise_response_for_cache(response) is response
-    assert "SYNTHETIC-RAW-SECRET" not in response.url
+    assert _cache_key(first) != _cache_key(second)
+
+
+def test_non_json_bodies_are_never_reparsed_as_json(tmp_path: Path) -> None:
+    """A CSV export that happens to parse as JSON must survive the cache intact."""
+    body = '{"token": "SYNTHETIC-CSV-VALUE"}'
+    with SafeCachedSession(cache_path=tmp_path) as session:
+        session.mount("https://", _SyntheticAdapter(body=body, content_type="text/csv"))
+        live = session.get("https://example.invalid/export.csv")
+        cached = session.get("https://example.invalid/export.csv")
+
+    assert live.text == body
+    assert cached.from_cache
+    assert cached.text == body

--- a/tests/helpers/test_http_cache.py
+++ b/tests/helpers/test_http_cache.py
@@ -8,10 +8,17 @@ from singer_sdk.helpers.http_cache import SafeCachedSession
 
 
 class _SyntheticAdapter(requests.adapters.BaseAdapter):
+    def __init__(self, *, response_url: str | None = None) -> None:
+        self.response_url = response_url
+        self.seen_headers = {}
+        self.seen_body = None
+
     def send(self, request, **kwargs):  # noqa: ARG002
+        self.seen_headers = dict(request.headers)
+        self.seen_body = request.body
         response = requests.Response()
         response.status_code = 200
-        response.url = request.url
+        response.url = self.response_url or request.url
         response.request = request
         response.headers["Set-Cookie"] = "session=SYNTHETIC-COOKIE-SECRET"
         response._content = b'{"result": "synthetic"}'
@@ -34,11 +41,18 @@ def test_cache_files_never_persist_synthetic_credentials(tmp_path: Path) -> None
         "SYNTHETIC-COOKIE-SECRET",
         "SYNTHETIC-QUERY-SECRET",
         "SYNTHETIC-BODY-SECRET",
+        "SYNTHETIC-USERINFO-SECRET",
     }
     with SafeCachedSession(cache_path=tmp_path, allowable_methods=("POST",)) as session:
-        session.mount("https://", _SyntheticAdapter())
+        adapter = _SyntheticAdapter(
+            response_url=(
+                "https://user:SYNTHETIC-USERINFO-SECRET@example.invalid/result"
+            )
+        )
+        session.mount("https://", adapter)
         response = session.post(
-            "https://example.invalid/data?access_token=SYNTHETIC-QUERY-SECRET&safe=yes",
+            "https://user:SYNTHETIC-USERINFO-SECRET@example.invalid/data"
+            "?access_token=SYNTHETIC-QUERY-SECRET&safe=yes",
             headers={
                 "Authorization": "Bearer SYNTHETIC-AUTH-SECRET",
                 "Private-Token": "SYNTHETIC-GITLAB-SECRET",
@@ -48,6 +62,8 @@ def test_cache_files_never_persist_synthetic_credentials(tmp_path: Path) -> None
         )
 
     assert response.status_code == 200
+    assert "SYNTHETIC-AUTH-SECRET" in adapter.seen_headers["Authorization"]
+    assert b"SYNTHETIC-BODY-SECRET" in adapter.seen_body
     persisted = b"\n".join(
         path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()
     ).lower()
@@ -55,6 +71,29 @@ def test_cache_files_never_persist_synthetic_credentials(tmp_path: Path) -> None
         assert marker.lower().encode() not in persisted
     for header in (b"authorization", b"private-token", b"set-cookie", b"cookie"):
         assert header not in persisted
+
+
+def test_cache_clears_unproven_post_bodies(tmp_path: Path) -> None:
+    markers_and_content_types = (
+        ("SYNTHETIC-MALFORMED-JSON", "application/json"),
+        ("SYNTHETIC-MALFORMED-FORM", "application/x-www-form-urlencoded"),
+        ("SYNTHETIC-OPAQUE-BODY", "application/octet-stream"),
+    )
+    with SafeCachedSession(cache_path=tmp_path, allowable_methods=("POST",)) as session:
+        session.mount("https://", _SyntheticAdapter())
+        for index, (marker, content_type) in enumerate(markers_and_content_types):
+            response = session.post(
+                f"https://example.invalid/body/{index}",
+                headers={"Content-Type": content_type},
+                data=marker,
+            )
+            assert response.status_code == 200
+
+    persisted = b"\n".join(
+        path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()
+    )
+    for marker, _ in markers_and_content_types:
+        assert marker.encode() not in persisted
 
 
 def test_default_cache_is_outside_current_directory(

--- a/tests/helpers/test_http_cache.py
+++ b/tests/helpers/test_http_cache.py
@@ -51,7 +51,7 @@ def test_cache_files_never_persist_synthetic_credentials(tmp_path: Path) -> None
         )
         session.mount("https://", adapter)
         response = session.post(
-            "https://user:SYNTHETIC-USERINFO-SECRET@example.invalid/data"
+            "https://example.invalid/data"
             "?access_token=SYNTHETIC-QUERY-SECRET&safe=yes",
             headers={
                 "Authorization": "Bearer SYNTHETIC-AUTH-SECRET",

--- a/tests/helpers/test_http_cache.py
+++ b/tests/helpers/test_http_cache.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+import pytest
 import requests
 
-from singer_sdk.helpers.http_cache import SafeCachedSession
+from singer_sdk.helpers.http_cache import (
+    SafeCachedSession,
+    _decode_text,
+    _strip_form_body,
+    _strip_json_body,
+    _strip_request,
+    _strip_url,
+    sanitise_response_for_cache,
+)
 
 
 class _SyntheticAdapter(requests.adapters.BaseAdapter):
@@ -103,3 +113,66 @@ def test_default_cache_is_outside_current_directory(
     with SafeCachedSession() as session:
         assert not Path(session.cache.cache_dir).is_relative_to(tmp_path)
     assert not (tmp_path / ".http_cache").exists()
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        pytest.param("text", "text", id="str"),
+        pytest.param(b"text", "text", id="bytes"),
+        pytest.param(bytearray(b"text"), "text", id="bytearray"),
+        pytest.param(b"\xff\xfe", None, id="undecodable-bytes"),
+        pytest.param(None, None, id="none"),
+        pytest.param(object(), None, id="unsupported-type"),
+    ],
+)
+def test_decode_text(value: object, expected: str | None) -> None:
+    assert _decode_text(value) == expected
+
+
+def test_empty_url_is_returned_unchanged() -> None:
+    assert not _strip_url("")
+
+
+def test_undecodable_bodies_are_dropped() -> None:
+    assert _strip_form_body(None) is None
+    assert _strip_json_body(None) is None
+
+
+def test_form_body_keeps_safe_parameters() -> None:
+    assert (
+        _strip_form_body("token=SYNTHETIC-FORM-SECRET&safe=form-kept")
+        == "safe=form-kept"
+    )
+
+
+def test_json_body_sanitises_nested_lists() -> None:
+    stripped = _strip_json_body(
+        '{"items": [{"token": "SYNTHETIC-LIST-SECRET"}, {"safe": "list-kept"}]}'
+    )
+    assert stripped is not None
+    assert json.loads(stripped) == {"items": [{}, {"safe": "list-kept"}]}
+
+
+def test_strip_request_tolerates_missing_cookie_jar() -> None:
+    request = requests.Request(
+        "GET",
+        "https://example.invalid/x?access_token=SYNTHETIC-BARE-SECRET",
+        headers={"Authorization": "Bearer SYNTHETIC-BARE-SECRET"},
+    ).prepare()
+    del request._cookies
+
+    _strip_request(request)
+
+    assert "Authorization" not in request.headers
+    assert "SYNTHETIC-BARE-SECRET" not in request.url
+
+
+def test_sanitise_response_tolerates_missing_raw() -> None:
+    response = requests.Response()
+    response.status_code = 200
+    response.url = "https://example.invalid/x?access_token=SYNTHETIC-RAW-SECRET"
+
+    assert response.raw is None
+    assert sanitise_response_for_cache(response) is response
+    assert "SYNTHETIC-RAW-SECRET" not in response.url

--- a/uv.lock
+++ b/uv.lock
@@ -3137,6 +3137,9 @@ dependencies = [
 arrow = [
     { name = "pyarrow" },
 ]
+cache = [
+    { name = "requests-cache" },
+]
 faker = [
     { name = "faker" },
 ]
@@ -3324,6 +3327,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "referencing", specifier = ">=0.30.0" },
     { name = "requests", specifier = ">=2.25.1" },
+    { name = "requests-cache", marker = "extra == 'cache'", specifier = ">=1.3" },
     { name = "s3fs", marker = "extra == 's3'", specifier = ">=2024.9.0" },
     { name = "simpleeval", specifier = "==1.0.7" },
     { name = "simplejson", specifier = ">=3.17.6" },
@@ -3333,7 +3337,7 @@ requires-dist = [
     { name = "universal-pathlib", specifier = ">=0.2.6" },
     { name = "urllib3", specifier = ">=1.26.20" },
 ]
-provides-extras = ["arrow", "faker", "jwt", "msgspec", "parquet", "s3", "sql", "ssh", "testing"]
+provides-extras = ["arrow", "cache", "faker", "jwt", "msgspec", "parquet", "s3", "sql", "ssh", "testing"]
 
 [package.metadata.requires-dev]
 benchmark = [

--- a/uv.lock
+++ b/uv.lock
@@ -3138,6 +3138,7 @@ arrow = [
     { name = "pyarrow" },
 ]
 cache = [
+    { name = "attrs" },
     { name = "requests-cache" },
 ]
 faker = [
@@ -3305,6 +3306,7 @@ typing = [
 
 [package.metadata]
 requires-dist = [
+    { name = "attrs", marker = "extra == 'cache'", specifier = ">=21.2" },
     { name = "backports-datetime-fromisoformat", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "click", specifier = ">=8.2,<9" },
     { name = "cryptography", marker = "extra == 'jwt'", specifier = ">=3.4.6" },

--- a/uv.lock
+++ b/uv.lock
@@ -1731,12 +1731,14 @@ requires-dist = [
 name = "meltano-tap-gitlab"
 source = { editable = "packages/meltano-tap-gitlab" }
 dependencies = [
+    { name = "requests-cache" },
     { name = "singer-sdk" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "requests-cache", specifier = ">=1.3" },
     { name = "singer-sdk", editable = "." },
     { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.5.0" },
 ]


### PR DESCRIPTION
## Summary

Prevents SDK sample HTTP caches from persisting authentication material in the repository or on disk without sanitisation.

- disables persistent caching entirely for DummyJSON login and token-refresh POSTs;
- moves sample response caches to a process-owned temporary directory by default, while allowing tests/callers to inject a path;
- sanitises request `Authorization`, `Private-Token`, proxy/API-token headers, cookies, response `Set-Cookie`, URL userinfo and authentication query parameters before requests-cache serialisation;
- removes recognised credential fields from valid JSON/form bodies and fails closed by clearing malformed JSON/form or unsupported opaque POST bodies from the cached representation;
- clears response/request cookie jars and sanitises redirect request metadata;
- uses the shared safe session in the DummyJSON, GitLab and unauthenticated Countries sample producers;
- declares the previously implicit GitLab `requests-cache` runtime dependency and updates only its lock metadata;
- ignores future `.http_cache/` directories without deleting or inspecting the 116 currently tracked cache fixtures.

## Confidentiality boundary

This draft deliberately does **not** read, rewrite, delete or include the contents of any tracked cache file. Existing cache fixture classification, deletion, history remediation and credential rotation require a confidential maintainer review and are outside this code-only contribution.

## Verification at `6bc474405d308142b4cd97b08ec7d05f6f127c59`

- `uv sync --locked --python 3.13 --no-dev --group testing --all-packages` completed;
- all three sample cache producer modules imported from that clean locked environment;
- `pytest tests/helpers/test_http_cache.py -q` — 3 passed using synthetic marker secrets only;
- the cache-file regressions recursively scan only their own temporary synthetic cache and prove header/query/body/userinfo marker values are absent, including malformed JSON/form and opaque bodies;
- the adapter snapshot proves authentication and request bodies still reach the transport before the response hook sanitises the cache representation;
- Ruff check and format checks passed for every changed Python file;
- `git diff --check` passed.

No external API or service was contacted by the tests.

## Summary by Sourcery

Keep SDK sample authentication material out of persistent HTTP caches while preserving safe caching behavior for sample data.

New Features:
- Add a shared safe filesystem-backed HTTP cache for SDK sample taps with configurable cache locations and credential-aware cache keys.

Bug Fixes:
- Prevent authentication material from being persisted in cached requests and responses, including headers, cookies, URL userinfo, authentication query parameters, JSON/form bodies, redirects, and response payloads.
- Prevent distinct credentials and pagination cursors from incorrectly sharing cache entries.
- Disable persistence for DummyJSON authentication and token-refresh requests.

Enhancements:
- Use the safe cache session across the Countries, DummyJSON, and GitLab sample producers while keeping live requests and caller-visible responses unchanged.

Build:
- Declare the shared cache extras and GitLab's requests-cache runtime dependency, updating the lock metadata.

Tests:
- Add comprehensive synthetic cache regression coverage for credential sanitisation, cache isolation, redirects, response handling, malformed and opaque bodies, and default cache placement.

Chores:
- Ignore future .http_cache directories without modifying existing tracked cache fixtures.