### PR TITLE
fix(targets): Defer signal handling when a drain is already in progress

### DIFF
--- a/singer_sdk/target_base.py
+++ b/singer_sdk/target_base.py
@@ -111,6 +111,11 @@ class Target(BaseSingerReader, abc.ABC):
         self._sinks_to_clear: list[Sink] = []
         self._max_parallelism: int | None = _MAX_PARALLELISM
 
+        # True for the duration of an in-progress `drain_all()` call. Used to defer
+        # termination-signal handling until the active drain has safely finished,
+        # rather than re-entering `drain_all()`/`drain_one()` mid-flight.
+        self._draining: bool = False
+
         # Approximated for max record age enforcement
         self._last_full_drain_at: float = time.time()
 
@@ -508,24 +513,43 @@ class Target(BaseSingerReader, abc.ABC):
 
         This method is internal to the SDK and should not need to be overridden.
 
+        A termination signal received while this method is already running is not
+        handled re-entrantly: `_handle_termination` defers to `_is_terminating` and
+        lets this call finish normally so that in-flight sinks are not interrupted
+        mid-`process_batch()`. Once the drain that was running when the signal
+        arrived completes, this method notices `_is_terminating` and performs the
+        real end-of-pipe drain and shutdown itself.
+
         Args:
             is_endofpipe: This is called after the target instance has finished
                 listening to the stdin.
         """
-        self._drain_all(self._sinks_to_clear, 1)
-        if is_endofpipe:
-            for sink in self._sinks_to_clear:
-                sink._clean_up()  # ruff:ignore[private-member-access]
-        self._sinks_to_clear = []
-        self._drain_all(self._sinks_active.values(), self.max_parallelism)
-        if is_endofpipe:
-            for sink in self._sinks_active.values():
-                sink._clean_up()  # ruff:ignore[private-member-access]
+        self._draining = True
+        try:
+            self._drain_all(self._sinks_to_clear, 1)
+            if is_endofpipe:
+                for sink in self._sinks_to_clear:
+                    sink._clean_up()  # ruff:ignore[private-member-access]
+            self._sinks_to_clear = []
+            self._drain_all(self._sinks_active.values(), self.max_parallelism)
+            if is_endofpipe:
+                for sink in self._sinks_active.values():
+                    sink._clean_up()  # ruff:ignore[private-member-access]
 
-        if self._latest_state:
-            self._write_state_message(copy.deepcopy(self._latest_state))
+            if self._latest_state:
+                self._write_state_message(copy.deepcopy(self._latest_state))
 
-        self._reset_max_record_age()
+            self._reset_max_record_age()
+        finally:
+            self._draining = False
+
+        if self._is_terminating and not is_endofpipe:
+            # A termination signal arrived while this drain was running. It was
+            # deferred until now to avoid re-entering `drain_one()` for a sink that
+            # was still mid-`process_batch()`. Now that all in-flight records have
+            # been safely committed, perform the real end-of-pipe drain and exit.
+            self.drain_all(is_endofpipe=True)
+            self._terminate()
 
     @t.final
     def drain_one(self, sink: Sink) -> None:  # noqa: PLR6301
@@ -587,6 +611,23 @@ class Target(BaseSingerReader, abc.ABC):
             # drain finish.
             return
         self._is_terminating = True
+
+        if self._draining:
+            # This signal was delivered while a drain_all() call was already
+            # in progress on the main thread (CPython delivers signals between
+            # bytecode instructions, so this can happen mid-`process_batch()`).
+            # Calling drain_all() again here would re-enter `drain_one()` for a
+            # sink that is still mid-drain, clobbering its in-flight batch
+            # context before it commits. Instead, just record that termination
+            # was requested; drain_all() checks `_is_terminating` right after it
+            # finishes and will perform the real shutdown then.
+            self.logger.info(
+                "Received termination signal %d during an active drain; "
+                "deferring shutdown until it completes...",
+                signum,
+            )
+            return
+
         self.logger.info(
             "Received termination signal %d, draining all sinks...",
             signum,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,7 @@ class TargetMock(Target):
         self.records_written: list[dict] = []
         self.num_records_processed: int = 0
         self.num_batches_processed: int = 0
+        self.signalled: bool = False
 
     def _write_state_message(self, state: dict):
         """Emit the stream's latest state."""

--- a/tests/core/test_target_base.py
+++ b/tests/core/test_target_base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import signal
 import sys
+import typing as t
 from unittest import mock
 
 import pytest
@@ -265,3 +266,75 @@ def test_duplicate_termination_signal_does_not_redrain():
 
     assert exc_info.value.code == 0
     assert len(drain_calls) == 1
+
+
+def _make_signalled_sink(target: TargetMock, stream_name: str) -> BatchSinkMock:
+    """Register a sink whose first `process_batch()` call fires a SIGTERM.
+
+    This simulates the first signal arriving mid-`process_batch()`, before the
+    original call has committed its records, as described in
+    https://github.com/meltano/sdk/issues/3775.
+    """
+    schema = {"properties": {"id": {"type": "integer"}}}
+    sink = t.cast(
+        "BatchSinkMock",
+        target.get_sink(stream_name, schema=schema, key_properties=["id"]),
+    )
+
+    def process_batch(context: dict) -> None:
+        if not target.signalled:
+            target.signalled = True
+            target._handle_termination(signal.SIGTERM, None)
+        target.records_written.extend(context["records"])
+        target.num_batches_processed += 1
+
+    sink.process_batch = process_batch
+
+    for i in range(3):
+        context = sink._get_context({"id": i})
+        sink.process_record({"id": i}, context)
+        sink.tally_record_read()
+
+    return sink
+
+
+def test_signal_during_final_drain_does_not_lose_records():
+    """A signal mid-`process_batch()` of the final drain must not lose records.
+
+    It must not re-enter `drain_one()` for the same sink either.
+    """
+    target = TargetMock()
+    _make_signalled_sink(target, "foo")
+    target._latest_state = {
+        "bookmarks": {"foo": {"replication_key_value": 2}},
+    }
+
+    # The interrupted drain is already the end-of-pipe drain, so no further
+    # forced shutdown is needed once it completes.
+    target.drain_all(is_endofpipe=True)
+
+    assert target.records_written == [{"id": 0}, {"id": 1}, {"id": 2}]
+    assert target.num_batches_processed == 1
+    assert target.state_messages_written[-1] == target._latest_state
+    assert target._is_terminating is True
+
+
+def test_signal_during_midstream_drain_defers_shutdown_then_exits():
+    """A signal during a non-final drain must defer, then drain and exit.
+
+    A SIGTERM arriving mid-drain (e.g. size/age-triggered) must let the
+    in-flight batch commit, then perform a real end-of-pipe drain and exit.
+    """
+    target = TargetMock()
+    _make_signalled_sink(target, "foo")
+    target._latest_state = {
+        "bookmarks": {"foo": {"replication_key_value": 2}},
+    }
+
+    with pytest.raises(SystemExit) as exc_info:
+        target.drain_all(is_endofpipe=False)
+
+    assert exc_info.value.code == 0
+    assert target.records_written == [{"id": 0}, {"id": 1}, {"id": 2}]
+    assert target.num_batches_processed == 1
+    assert target.state_messages_written[-1] == target._latest_state


### PR DESCRIPTION
Closes https://github.com/meltano/sdk/issues/3775

## Summary by Sourcery

Prevent termination signals from interrupting active target drains and ensure shutdown completes safely afterward.

Bug Fixes:
- Defer termination handling during an active sink drain so in-flight batches can finish without records being lost or drain operations being re-entered.
- Complete the requested shutdown after the active drain finishes, including the final end-of-pipe drain and process termination.

Tests:
- Add coverage for termination signals received during final and midstream drains, verifying records, state, and shutdown behavior.