### PR TITLE
refactor: Update singerlib catalog classes type annotations to accept a more generic mapping type instead of `dict`

### DIFF
--- a/singer_sdk/singerlib/catalog.py
+++ b/singer_sdk/singerlib/catalog.py
@@ -17,7 +17,7 @@ else:
 
 
 if t.TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping
 
     if sys.version_info >= (3, 11):
         from typing import Self  # noqa: ICN003
@@ -77,7 +77,7 @@ class Metadata:
     selected_by_default: bool | None = None
 
     @classmethod
-    def from_dict(cls, value: dict[str, t.Any]) -> Self:
+    def from_dict(cls, value: Mapping[str, t.Any]) -> Self:
         """Parse metadata dictionary.
 
         Args:
@@ -188,7 +188,7 @@ class MetadataMapping(dict[Breadcrumb, AnyMetadata]):  # noqa: FURB189
     def get_standard_metadata(
         cls: type[Self],
         *,
-        schema: dict[str, t.Any] | None = None,
+        schema: Mapping[str, t.Any] | None = None,
         schema_name: str | None = None,
         key_properties: t.Sequence[str] | None = None,
         valid_replication_keys: list[str] | None = None,
@@ -220,7 +220,7 @@ class MetadataMapping(dict[Breadcrumb, AnyMetadata]):  # noqa: FURB189
         )
 
         def _add_subfield_metadata(
-            properties: dict,
+            properties: Mapping,
             breadcrumb: Breadcrumb = (),
         ) -> None:
             """Add breadcrumbs and metadata for subfields."""
@@ -343,7 +343,7 @@ class CatalogEntry:
     replication_method: str | None = None
 
     @classmethod
-    def from_dict(cls: type[Self], stream: dict[str, t.Any]) -> Self:
+    def from_dict(cls: type[Self], stream: Mapping[str, t.Any]) -> Self:
         """Create a catalog entry from a dictionary.
 
         Args:
@@ -373,10 +373,11 @@ class CatalogEntry:
         Returns:
             A dictionary representation of the catalog entry.
         """
-        result: dict[str, t.Any] = {}
-        result["tap_stream_id"] = self.tap_stream_id
-        result["schema"] = self.schema.to_dict()
-        result["metadata"] = self.metadata.to_list()
+        result: dict[str, t.Any] = {
+            "tap_stream_id": self.tap_stream_id,
+            "schema": self.schema.to_dict(),
+            "metadata": self.metadata.to_list(),
+        }
 
         if self.database:
             result["database_name"] = self.database
@@ -403,7 +404,7 @@ class Catalog(dict[str, CatalogEntry]):  # noqa: FURB189
     """Singer catalog mapping of stream entries."""
 
     @classmethod
-    def from_dict(cls: type[Self], data: dict[str, list[dict[str, t.Any]]]) -> Self:
+    def from_dict(cls: type[Self], data: Mapping[str, list[dict[str, t.Any]]]) -> Self:
         """Create a catalog from a dictionary.
 
         Args:

--- a/singer_sdk/singerlib/schema.py
+++ b/singer_sdk/singerlib/schema.py
@@ -10,6 +10,8 @@ from referencing import Registry
 from referencing.jsonschema import DRAFT202012
 
 if t.TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from referencing._core import Resolver
 
 __all__ = [
@@ -134,7 +136,7 @@ class Schema:
     @classmethod
     def from_dict(
         cls: t.Type[Schema],  # noqa: UP006
-        data: dict,
+        data: Mapping,
         **schema_defaults: t.Any,
     ) -> Schema:
         """Initialize a Schema object based on the JSON Schema structure.
@@ -255,7 +257,7 @@ _OPTIONAL_SCHEMA_KEYWORDS: tuple[str, ...] = (
 
 def resolve_schema_references(
     schema: _SchemaDict,
-    refs: dict[str, _SchemaDict] | None = None,
+    refs: Mapping[str, _SchemaDict] | None = None,
 ) -> dict:
     """Resolves and replaces json-schema $refs with the appropriate dict.
 

--- a/singer_sdk/tap_base.py
+++ b/singer_sdk/tap_base.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import abc
-import collections.abc
 import contextlib
 import sys
 import typing as t
 import warnings
+from collections.abc import Mapping
 from enum import Enum
 
 import click
@@ -91,7 +91,7 @@ class Tap(BaseSingerWriter, abc.ABC):  # noqa: PLR0904
         self,
         *,
         config: dict | PurePath | str | list[PurePath | str] | None = None,
-        catalog: PurePath | str | dict | Catalog | None = None,
+        catalog: PurePath | str | Mapping | Catalog | None = None,
         state: PurePath | str | dict | None = None,
         parse_env_config: bool = False,
         validate_config: bool = True,
@@ -129,8 +129,8 @@ class Tap(BaseSingerWriter, abc.ABC):  # noqa: PLR0904
         # Process input catalog
         if isinstance(catalog, Catalog):
             self._input_catalog = catalog
-        elif isinstance(catalog, collections.abc.MutableMapping):
-            self._input_catalog = Catalog.from_dict(catalog)  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
+        elif isinstance(catalog, Mapping):
+            self._input_catalog = Catalog.from_dict(catalog)  # type: ignore[arg-type]
         elif catalog is not None:
             self._input_catalog = Catalog.from_dict(read_json_file(catalog))
             warnings.warn(


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Accept generic mapping types throughout Singer catalog and schema parsing APIs.

Enhancements:
- Broaden Singer catalog and schema APIs to accept generic mapping inputs instead of requiring concrete dictionaries.
- Allow tap catalog initialization from any mapping-compatible catalog object.