### PR TITLE
refactor: Define explicit public exports for Singer SDK modules

### DIFF
--- a/singer_sdk/contrib/msgspec.py
+++ b/singer_sdk/contrib/msgspec.py
@@ -20,6 +20,11 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import override
 
+__all__ = [
+    "MsgSpecReader",
+    "MsgSpecWriter",
+]
+
 logger = logging.getLogger(__name__)
 
 

--- a/singer_sdk/singerlib/catalog.py
+++ b/singer_sdk/singerlib/catalog.py
@@ -24,6 +24,15 @@ if t.TYPE_CHECKING:
     else:
         from typing_extensions import Self
 
+__all__ = [
+    "Catalog",
+    "CatalogEntry",
+    "Metadata",
+    "MetadataMapping",
+    "SelectionMask",
+    "StreamMetadata",
+]
+
 Breadcrumb: t.TypeAlias = tuple[str, ...]
 
 logger = logging.getLogger(__name__)

--- a/singer_sdk/singerlib/encoding/base.py
+++ b/singer_sdk/singerlib/encoding/base.py
@@ -16,6 +16,12 @@ if sys.version_info < (3, 11):
 
     MonkeyPatch.patch_fromisoformat()
 
+__all__ = [
+    "GenericSingerReader",
+    "GenericSingerWriter",
+    "SingerMessageType",
+]
+
 logger = logging.getLogger(__name__)
 
 

--- a/singer_sdk/singerlib/encoding/simple.py
+++ b/singer_sdk/singerlib/encoding/simple.py
@@ -28,6 +28,16 @@ if t.TYPE_CHECKING:
     else:
         from typing_extensions import Self
 
+__all__ = [
+    "ActivateVersionMessage",
+    "Message",
+    "RecordMessage",
+    "SchemaMessage",
+    "SimpleSingerReader",
+    "SimpleSingerWriter",
+    "StateMessage",
+]
+
 Schema: t.TypeAlias = Mapping[str, t.Any]
 
 logger = logging.getLogger(__name__)

--- a/singer_sdk/singerlib/schema.py
+++ b/singer_sdk/singerlib/schema.py
@@ -12,6 +12,11 @@ from referencing.jsonschema import DRAFT202012
 if t.TYPE_CHECKING:
     from referencing._core import Resolver
 
+__all__ = [
+    "Schema",
+    "resolve_schema_references",
+]
+
 _SchemaDict: t.TypeAlias = dict[str, t.Any]
 
 META_KEYS = [


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Define explicit public export lists for Singer SDK contribution, catalog, encoding, and schema modules.