### PR TITLE
feat: Add a new built-in target test for stream name parts (`<db>-<schema>-<name>`, `<schema>-<name>`)

### DIFF
--- a/singer_sdk/testing/suites.py
+++ b/singer_sdk/testing/suites.py
@@ -43,6 +43,7 @@ from .target_tests import (
     TargetSchemaNoProperties,
     TargetSchemaUpdates,
     TargetSpecialCharsInAttributes,
+    TargetStreamNameParts,
     TargetStringFormats,
 )
 from .templates import TestTemplate
@@ -134,5 +135,6 @@ target_tests = SingerTestSuite(
         TargetSchemaUpdates,
         TargetSpecialCharsInAttributes,
         TargetStringFormats,
+        TargetStreamNameParts,
     ],
 )

--- a/singer_sdk/testing/target_test_streams/stream_name_parts.singer
+++ b/singer_sdk/testing/target_test_streams/stream_name_parts.singer
@@ -1,0 +1,4 @@
+{"type":"SCHEMA","stream":"schema-name","key_properties":["id"], "schema":{"type":"object","properties":{"id":{"type":"integer"}, "name":{"type":"string"}}, "required":["id"]}}
+{"type":"RECORD","stream":"schema-name","record":{"id":1,"name":"Anna"}}
+{"type":"SCHEMA","stream":"database-schema-name","key_properties":["id"], "schema":{"type":"object","properties":{"id":{"type":"integer"}, "name":{"type":"string"}}, "required":["id"]}}
+{"type":"RECORD","stream":"database-schema-name","record":{"id":2,"name":"Bertha"}}

--- a/singer_sdk/testing/target_tests.py
+++ b/singer_sdk/testing/target_tests.py
@@ -169,3 +169,9 @@ class TargetRecordMissingOptionalFields(TargetFileTestTemplate):
     """Test Target handles record missing optional fields."""
 
     name = "record_missing_fields"
+
+
+class TargetStreamNameParts(TargetFileTestTemplate):
+    """Test target handles stream name parts like `schema-table`."""
+
+    name = "stream_name_parts"


### PR DESCRIPTION
## Related

- https://github.com/meltano/sdk/pull/3776

## Summary by Sourcery

New Features:
- Add a built-in target test covering stream names composed from database, schema, and table name parts.