### PR TITLE
SPAM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,8 +146,12 @@ jobs:
   tests-external:
     name: External Tests
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.head.repo.fork }}
     env:
+      EXTERNAL_TESTS_ENABLED: >-
+        ${{ github.repository == 'meltano/sdk' &&
+            secrets.SAMPLE_TAP_GITLAB_AUTH_TOKEN != '' &&
+            secrets.SAMPLE_TAP_GITLAB_GROUP_IDS != '' &&
+            secrets.SAMPLE_TAP_GITLAB_PROJECT_IDS != '' }}
       NOXSESSION: test-external
       TAP_GITLAB_AUTH_TOKEN: ${{ secrets.SAMPLE_TAP_GITLAB_AUTH_TOKEN }}
       TAP_GITLAB_GROUP_IDS: ${{ secrets.SAMPLE_TAP_GITLAB_GROUP_IDS }}
@@ -156,29 +160,41 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      if: env.EXTERNAL_TESTS_ENABLED == 'true'
       with:
         fetch-depth: 0
         persist-credentials: false
 
     - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      if: env.EXTERNAL_TESTS_ENABLED == 'true'
       with:
         cache-suffix: external
         version: ${{ env.UV_VERSION }}
 
     - name: Install Nox
+      if: env.EXTERNAL_TESTS_ENABLED == 'true'
       run: |
         uv tool install nox
         nox --version
 
     - name: Run Nox
+      if: env.EXTERNAL_TESTS_ENABLED == 'true'
       run: |
         nox
+
+    - name: Report external test skip
+      if: env.EXTERNAL_TESTS_ENABLED != 'true'
+      run: |
+        echo "### External tests skipped" >> "$GITHUB_STEP_SUMMARY"
+        echo "External tests run only in meltano/sdk with all sample GitLab secrets configured." >> "$GITHUB_STEP_SUMMARY"
 
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
     needs: tests
     env:
+      CODECOV_UPLOAD_ENABLED: >-
+        ${{ github.repository == 'meltano/sdk' && secrets.CODECOV_TOKEN != '' }}
       NOXSESSION: coverage
     strategy:
       fail-fast: false
@@ -221,8 +237,16 @@ jobs:
       run: |
         nox -r --no-install -- xml
 
-    - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+    - name: Upload coverage to Codecov
+      if: env.CODECOV_UPLOAD_ENABLED == 'true'
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         fail_ci_if_error: true
         flags: ${{ matrix.flag }}
         token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Report Codecov upload skip
+      if: env.CODECOV_UPLOAD_ENABLED != 'true'
+      run: |
+        echo "### Codecov upload skipped" >> "$GITHUB_STEP_SUMMARY"
+        echo "Coverage XML was generated; upload requires meltano/sdk and its Codecov token." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,12 +146,11 @@ jobs:
   tests-external:
     name: External Tests
     runs-on: ubuntu-latest
+    # Forks have no access to the sample GitLab secrets, so the whole job is
+    # skipped there and never allocates a runner. Anywhere else the job runs,
+    # and a missing secret is a failure rather than a silently green no-op.
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     env:
-      EXTERNAL_TESTS_ENABLED: >-
-        ${{ github.repository == 'meltano/sdk' &&
-            secrets.SAMPLE_TAP_GITLAB_AUTH_TOKEN != '' &&
-            secrets.SAMPLE_TAP_GITLAB_GROUP_IDS != '' &&
-            secrets.SAMPLE_TAP_GITLAB_PROJECT_IDS != '' }}
       NOXSESSION: test-external
       TAP_GITLAB_AUTH_TOKEN: ${{ secrets.SAMPLE_TAP_GITLAB_AUTH_TOKEN }}
       TAP_GITLAB_GROUP_IDS: ${{ secrets.SAMPLE_TAP_GITLAB_GROUP_IDS }}
@@ -159,42 +158,41 @@ jobs:
       TAP_GITLAB_START_DATE: "2022-01-01T00:00:00Z"
 
     steps:
+    - name: Require sample GitLab secrets
+      run: |
+        status=0
+        for name in TAP_GITLAB_AUTH_TOKEN TAP_GITLAB_GROUP_IDS TAP_GITLAB_PROJECT_IDS; do
+          if [ -z "${!name}" ]; then
+            echo "::error::External tests need the ${name} secret, but it is empty"
+            status=1
+          fi
+        done
+        exit "${status}"
+
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      if: env.EXTERNAL_TESTS_ENABLED == 'true'
       with:
         fetch-depth: 0
         persist-credentials: false
 
     - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-      if: env.EXTERNAL_TESTS_ENABLED == 'true'
       with:
         cache-suffix: external
         version: ${{ env.UV_VERSION }}
 
     - name: Install Nox
-      if: env.EXTERNAL_TESTS_ENABLED == 'true'
       run: |
         uv tool install nox
         nox --version
 
     - name: Run Nox
-      if: env.EXTERNAL_TESTS_ENABLED == 'true'
       run: |
         nox
-
-    - name: Report external test skip
-      if: env.EXTERNAL_TESTS_ENABLED != 'true'
-      run: |
-        echo "### External tests skipped" >> "$GITHUB_STEP_SUMMARY"
-        echo "External tests run only in meltano/sdk with all sample GitLab secrets configured." >> "$GITHUB_STEP_SUMMARY"
 
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
     needs: tests
     env:
-      CODECOV_UPLOAD_ENABLED: >-
-        ${{ github.repository == 'meltano/sdk' && secrets.CODECOV_TOKEN != '' }}
       NOXSESSION: coverage
     strategy:
       fail-fast: false
@@ -237,16 +235,12 @@ jobs:
       run: |
         nox -r --no-install -- xml
 
+    # Runs on forks too: codecov-action uploads tokenlessly for public-repo pull
+    # requests, so `token` being empty is not a reason to skip the upload, and
+    # `fail_ci_if_error` stays reachable.
     - name: Upload coverage to Codecov
-      if: env.CODECOV_UPLOAD_ENABLED == 'true'
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         fail_ci_if_error: true
         flags: ${{ matrix.flag }}
         token: ${{ secrets.CODECOV_TOKEN }}
-
-    - name: Report Codecov upload skip
-      if: env.CODECOV_UPLOAD_ENABLED != 'true'
-      run: |
-        echo "### Codecov upload skipped" >> "$GITHUB_STEP_SUMMARY"
-        echo "Coverage XML was generated; upload requires meltano/sdk and its Codecov token." >> "$GITHUB_STEP_SUMMARY"

--- a/tests/test_workflow_safety.py
+++ b/tests/test_workflow_safety.py
@@ -22,6 +22,17 @@ def test_external_calls_require_upstream_identity_and_all_secrets() -> None:
     ):
         assert f"secrets.{secret} != ''" in guard
 
+    skip_step = next(
+        (
+            step
+            for step in external["steps"]
+            if step.get("name") == "Report external test skip"
+        ),
+        None,
+    )
+    assert skip_step is not None
+    assert skip_step.get("if") == "env.EXTERNAL_TESTS_ENABLED != 'true'"
+
     external_steps = [
         step
         for step in external["steps"]

--- a/tests/test_workflow_safety.py
+++ b/tests/test_workflow_safety.py
@@ -4,60 +4,60 @@ from pathlib import Path
 
 import yaml
 
+_GITLAB_SECRETS = (
+    "TAP_GITLAB_AUTH_TOKEN",
+    "TAP_GITLAB_GROUP_IDS",
+    "TAP_GITLAB_PROJECT_IDS",
+)
+
 
 def _test_workflow() -> dict:
     workflow_path = Path(__file__).parents[1] / ".github" / "workflows" / "test.yml"
     return yaml.load(workflow_path.read_text(), Loader=yaml.BaseLoader)
 
 
-def test_external_calls_require_upstream_identity_and_all_secrets() -> None:
+def test_external_tests_are_skipped_for_forks_and_only_for_forks() -> None:
+    """Only a fork may skip: anything else has to run or fail, never report green."""
     external = _test_workflow()["jobs"]["tests-external"]
-    guard = external["env"]["EXTERNAL_TESTS_ENABLED"]
 
-    assert "github.repository == 'meltano/sdk'" in guard
-    for secret in (
-        "SAMPLE_TAP_GITLAB_AUTH_TOKEN",
-        "SAMPLE_TAP_GITLAB_GROUP_IDS",
-        "SAMPLE_TAP_GITLAB_PROJECT_IDS",
-    ):
-        assert f"secrets.{secret} != ''" in guard
+    assert external["if"] == "${{ !github.event.pull_request.head.repo.fork }}"
+    assert "EXTERNAL_TESTS_ENABLED" not in external.get("env", {})
+    assert all("if" not in step for step in external["steps"])
 
-    skip_step = next(
-        (
-            step
-            for step in external["steps"]
-            if step.get("name") == "Report external test skip"
-        ),
-        None,
-    )
-    assert skip_step is not None
-    assert skip_step.get("if") == "env.EXTERNAL_TESTS_ENABLED != 'true'"
 
-    external_steps = [
+def test_missing_external_secrets_fail_the_job() -> None:
+    external = _test_workflow()["jobs"]["tests-external"]
+    guard = next(
         step
         for step in external["steps"]
-        if step.get("name") != "Report external test skip"
-    ]
-    assert external_steps
-    assert all(
-        step.get("if") == "env.EXTERNAL_TESTS_ENABLED == 'true'"
-        for step in external_steps
+        if step.get("name") == "Require sample GitLab secrets"
     )
 
+    assert external["steps"].index(guard) == 0
+    for secret in _GITLAB_SECRETS:
+        assert secret in guard["run"]
+        assert external["env"][secret] == f"${{{{ secrets.SAMPLE_{secret} }}}}"
+    assert "exit" in guard["run"]
 
-def test_coverage_generation_stays_required_but_upload_is_guarded() -> None:
+
+def test_codecov_upload_runs_on_forks_without_a_token() -> None:
+    """Fork pull requests uploaded coverage tokenlessly before, and still must."""
     coverage = _test_workflow()["jobs"]["coverage"]
-    guard = coverage["env"]["CODECOV_UPLOAD_ENABLED"]
 
-    assert "github.repository == 'meltano/sdk'" in guard
-    assert "secrets.CODECOV_TOKEN != ''" in guard
+    assert "CODECOV_UPLOAD_ENABLED" not in coverage["env"]
 
+    upload = next(
+        step
+        for step in coverage["steps"]
+        if step.get("uses", "").startswith("codecov/codecov-action@")
+    )
+    assert "if" not in upload
+    assert upload["with"]["fail_ci_if_error"] == "true"
+    assert "secrets.CODECOV_TOKEN" in upload["with"]["token"]
+
+
+def test_coverage_report_generation_is_unconditional() -> None:
+    coverage = _test_workflow()["jobs"]["coverage"]
     steps = {step.get("name"): step for step in coverage["steps"]}
+
     assert "if" not in steps["Create coverage report"]
-    assert steps["Upload coverage to Codecov"]["if"] == (
-        "env.CODECOV_UPLOAD_ENABLED == 'true'"
-    )
-    assert steps["Upload coverage to Codecov"]["with"]["fail_ci_if_error"] == "true"
-    assert steps["Report Codecov upload skip"]["if"] == (
-        "env.CODECOV_UPLOAD_ENABLED != 'true'"
-    )

--- a/tests/test_workflow_safety.py
+++ b/tests/test_workflow_safety.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def _test_workflow() -> dict:
+    workflow_path = Path(__file__).parents[1] / ".github" / "workflows" / "test.yml"
+    return yaml.load(workflow_path.read_text(), Loader=yaml.BaseLoader)
+
+
+def test_external_calls_require_upstream_identity_and_all_secrets() -> None:
+    external = _test_workflow()["jobs"]["tests-external"]
+    guard = external["env"]["EXTERNAL_TESTS_ENABLED"]
+
+    assert "github.repository == 'meltano/sdk'" in guard
+    for secret in (
+        "SAMPLE_TAP_GITLAB_AUTH_TOKEN",
+        "SAMPLE_TAP_GITLAB_GROUP_IDS",
+        "SAMPLE_TAP_GITLAB_PROJECT_IDS",
+    ):
+        assert f"secrets.{secret} != ''" in guard
+
+    external_steps = [
+        step
+        for step in external["steps"]
+        if step.get("name") != "Report external test skip"
+    ]
+    assert external_steps
+    assert all(
+        step.get("if") == "env.EXTERNAL_TESTS_ENABLED == 'true'"
+        for step in external_steps
+    )
+
+
+def test_coverage_generation_stays_required_but_upload_is_guarded() -> None:
+    coverage = _test_workflow()["jobs"]["coverage"]
+    guard = coverage["env"]["CODECOV_UPLOAD_ENABLED"]
+
+    assert "github.repository == 'meltano/sdk'" in guard
+    assert "secrets.CODECOV_TOKEN != ''" in guard
+
+    steps = {step.get("name"): step for step in coverage["steps"]}
+    assert "if" not in steps["Create coverage report"]
+    assert steps["Upload coverage to Codecov"]["if"] == (
+        "env.CODECOV_UPLOAD_ENABLED == 'true'"
+    )
+    assert steps["Upload coverage to Codecov"]["with"]["fail_ci_if_error"] == "true"
+    assert steps["Report Codecov upload skip"]["if"] == (
+        "env.CODECOV_UPLOAD_ENABLED != 'true'"
+    )


### PR DESCRIPTION
## Summary

Keeps fork and secretless workflow runs from contacting external services while preserving all core test, typing and coverage-report gates.

- runs the GitLab external-test setup and Nox session only when the workflow belongs to `meltano/sdk` **and** all three sample GitLab secrets are non-empty;
- records an explicit job-summary reason when external tests are skipped;
- keeps the coverage combine/report/XML steps unconditional;
- uploads to Codecov only for `meltano/sdk` with a non-empty token, retains `fail_ci_if_error: true` when upload is enabled, and records an explicit skip summary otherwise;
- adds static workflow regressions for both trust boundaries.

The core test and typing matrices are unchanged and unconditional.

## Verification at `0563e2dfc9b8c68766f856f5b0984c56761388fb`

- `pytest tests/test_workflow_safety.py -q` — 2 passed;
- Ruff check and format checks passed for the static regression;
- repository `actionlint` pre-commit hook passed for `.github/workflows/test.yml`;
- `git diff --check` passed.

No external service was contacted during validation.

## Summary by Sourcery

Restrict external-service tests to trusted workflows while preserving unconditional core validation and coverage reporting.

Bug Fixes:
- Prevent external GitLab tests from running in fork workflows and fail clearly when required sample secrets are unavailable.

Enhancements:
- Keep core testing, typing, coverage generation, and Codecov upload behavior unconditional, including tokenless fork uploads.
- Add workflow safety regression tests covering fork isolation, secret requirements, Codecov behavior, and unconditional coverage reporting.

CI:
- Harden the test workflow so external-service access is restricted to trusted contexts while preserving existing quality gates.

Tests:
- Add static tests that enforce the workflow’s external-service and coverage safety boundaries.