### PR TITLE
chore: Remove unused ty suppression comments

### DIFF
--- a/singer_sdk/helpers/_batch.py
+++ b/singer_sdk/helpers/_batch.py
@@ -222,7 +222,7 @@ class BatchConfig:
             self.encoding = BaseBatchFileEncoding.from_dict(self.encoding)  # type: ignore[unreachable]
 
         if isinstance(self.storage, dict):
-            self.storage = StorageTarget.from_dict(self.storage)  # ty: ignore[invalid-argument-type]
+            self.storage = StorageTarget.from_dict(self.storage)
 
         if self.batch_size is None:
             self.batch_size = DEFAULT_BATCH_SIZE  # type: ignore[unreachable]

--- a/singer_sdk/helpers/_flattening.py
+++ b/singer_sdk/helpers/_flattening.py
@@ -398,12 +398,12 @@ def _flatten_schema(  # noqa: C901, PLR0912
             and len(composite) > 0
             and (first_element := _first(composite))
         ):
-            if first_element["type"] == "string":  # ty:ignore[not-subscriptable]
-                items.append((new_key, {**first_element, "type": ["null", "string"]}))  # ty:ignore[invalid-argument-type]
-            elif first_element["type"] == "array":  # ty:ignore[not-subscriptable]
-                items.append((new_key, {**first_element, "type": ["null", "array"]}))  # ty:ignore[invalid-argument-type]
-            elif first_element["type"] == "object":  # ty:ignore[not-subscriptable]
-                items.append((new_key, {**first_element, "type": ["null", "object"]}))  # ty:ignore[invalid-argument-type]
+            if first_element["type"] == "string":
+                items.append((new_key, {**first_element, "type": ["null", "string"]}))
+            elif first_element["type"] == "array":
+                items.append((new_key, {**first_element, "type": ["null", "array"]}))
+            elif first_element["type"] == "object":
+                items.append((new_key, {**first_element, "type": ["null", "object"]}))
         else:
             # Handle typeless properties (e.g., "PropertyName": {})
             # Treat them as string type to allow JSON serialization

--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -610,7 +610,7 @@ class Sink(abc.ABC):  # noqa: PLR0904
                     date_val = handle_invalid_timestamp_in_record(
                         record,
                         [key],
-                        date_val,  # ty: ignore[invalid-argument-type]
+                        date_val,
                         datelike_type,
                         ex,
                         treatment,

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -159,11 +159,11 @@ class Stream(abc.ABC):  # noqa: PLR0904
 
         if schema:
             if isinstance(schema, (PathLike, str)):
-                if not Path(schema).is_file():  # ty: ignore[invalid-argument-type]
+                if not Path(schema).is_file():
                     msg = f"Could not find schema file '{self.schema_filepath}'."
                     raise FileNotFoundError(msg)
 
-                self._schema_filepath = Path(schema)  # ty: ignore[invalid-argument-type]
+                self._schema_filepath = Path(schema)
                 warnings.warn(
                     "Passing a schema filepath is deprecated. Please pass a schema "
                     "dictionary or a Singer Schema object instead.",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove obsolete type-checker suppression comments from batch helpers, schema flattening, timestamp parsing, and stream schema handling.