### PR TITLE
refactor: Standarize the type annotation of "primary keys" / "key properties" accross the codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
   - id: check-readthedocs
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.16.1
+  rev: v0.16.6
   hooks:
   - id: ruff-check
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,6 +263,7 @@ omit = [
     "packages/meltano-target-*",
     "singer_sdk/helpers/_compat.py",
     "singer_sdk/helpers/types.py",
+    "singer_sdk/singerlib/types.py",
 ]
 
 [tool.coverage.report]

--- a/singer_sdk/batch.py
+++ b/singer_sdk/batch.py
@@ -29,7 +29,7 @@ def __getattr__(name: str) -> t.Any:  # noqa: ANN401 # pragma: no cover
             stacklevel=2,
         )
 
-        from singer_sdk.contrib.batch_encoder_jsonl import JSONLinesBatcher  # noqa: PLC0415, I001
+        from singer_sdk.contrib.batch_encoder_jsonl import JSONLinesBatcher  # ruff: ignore[import-outside-top-level]
 
         return JSONLinesBatcher
 

--- a/singer_sdk/mapper.py
+++ b/singer_sdk/mapper.py
@@ -39,6 +39,7 @@ if t.TYPE_CHECKING:
 
     from singer_sdk.helpers._flattening import FlatteningOptions
     from singer_sdk.singerlib.catalog import Catalog
+    from singer_sdk.singerlib.types import KeyProperties
 
 
 MAPPER_ELSE_OPTION = "__else__"
@@ -115,7 +116,7 @@ class StreamMap(abc.ABC):
         self,
         stream_alias: str,
         raw_schema: dict,
-        key_properties: t.Sequence[str] | None,
+        key_properties: KeyProperties | None,
         flattening_options: FlatteningOptions | None,
     ) -> None:
         """Initialize mapper.
@@ -354,7 +355,7 @@ class CustomStreamMap(StreamMap):
         map_config: dict,
         faker_config: dict,
         raw_schema: dict,
-        key_properties: t.Sequence[str] | None,
+        key_properties: KeyProperties | None,
         map_transform: dict,
         flattening_options: FlatteningOptions | None,
         *,
@@ -845,7 +846,7 @@ class PluginMapper:
         self,
         stream_name: str,
         schema: dict,
-        key_properties: t.Sequence[str] | None,
+        key_properties: KeyProperties | None,
     ) -> None:
         """Register a new stream as described by its name and schema.
 

--- a/singer_sdk/schema/source.py
+++ b/singer_sdk/schema/source.py
@@ -40,9 +40,10 @@ else:
     from typing_extensions import TypeVar
 
 if t.TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable
 
     from singer_sdk.helpers._compat import Traversable
+    from singer_sdk.singerlib.types import KeyProperties
     from singer_sdk.streams.core import Stream
 
 
@@ -62,7 +63,7 @@ class SchemaPreprocessor(t.Protocol):
         self,
         schema: Schema,
         *,
-        key_properties: Sequence[str] = (),
+        key_properties: KeyProperties = (),
     ) -> Schema:
         """Pre-process a schema.
 
@@ -88,7 +89,7 @@ class SchemaSource(ABC, t.Generic[_TKey]):
         self,
         schema: Schema,
         *,
-        key_properties: Sequence[str] = (),
+        key_properties: KeyProperties = (),
     ) -> Schema:
         """Pre-process the schema before providing it to the stream.
 
@@ -112,7 +113,7 @@ class SchemaSource(ABC, t.Generic[_TKey]):
         key: _TKey,
         /,
         *,
-        key_properties: Sequence[str] = (),
+        key_properties: KeyProperties = (),
     ) -> Schema:
         """Convenience method to get a schema component.
 
@@ -254,7 +255,7 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
         self,
         schema: Schema,
         *,
-        key_properties: Sequence[str] = (),
+        key_properties: KeyProperties = (),
     ) -> Schema:
         """Handle JSON object schemas.
 
@@ -400,7 +401,7 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
         self,
         schema: Schema,
         *,
-        key_properties: Sequence[str] = (),
+        key_properties: KeyProperties = (),
     ) -> Schema:
         """Normalize an OpenAPI schema to standard JSON Schema.
 
@@ -449,7 +450,7 @@ class OpenAPISchemaNormalizer(SchemaPreprocessor):
         self,
         schema: Schema,
         *,
-        key_properties: Sequence[str] = (),
+        key_properties: KeyProperties = (),
     ) -> Schema:
         return self.normalize_schema(schema, key_properties=key_properties)
 

--- a/singer_sdk/singerlib/catalog.py
+++ b/singer_sdk/singerlib/catalog.py
@@ -19,6 +19,8 @@ else:
 if t.TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
+    from singer_sdk.singerlib.types import KeyProperties
+
     if sys.version_info >= (3, 11):
         from typing import Self  # noqa: ICN003
     else:
@@ -113,7 +115,7 @@ class Metadata:
 class StreamMetadata(Metadata):
     """Stream metadata."""
 
-    table_key_properties: t.Sequence[str] | None = None
+    table_key_properties: KeyProperties | None = None
     replication_key: str | None = None
     forced_replication_method: str | None = None
     valid_replication_keys: list[str] | None = None
@@ -190,7 +192,7 @@ class MetadataMapping(dict[Breadcrumb, AnyMetadata]):  # noqa: FURB189
         *,
         schema: Mapping[str, t.Any] | None = None,
         schema_name: str | None = None,
-        key_properties: t.Sequence[str] | None = None,
+        key_properties: KeyProperties | None = None,
         valid_replication_keys: list[str] | None = None,
         replication_method: str | None = None,
         selected_by_default: bool | None = None,
@@ -333,7 +335,7 @@ class CatalogEntry:
     metadata: MetadataMapping = field(default_factory=MetadataMapping)
     schema: Schema = field(default_factory=Schema)
     stream: str | None = None
-    key_properties: t.Sequence[str] | None = None
+    key_properties: KeyProperties | None = None
     replication_key: str | None = None
     is_view: bool | None = None
     database: str | None = None

--- a/singer_sdk/singerlib/encoding/simple.py
+++ b/singer_sdk/singerlib/encoding/simple.py
@@ -23,6 +23,8 @@ else:
 if t.TYPE_CHECKING:
     import builtins
 
+    from singer_sdk.singerlib.types import KeyProperties
+
     if sys.version_info >= (3, 11):
         from typing import Self  # noqa: ICN003
     else:
@@ -183,7 +185,7 @@ class SchemaMessage(Message):
         self,
         stream: str,
         schema: Schema,
-        key_properties: Sequence[str] | None = None,
+        key_properties: KeyProperties | str | None = None,
         bookmark_properties: Sequence[str] | None = None,
     ) -> None:
         """Initialize schema object."""

--- a/singer_sdk/singerlib/messages.py
+++ b/singer_sdk/singerlib/messages.py
@@ -19,6 +19,8 @@ if t.TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from datetime import datetime
 
+    from .types import KeyProperties
+
 __all__ = [
     "ActivateVersionMessage",
     "Message",
@@ -69,7 +71,7 @@ def write_schema(
     stream_name: str,
     schema: Mapping[str, t.Any],
     *,
-    key_properties: Sequence[str] | None = None,
+    key_properties: KeyProperties | str | None = None,
     bookmark_properties: Sequence[str] | None = None,
 ) -> None:
     """Write a SCHEMA message to stdout.

--- a/singer_sdk/singerlib/types.py
+++ b/singer_sdk/singerlib/types.py
@@ -1,0 +1,7 @@
+"""Reusable type annotations for Singer objects."""
+
+from __future__ import annotations
+
+import typing as t
+
+KeyProperties: t.TypeAlias = list[str] | tuple[str, ...]

--- a/singer_sdk/sinks/core.py
+++ b/singer_sdk/sinks/core.py
@@ -45,6 +45,7 @@ if t.TYPE_CHECKING:
     from logging import Logger
 
     from singer_sdk.helpers._batch import BaseBatchFileEncoding
+    from singer_sdk.singerlib.types import KeyProperties
     from singer_sdk.target_base import Target
 
 
@@ -163,7 +164,7 @@ class Sink(abc.ABC):  # noqa: PLR0904
         target: Target,
         stream_name: str,
         schema: dict,
-        key_properties: t.Sequence[str] | None,
+        key_properties: KeyProperties | None,
     ) -> None:
         """Initialize target sink.
 
@@ -427,7 +428,7 @@ class Sink(abc.ABC):  # noqa: PLR0904
         return DatetimeErrorTreatmentEnum.ERROR
 
     @property
-    def key_properties(self) -> t.Sequence[str]:
+    def key_properties(self) -> KeyProperties:
         """Key properties.
 
         Override this method to return a list of key properties in a format that is

--- a/singer_sdk/sql/connector.py
+++ b/singer_sdk/sql/connector.py
@@ -41,6 +41,8 @@ if t.TYPE_CHECKING:
         ReflectedPrimaryKeyConstraint,
     )
 
+    from singer_sdk.singerlib.types import KeyProperties
+
 
 class FullyQualifiedName(UserString):
     """A fully qualified table name.
@@ -1286,7 +1288,7 @@ class SQLConnector:  # noqa: PLR0904
         self,
         full_table_name: str | FullyQualifiedName,
         schema: dict,
-        primary_keys: t.Sequence[str] | None = None,
+        primary_keys: KeyProperties | None = None,
         partition_keys: list[str] | None = None,
         as_temp_table: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
@@ -1377,7 +1379,7 @@ class SQLConnector:  # noqa: PLR0904
         self,
         full_table_name: str | FullyQualifiedName,
         schema: dict,
-        primary_keys: t.Sequence[str],
+        primary_keys: KeyProperties,
         partition_keys: list[str] | None = None,
         as_temp_table: bool = False,  # noqa: FBT002, FBT001
     ) -> None:
@@ -1438,7 +1440,7 @@ class SQLConnector:  # noqa: PLR0904
         self,
         *,
         full_table_name: str | FullyQualifiedName,  # noqa: ARG002
-        primary_keys: t.Sequence[str],  # noqa: ARG002
+        primary_keys: KeyProperties,  # noqa: ARG002
     ) -> None:
         """Adapt target table primary key to provided schema if possible.
 

--- a/singer_sdk/sql/sink.py
+++ b/singer_sdk/sql/sink.py
@@ -28,6 +28,7 @@ else:
 if t.TYPE_CHECKING:
     from sqlalchemy.sql import Executable
 
+    from singer_sdk.singerlib.types import KeyProperties
     from singer_sdk.sql.connector import FullyQualifiedName
     from singer_sdk.target_base import Target
 
@@ -48,7 +49,7 @@ class SQLSink(BatchSink, t.Generic[_C]):
         target: Target,
         stream_name: str,
         schema: dict,
-        key_properties: t.Sequence[str] | None,
+        key_properties: KeyProperties | None,
         connector: _C | None = None,
     ) -> None:
         """Initialize SQL Sink.
@@ -233,7 +234,7 @@ class SQLSink(BatchSink, t.Generic[_C]):
 
     @property
     @override
-    def key_properties(self) -> t.Sequence[str]:
+    def key_properties(self) -> KeyProperties:
         """Key properties, conformed to target system naming requirements."""
         return [self.conform_name(key, "column") for key in super().key_properties]
 

--- a/singer_sdk/sql/stream.py
+++ b/singer_sdk/sql/stream.py
@@ -24,6 +24,7 @@ if t.TYPE_CHECKING:
 
     from singer_sdk.helpers.types import Context, Record
     from singer_sdk.singerlib import MetadataMapping
+    from singer_sdk.singerlib.types import KeyProperties
     from singer_sdk.sql.connector import FullyQualifiedName
     from singer_sdk.tap_base import Tap
 
@@ -106,13 +107,13 @@ class SQLStream(Stream, abc.ABC):
 
     @property
     @override
-    def primary_keys(self) -> t.Sequence[str]:
+    def primary_keys(self) -> KeyProperties:
         """Primary keys from the catalog entry definition."""
         return self._singer_catalog_entry.metadata.root.table_key_properties or []
 
     @primary_keys.setter
     @override
-    def primary_keys(self, new_value: t.Sequence[str]) -> None:
+    def primary_keys(self, new_value: KeyProperties) -> None:
         """Set or reset the primary key(s) in the stream's catalog entry.
 
         Args:

--- a/singer_sdk/sql/target.py
+++ b/singer_sdk/sql/target.py
@@ -20,6 +20,7 @@ else:
 
 if t.TYPE_CHECKING:
     from singer_sdk.helpers.capabilities import CapabilitiesEnum
+    from singer_sdk.singerlib.types import KeyProperties
     from singer_sdk.sinks.core import Sink
     from singer_sdk.sql.connector import SQLConnector
     from singer_sdk.sql.sink import SQLSink
@@ -95,7 +96,7 @@ class SQLTarget(Target):
         *,
         stream_name: str,
         schema: dict,
-        key_properties: t.Sequence[str] | None = None,
+        key_properties: KeyProperties | None = None,
     ) -> Sink:
         """Instantiate a new SQL sink for the given stream.
 
@@ -124,7 +125,7 @@ class SQLTarget(Target):
         self,
         stream_name: str,
         schema: dict,
-        key_properties: t.Sequence[str] | None = None,
+        key_properties: KeyProperties | None = None,
     ) -> Sink:
         """Create a sink and register it.
 
@@ -181,7 +182,7 @@ class SQLTarget(Target):
         *,
         record: dict | None = None,
         schema: dict | None = None,
-        key_properties: t.Sequence[str] | None = None,
+        key_properties: KeyProperties | None = None,
     ) -> Sink:
         """Return a sink for the given stream name.
 

--- a/singer_sdk/streams/core.py
+++ b/singer_sdk/streams/core.py
@@ -48,6 +48,7 @@ if t.TYPE_CHECKING:
     from singer_sdk.helpers._compat import Traversable
     from singer_sdk.mapper import StreamMap
     from singer_sdk.singerlib.catalog import StreamMetadata
+    from singer_sdk.singerlib.types import KeyProperties
     from singer_sdk.tap_base import Tap
 
 
@@ -147,7 +148,7 @@ class Stream(abc.ABC):  # noqa: PLR0904
         self._stream_maps: list[StreamMap] | None = None
         self.forced_replication_method: str | None = None
         self._replication_key: str | None = None
-        self._primary_keys: t.Sequence[str] | None = None
+        self._primary_keys: KeyProperties | None = None
         self._state_partitioning_keys: t.Sequence[str] | None = None
         self._schema_filepath: Path | Traversable | None = None
         self._metadata: singer.MetadataMapping | None = None
@@ -519,12 +520,12 @@ class Stream(abc.ABC):  # noqa: PLR0904
         return self._schema
 
     @property
-    def primary_keys(self) -> t.Sequence[str]:
+    def primary_keys(self) -> KeyProperties:
         """Primary keys."""
         return self._primary_keys or []
 
     @primary_keys.setter
-    def primary_keys(self, new_value: t.Sequence[str]) -> None:
+    def primary_keys(self, new_value: KeyProperties) -> None:
         """Set primary key(s) for the stream.
 
         Args:

--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -42,6 +42,7 @@ if t.TYPE_CHECKING:
     from singer_sdk.helpers.capabilities import CapabilitiesEnum
     from singer_sdk.mapper import PluginMapper
     from singer_sdk.singerlib.encoding.base import GenericSingerReader
+    from singer_sdk.singerlib.types import KeyProperties
     from singer_sdk.sinks import Sink
     from singer_sdk.sql import SQLTarget  # noqa: F401
 
@@ -146,7 +147,7 @@ class Target(BaseSingerReader, abc.ABC):
         *,
         record: dict | None = None,
         schema: dict | None = None,
-        key_properties: t.Sequence[str] | None = None,
+        key_properties: KeyProperties | None = None,
     ) -> Sink:
         """Return a sink for the given stream name.
 
@@ -235,7 +236,7 @@ class Target(BaseSingerReader, abc.ABC):
         *,
         stream_name: str,
         schema: dict,
-        key_properties: t.Sequence[str] | None = None,
+        key_properties: KeyProperties | None = None,
     ) -> Sink:
         """Instantiate a new sink object for the given stream.
 
@@ -265,7 +266,7 @@ class Target(BaseSingerReader, abc.ABC):
         self,
         stream_name: str,
         schema: dict,
-        key_properties: t.Sequence[str] | None = None,
+        key_properties: KeyProperties | None = None,
     ) -> Sink:
         """Create a sink and register it.
 


### PR DESCRIPTION
Makes the annotation consistent accross the codebase and also discourages using a bare string as the primary key. A one-element list or tuple is preferred.

## Summary by Sourcery

Standardize key-property type annotations across the codebase and discourage bare-string primary-key values.

Enhancements:
- Standardize primary-key and key-property annotations across stream, catalog, mapper, sink, and SQL APIs with a shared `KeyProperties` type that prefers lists or tuples over bare strings.

Build:
- Update the Ruff pre-commit hook to v0.16.6 and adjust the coverage exclusion list.

Chores:
- Refine Ruff import-lint suppression for a lazily imported batch encoder.