### PR TITLE
feat(targets): add configurable batch wait time limit

### DIFF
--- a/singer_sdk/helpers/capabilities.py
+++ b/singer_sdk/helpers/capabilities.py
@@ -304,6 +304,17 @@ TARGET_BATCH_SIZE_ROWS_CONFIG = PropertiesList(
         description="Maximum number of rows in each batch.",
     ),
 ).to_dict()
+TARGET_BATCH_WAIT_LIMIT_SECONDS_CONFIG = PropertiesList(
+    Property(
+        "batch_wait_limit_seconds",
+        IntegerType,
+        title="Batch Wait Limit (Seconds)",
+        description=(
+            "Maximum number of seconds to wait for a batch to reach "
+            "the configured batch size before processing it anyway."
+        ),
+    ),
+).to_dict()
 
 
 class TargetLoadMethods(str, Enum):

--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -360,7 +360,9 @@ class Sink(abc.ABC):  # noqa: PLR0904
         """True if the current batch has exceeded the wait time limit."""
         if self._batch_start_time is None or self.batch_wait_limit_seconds is None:
             return False
-        return (time.monotonic() - self._batch_start_time) >= self.batch_wait_limit_seconds
+        return (
+            time.monotonic() - self._batch_start_time
+        ) >= self.batch_wait_limit_seconds
 
     @property
     def max_size(self) -> int:
@@ -656,7 +658,7 @@ class Sink(abc.ABC):  # noqa: PLR0904
 
     # SDK developer overrides:
 
-    def preprocess_record(self, record: dict, context: dict) -> dict:  # noqa: PLR6301, ARG002
+    def preprocess_record(self, record: dict, context: dict) -> dict:  # noqa: ARG002
         """Process incoming record and return a modified result.
 
         Args:

--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -206,6 +206,10 @@ class Sink(abc.ABC):  # noqa: PLR0904
         self._batch_size_rows: int | None = target.config.get(
             "batch_size_rows",
         )
+        self._batch_wait_limit_seconds: int | None = target.config.get(
+            "batch_wait_limit_seconds",
+        )
+        self._batch_start_time: float | None = None
 
         # Track fields we've already warned about missing from schema
         self._warned_missing_fields: set[str] = set()
@@ -328,7 +332,7 @@ class Sink(abc.ABC):  # noqa: PLR0904
     @property
     def is_full(self) -> bool:
         """True if the sink needs to be drained."""
-        return self.current_size >= self.max_size
+        return self.current_size >= self.max_size or self.is_too_old
 
     @property
     def batch_size_rows(self) -> int | None:
@@ -337,6 +341,21 @@ class Sink(abc.ABC):  # noqa: PLR0904
         Or None if not set.
         """
         return self._batch_size_rows
+
+    @property
+    def batch_wait_limit_seconds(self) -> int | None:
+        """The maximum number of seconds to wait for a batch to fill.
+
+        Or None if not set.
+        """
+        return self._batch_wait_limit_seconds
+
+    @property
+    def is_too_old(self) -> bool:
+        """True if the current batch has exceeded the wait time limit."""
+        if self._batch_start_time is None or self.batch_wait_limit_seconds is None:
+            return False
+        return (time.time() - self._batch_start_time) >= self.batch_wait_limit_seconds
 
     @property
     def max_size(self) -> int:
@@ -628,6 +647,8 @@ class Sink(abc.ABC):  # noqa: PLR0904
         Args:
             context: Stream partition or context dictionary.
         """
+        if self._batch_start_time is None:
+            self._batch_start_time = time.time()
         self.logger.debug("Processed record: %s", context)
 
     # SDK developer overrides:
@@ -695,6 +716,7 @@ class Sink(abc.ABC):  # noqa: PLR0904
         self.drained_state = self._draining_state
         self._draining_state = None
         self._context_draining = None
+        self._batch_start_time = None
         if self._batch_records_read:
             self.tally_record_written(
                 self._batch_records_read - self._batch_dupe_records_merged,

--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -209,6 +209,11 @@ class Sink(abc.ABC):  # noqa: PLR0904
         self._batch_wait_limit_seconds: int | None = target.config.get(
             "batch_wait_limit_seconds",
         )
+        if (
+            self._batch_wait_limit_seconds is not None
+            and self._batch_wait_limit_seconds < 0
+        ):
+            self._batch_wait_limit_seconds = None
         self._batch_start_time: float | None = None
 
         # Track fields we've already warned about missing from schema
@@ -355,7 +360,7 @@ class Sink(abc.ABC):  # noqa: PLR0904
         """True if the current batch has exceeded the wait time limit."""
         if self._batch_start_time is None or self.batch_wait_limit_seconds is None:
             return False
-        return (time.time() - self._batch_start_time) >= self.batch_wait_limit_seconds
+        return (time.monotonic() - self._batch_start_time) >= self.batch_wait_limit_seconds
 
     @property
     def max_size(self) -> int:
@@ -647,8 +652,6 @@ class Sink(abc.ABC):  # noqa: PLR0904
         Args:
             context: Stream partition or context dictionary.
         """
-        if self._batch_start_time is None:
-            self._batch_start_time = time.time()
         self.logger.debug("Processed record: %s", context)
 
     # SDK developer overrides:
@@ -663,6 +666,8 @@ class Sink(abc.ABC):  # noqa: PLR0904
         Returns:
             A new, processed record.
         """
+        if self._batch_start_time is None:
+            self._batch_start_time = time.monotonic()
         return record
 
     @abc.abstractmethod

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -340,6 +340,11 @@ class Target(BaseSingerReader, abc.ABC):
         """
         self._assert_line_requires(message_dict, requires={"stream", "record"})
 
+        # Drain any sinks whose batches expired since the last record.
+        for sink in self._sinks_active.values():
+            if sink.is_full:
+                self.drain_one(sink)
+
         stream_name = message_dict["stream"]
         if stream_name not in self.mapper.stream_maps:
             self._assert_sink_exists(stream_name)

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -21,6 +21,7 @@ from singer_sdk.helpers.capabilities import (
     ADD_RECORD_METADATA_CONFIG,
     BATCH_CONFIG,
     TARGET_BATCH_SIZE_ROWS_CONFIG,
+    TARGET_BATCH_WAIT_LIMIT_SECONDS_CONFIG,
     TARGET_LOAD_METHOD_CONFIG,
     TARGET_VALIDATE_RECORDS_CONFIG,
     PluginCapabilities,
@@ -674,6 +675,7 @@ class Target(BaseSingerReader, abc.ABC):
         _merge_missing(ADD_RECORD_METADATA_CONFIG, config_jsonschema)
         _merge_missing(TARGET_LOAD_METHOD_CONFIG, config_jsonschema)
         _merge_missing(TARGET_BATCH_SIZE_ROWS_CONFIG, config_jsonschema)
+        _merge_missing(TARGET_BATCH_WAIT_LIMIT_SECONDS_CONFIG, config_jsonschema)
 
         capabilities = cls.capabilities
 

--- a/tests/core/test_target_base.py
+++ b/tests/core/test_target_base.py
@@ -406,3 +406,55 @@ def test_negative_batch_wait_limit_seconds_ignored():
     )
     assert sink._batch_wait_limit_seconds is None
     assert sink.batch_wait_limit_seconds is None
+
+
+def test_expired_batch_drained_on_next_record():
+    input_schema = {
+        "properties": {
+            "id": {"type": ["string", "null"]},
+        },
+    }
+    key_properties = []
+    target = TargetMock(config={"batch_wait_limit_seconds": 1})
+    sink = BatchSinkMock(
+        target=target,
+        stream_name="foo",
+        schema=input_schema,
+        key_properties=key_properties,
+    )
+    target._sinks_active["foo"] = sink
+
+    # Open a batch with a record and then fake-expire it.
+    sink._get_context({"id": "old"})
+    sink.process_record({"id": "old"}, sink._pending_batch)
+    sink._batch_start_time = time.monotonic() - 2
+
+    # Verify the sink reports as full due to time expiry.
+    assert sink.is_too_old is True
+    assert sink.is_full is True
+
+    # Drain and verify state is reset.
+    sink.start_drain()
+    sink.process_batch(sink._context_draining)
+    sink.mark_drained()
+    assert sink._batch_start_time is None
+    assert sink._batch_records_read == 0
+    assert target.num_batches_processed == 1
+
+
+def test_preprocess_record_starts_timer():
+    input_schema = {
+        "properties": {
+            "id": {"type": ["string", "null"]},
+        },
+    }
+    target = TargetMock()
+    sink = BatchSinkMock(
+        target=target,
+        stream_name="foo",
+        schema=input_schema,
+        key_properties=[],
+    )
+    assert sink._batch_start_time is None
+    sink.preprocess_record({"id": "x"}, {})
+    assert sink._batch_start_time is not None

--- a/tests/core/test_target_base.py
+++ b/tests/core/test_target_base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import signal
+import time
 from unittest import mock
 
 import pytest
@@ -257,3 +258,134 @@ def test_duplicate_termination_signal_does_not_redrain():
 
     assert exc_info.value.code == 0
     assert len(drain_calls) == 1
+
+
+def test_batch_wait_limit_seconds_config():
+    input_schema = {
+        "properties": {
+            "id": {"type": ["string", "null"]},
+        },
+    }
+    key_properties = []
+    target_default = TargetMock()
+    sink_default = BatchSinkMock(
+        target=target_default,
+        stream_name="foo",
+        schema=input_schema,
+        key_properties=key_properties,
+    )
+    assert sink_default._batch_wait_limit_seconds is None
+    assert sink_default.batch_wait_limit_seconds is None
+
+    target_set = TargetMock(config={"batch_wait_limit_seconds": 30})
+    sink_set = BatchSinkMock(
+        target=target_set,
+        stream_name="bar",
+        schema=input_schema,
+        key_properties=key_properties,
+    )
+    assert sink_set._batch_wait_limit_seconds == 30
+    assert sink_set.batch_wait_limit_seconds == 30
+
+
+def test_is_too_old_false_when_no_start_time():
+    input_schema = {
+        "properties": {
+            "id": {"type": ["string", "null"]},
+        },
+    }
+    target = TargetMock(config={"batch_wait_limit_seconds": 5})
+    sink = BatchSinkMock(
+        target=target,
+        stream_name="foo",
+        schema=input_schema,
+        key_properties=[],
+    )
+    assert sink._batch_start_time is None
+    assert sink.is_too_old is False
+
+
+def test_is_too_old_false_within_limit():
+    input_schema = {
+        "properties": {
+            "id": {"type": ["string", "null"]},
+        },
+    }
+    target = TargetMock(config={"batch_wait_limit_seconds": 10})
+    sink = BatchSinkMock(
+        target=target,
+        stream_name="foo",
+        schema=input_schema,
+        key_properties=[],
+    )
+    sink._batch_start_time = time.time()
+    assert sink.is_too_old is False
+
+
+def test_is_too_old_true_after_limit():
+    input_schema = {
+        "properties": {
+            "id": {"type": ["string", "null"]},
+        },
+    }
+    target = TargetMock(config={"batch_wait_limit_seconds": 1})
+    sink = BatchSinkMock(
+        target=target,
+        stream_name="foo",
+        schema=input_schema,
+        key_properties=[],
+    )
+    sink._batch_start_time = time.time() - 2
+    assert sink.is_too_old is True
+
+
+def test_is_full_includes_too_old():
+    input_schema = {
+        "properties": {
+            "id": {"type": ["string", "null"]},
+        },
+    }
+    target = TargetMock(config={"batch_wait_limit_seconds": 1})
+    sink = BatchSinkMock(
+        target=target,
+        stream_name="foo",
+        schema=input_schema,
+        key_properties=[],
+    )
+    # Batch not started yet, not full by size
+    sink._batch_records_read = 0
+    assert sink.is_full is False
+
+    # Batch started but not yet expired
+    sink._batch_start_time = time.time()
+    assert sink.is_full is False
+
+    # Batch expired
+    sink._batch_start_time = time.time() - 2
+    assert sink.is_full is True
+
+
+def test_batch_start_time_reset_on_drain():
+    input_schema = {
+        "properties": {
+            "id": {"type": ["string", "null"]},
+        },
+    }
+    target = TargetMock(config={"batch_wait_limit_seconds": 10})
+    sink = BatchSinkMock(
+        target=target,
+        stream_name="foo",
+        schema=input_schema,
+        key_properties=[],
+    )
+    sink._batch_start_time = time.time()
+    sink._batch_records_read = 5
+    sink.mark_drained()
+    assert sink._batch_start_time is None
+    assert sink._batch_records_read == 0
+
+
+def test_batch_wait_limit_seconds_in_about():
+    target = TargetMock()
+    about = target._get_about_info()
+    assert "batch_wait_limit_seconds" in about.settings["properties"]

--- a/tests/core/test_target_base.py
+++ b/tests/core/test_target_base.py
@@ -318,7 +318,7 @@ def test_is_too_old_false_within_limit():
         schema=input_schema,
         key_properties=[],
     )
-    sink._batch_start_time = time.time()
+    sink._batch_start_time = time.monotonic()
     assert sink.is_too_old is False
 
 
@@ -335,7 +335,7 @@ def test_is_too_old_true_after_limit():
         schema=input_schema,
         key_properties=[],
     )
-    sink._batch_start_time = time.time() - 2
+    sink._batch_start_time = time.monotonic() - 2
     assert sink.is_too_old is True
 
 
@@ -357,11 +357,11 @@ def test_is_full_includes_too_old():
     assert sink.is_full is False
 
     # Batch started but not yet expired
-    sink._batch_start_time = time.time()
+    sink._batch_start_time = time.monotonic()
     assert sink.is_full is False
 
     # Batch expired
-    sink._batch_start_time = time.time() - 2
+    sink._batch_start_time = time.monotonic() - 2
     assert sink.is_full is True
 
 
@@ -378,7 +378,7 @@ def test_batch_start_time_reset_on_drain():
         schema=input_schema,
         key_properties=[],
     )
-    sink._batch_start_time = time.time()
+    sink._batch_start_time = time.monotonic()
     sink._batch_records_read = 5
     sink.mark_drained()
     assert sink._batch_start_time is None
@@ -389,3 +389,20 @@ def test_batch_wait_limit_seconds_in_about():
     target = TargetMock()
     about = target._get_about_info()
     assert "batch_wait_limit_seconds" in about.settings["properties"]
+
+
+def test_negative_batch_wait_limit_seconds_ignored():
+    input_schema = {
+        "properties": {
+            "id": {"type": ["string", "null"]},
+        },
+    }
+    target = TargetMock(config={"batch_wait_limit_seconds": -5})
+    sink = BatchSinkMock(
+        target=target,
+        stream_name="foo",
+        schema=input_schema,
+        key_properties=[],
+    )
+    assert sink._batch_wait_limit_seconds is None
+    assert sink.batch_wait_limit_seconds is None

--- a/tests/core/test_target_base.py
+++ b/tests/core/test_target_base.py
@@ -424,22 +424,24 @@ def test_expired_batch_drained_on_next_record():
     )
     target._sinks_active["foo"] = sink
 
-    # Open a batch with a record and then fake-expire it.
+    # Register the stream in the mapper so _process_record_message finds it.
+    target.mapper.register_raw_stream_schema(
+        "foo",
+        input_schema,
+        key_properties,
+    )
+
+    # Simulate an expired batch by going through the normal flow.
     sink._get_context({"id": "old"})
     sink.process_record({"id": "old"}, sink._pending_batch)
     sink._batch_start_time = time.monotonic() - 2
 
-    # Verify the sink reports as full due to time expiry.
-    assert sink.is_too_old is True
-    assert sink.is_full is True
-
-    # Drain and verify state is reset.
-    sink.start_drain()
-    sink.process_batch(sink._context_draining)
-    sink.mark_drained()
-    assert sink._batch_start_time is None
-    assert sink._batch_records_read == 0
+    # Processing a new record should drain the expired batch first.
+    target._process_record_message(
+        {"stream": "foo", "record": {"id": "new"}, "time_extracted": None},
+    )
     assert target.num_batches_processed == 1
+    assert any(r.get("id") == "new" for r in target.records_written)
 
 
 def test_preprocess_record_starts_timer():

--- a/tests/sql/test_target.py
+++ b/tests/sql/test_target.py
@@ -53,5 +53,6 @@ def test_target_about_info(
         "add_record_metadata",
         "load_method",
         "batch_size_rows",
+        "batch_wait_limit_seconds",
     }
     assert set(about.settings["properties"]) == expected_settings | default_settings


### PR DESCRIPTION
## Summary

- add a new target-level setting `batch_wait_limit_seconds` that sets the maximum time a batch can remain open before being processed, regardless of row count
- track batch start time in `Sink._batch_start_time` and reset it after each drain
- add `Sink.is_too_old` property to check elapsed time against the configured limit
- update `Sink.is_full` to trigger a drain when the time limit is exceeded
- drain expired batches at the start of record processing so batches that exceeded their limit while idle are handled before the next record

This addresses the case where a target runs in a memory-constrained environment and cannot afford to wait for large batches to fill up. The existing `batch_size_rows` setting controls the row count; this adds the complementary time-based control.

## Validation

- `uv run pytest -q` — 859 passed, 388 deselected, 1 xfailed, 21 subtests passed
- mypy on changed files — passed

## Files changed

- `singer_sdk/helpers/capabilities.py` — new `TARGET_BATCH_WAIT_LIMIT_SECONDS_CONFIG`
- `singer_sdk/sinks/core.py` — `batch_wait_limit_seconds`, `_batch_start_time`, `is_too_old`, updated `is_full` and `mark_drained`
- `singer_sdk/target_base.py` — import and merge new config in `append_builtin_config`, drain expired sinks at start of record processing
- `tests/core/test_target_base.py` — 10 new tests for config, `is_too_old`, `is_full` integration, drain reset, about info, negative values, expired batch drain, timer init
- `tests/sql/test_target.py` — added `batch_wait_limit_seconds` to expected default settings

Closes #1626

## Summary by Sourcery

Add time-based batch draining for targets to prevent low-volume batches from remaining open indefinitely.

New Features:
- Add a configurable target-level time limit that processes open batches after they have waited too long, complementing row-count batch sizing.

Bug Fixes:
- Ensure expired batches are drained before processing a new record, including batches that expired while the target was idle.

Enhancements:
- Track batch lifetimes and reset the timer after each batch is drained.
- Expose the batch wait limit through target configuration and generated settings metadata, while ignoring negative values.

Tests:
- Add coverage for batch wait configuration, expiration behavior, drain integration, timer lifecycle, metadata exposure, and invalid values.