### PR TITLE
fix: Quiet down noisy null replication key bookmark advancement logs

### DIFF
--- a/singer_sdk/helpers/_state.py
+++ b/singer_sdk/helpers/_state.py
@@ -228,7 +228,7 @@ def increment_state(
     new_rk_value = to_json_compatible(latest_record[replication_key])
 
     if new_rk_value is None:
-        logger.warning("New replication value is null")
+        logger.debug("New replication value is null")
         return
 
     if old_rk_value is None or not check_sorted or new_rk_value >= old_rk_value:

--- a/tests/core/test_state_handling.py
+++ b/tests/core/test_state_handling.py
@@ -143,7 +143,7 @@ def test_null_replication_value(caplog):
     is_sorted = True
     check_sorted = False
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.DEBUG):
         _state.increment_state(
             stream_state,
             latest_record=latest_record,
@@ -155,7 +155,7 @@ def test_null_replication_value(caplog):
     assert stream_state["replication_key_value"] == "2021-05-17T20:41:16Z", (
         "State should not be updated."
     )
-    assert caplog.records[0].levelname == "WARNING"
+    assert caplog.records[0].levelname == "DEBUG"
     assert "is null" in caplog.records[0].message
 
 


### PR DESCRIPTION
SSIA, if a stream has 500k / 1M records with a null replication key value, that's 500k warning logs

## Summary by Sourcery

Lower the log severity of null replication value messages to keep high-volume replication logs quiet.

Bug Fixes:
- Reduce null replication value messages from warnings to debug logs to prevent excessive log noise for streams containing many null keys.

Tests:
- Update state handling coverage to verify null replication values are logged at debug level.