### PR TITLE
refactor: Make the `MetadataMapping.__getitem__` key param positional-only

### DIFF
--- a/singer_sdk/singerlib/catalog.py
+++ b/singer_sdk/singerlib/catalog.py
@@ -170,13 +170,13 @@ class MetadataMapping(dict[Breadcrumb, AnyMetadata]):  # noqa: FURB189
         return self[breadcrumb]
 
     @t.overload
-    def __getitem__(self, key: tuple[()]) -> StreamMetadata: ...
+    def __getitem__(self, key: tuple[()], /) -> StreamMetadata: ...
 
     @t.overload
-    def __getitem__(self, key: Breadcrumb) -> Metadata: ...
+    def __getitem__(self, key: Breadcrumb, /) -> Metadata: ...
 
     @override
-    def __getitem__(self, key: Breadcrumb) -> AnyMetadata:
+    def __getitem__(self, key: Breadcrumb, /) -> AnyMetadata:
         return super().__getitem__(key)
 
     @property


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Make `MetadataMapping` key access positional-only while preserving its existing metadata lookup behavior.