### PR TITLE
fix: Remove default storage root value from the BATCH configuration JSON schema

### DIFF
--- a/singer_sdk/helpers/capabilities.py
+++ b/singer_sdk/helpers/capabilities.py
@@ -215,7 +215,6 @@ BATCH_CONFIG = PropertiesList(
                     Property(
                         "root",
                         StringType,
-                        default="file://",
                         nullable=False,
                         title="Batch Storage Root",
                         description="Root path to use when writing batch files.",


### PR DESCRIPTION
A partial revert of c41b5d68

## Summary by Sourcery

Bug Fixes:
- Remove the default `file://` value from the BATCH storage root configuration schema.