### PR TITLE
fix: When parsing settings from the environment, look for a `.env` starting in the current working directory so projects can find the local `.env` even when the virtualenv is not in the project tree

### DIFF
--- a/singer_sdk/configuration/_dict_config.py
+++ b/singer_sdk/configuration/_dict_config.py
@@ -47,7 +47,7 @@ def parse_environment_config(
     result: dict[str, t.Any] = {}
 
     if not dotenv_path:
-        dotenv_path = find_dotenv()
+        dotenv_path = find_dotenv(usecwd=True)
 
     logger.debug("Loading configuration from %s", dotenv_path)
     DotEnv(dotenv_path).set_as_environment_variables()

--- a/tests/core/configuration/test_dict_config.py
+++ b/tests/core/configuration/test_dict_config.py
@@ -46,6 +46,7 @@ def config_file2(tmpdir) -> str:
     return filepath
 
 
+@mock.patch.dict(os.environ, {}, clear=True)
 def test_get_env_var_config(
     monkeypatch: pytest.MonkeyPatch,
     subtests: pytest.Subtests,
@@ -119,25 +120,28 @@ def test_get_env_var_config(
 
 
 @mock.patch.dict(os.environ, {}, clear=True)
-def test_get_dotenv_config(tmp_path: Path):
+def test_get_dotenv_config(tmp_path: Path, request: pytest.FixtureRequest):
+    value = request.node.name
     dotenv = tmp_path / ".env"
-    dotenv.write_text("PLUGIN_TEST_PROP1=hello\n")
+    dotenv.write_text(f"PLUGIN_TEST_PROP1={value}\n")
     dotenv_config = parse_environment_config(
         CONFIG_JSONSCHEMA,
         "PLUGIN_TEST_",
         dotenv_path=dotenv,
     )
     assert dotenv_config
-    assert dotenv_config["prop1"] == "hello"
+    assert dotenv_config["prop1"] == value
 
 
 @mock.patch.dict(os.environ, {}, clear=True)
 def test_get_dotenv_config_discover_file_cwd(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ):
+    value = request.node.name
     dotenv = tmp_path / ".env"
-    dotenv.write_text("PLUGIN_TEST_PROP1=hello\n")
+    dotenv.write_text(f"PLUGIN_TEST_PROP1={value}\n")
 
     # Change to the temporary directory
     monkeypatch.chdir(tmp_path)
@@ -147,4 +151,4 @@ def test_get_dotenv_config_discover_file_cwd(
         dotenv_path=None,  # Let it discover the .env file
     )
     assert dotenv_config
-    assert dotenv_config["prop1"] == "hello"
+    assert dotenv_config["prop1"] == value

--- a/tests/core/configuration/test_dict_config.py
+++ b/tests/core/configuration/test_dict_config.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -116,6 +118,7 @@ def test_get_env_var_config(
         assert not set.intersection(missing_props, no_env_config)
 
 
+@mock.patch.dict(os.environ, {}, clear=True)
 def test_get_dotenv_config(tmp_path: Path):
     dotenv = tmp_path / ".env"
     dotenv.write_text("PLUGIN_TEST_PROP1=hello\n")
@@ -123,6 +126,25 @@ def test_get_dotenv_config(tmp_path: Path):
         CONFIG_JSONSCHEMA,
         "PLUGIN_TEST_",
         dotenv_path=dotenv,
+    )
+    assert dotenv_config
+    assert dotenv_config["prop1"] == "hello"
+
+
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_get_dotenv_config_discover_file_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("PLUGIN_TEST_PROP1=hello\n")
+
+    # Change to the temporary directory
+    monkeypatch.chdir(tmp_path)
+    dotenv_config = parse_environment_config(
+        CONFIG_JSONSCHEMA,
+        "PLUGIN_TEST_",
+        dotenv_path=None,  # Let it discover the .env file
     )
     assert dotenv_config
     assert dotenv_config["prop1"] == "hello"


### PR DESCRIPTION
Closes https://github.com/meltano/sdk/issues/2836

## Summary by Sourcery

Load local .env configuration relative to the current working directory when no dotenv path is provided.

Bug Fixes:
- Discover .env files from the current working directory when parsing environment-based settings, allowing projects to load local configuration independently of the virtualenv location.

Tests:
- Add coverage for automatic .env discovery from the current working directory and isolate environment-based configuration tests.